### PR TITLE
Add a meta noindex header

### DIFF
--- a/templates/manage.html
+++ b/templates/manage.html
@@ -4,6 +4,7 @@
 <script src="//code.jquery.com/jquery-2.1.4.min.js"></script>
 
 <meta name="viewport" content="initial-scale=1.0">
+<meta name="robots" content="noindex">
 <link rel="stylesheet" type="text/css" href="/resources/famfamfam-flags.css" >
 <style>
 table{

--- a/templates/manage_new.html
+++ b/templates/manage_new.html
@@ -17,6 +17,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="robots" content="noindex">
   <meta name="description" content="">
   <meta name="author" content="">
   <link rel="icon" href="../../favicon.ico">


### PR DESCRIPTION
**tldr;**
Stops token management pages from being indexed, and will drop
existing pages from the Googlebot index.

**Longer explanation**

Note that I'm not adding a:

`Disallow: /manage`

entry to `robots.txt` because https://support.google.com/webmasters/answer/93710?hl=en notes that this will cause the `/manage` pages not be followed, and thus the meta tag won't be seen and the page will remain in the Google index.

**Background**
If you Google for ["inurl:canarytokens.org/manage"](https://www.google.com/search?q=%22inurl:canarytokens.org/manage%22&filter=0&biw=2560&bih=946) - you'll see that a couple of these management pages have become indexed. Thanks to @ericescobar for letting me know.

One of them is mine, and I'm not sure how this has happened. The only time that the token management URL has ever appeared is in the alert emails from the canarytokens service itself (it's not in a google doc or other web page anywhere). However, you'd imagine that more management URLs would have been picked up by googlebot if it was crawling links in gmail.

I created the token last year, to test which webmail providers spider URLs in emails: https://webmasters.stackexchange.com/questions/115018/which-webmail-providers-spider-links-in-emails.

At the time BingPreview was the only culprit; I got a ping from it pretty much as soon as I'd sent the test email out. And then I'd get emails from your service saying the token had been triggered occasionally after that. 

I've never emailed the management URL to anyone, and it's never been put in a Google doc or website. The alert emails from canarytokens.org do have the management URL in. Doing some digging:

The first ever ping for it was from BingPreview on 2018-05-09 16:28:29 and the first Googlebot hit was on 2018-07-27 20:04:01, and [Google says that it first appeared in its index on 2019-01-04](https://webcache.googleusercontent.com/search?q=cache:RG1_DsCq0EwJ:https://canarytokens.org/manage%3Ftoken%3Dgrjk185qqys81zkg2d5y211f7%26auth%3Dbf240c4c405882b885109cfdc189515e+&cd=1&hl=en&ct=clnk&gl=uk)