### PR TITLE
added handler to loggin by calling logging.basicConfig() before creat…

### DIFF
--- a/frontend.tac
+++ b/frontend.tac
@@ -10,6 +10,7 @@ from switchboard import Switchboard
 
 import setup_db
 
+logging.basicConfig()
 logger = logging.getLogger('generator_httpd')
 logger.setLevel(logging.DEBUG)
 formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
added handler to "logger" object by calling logging.basicConfig() before creating the "logger" object so that the "logger" object would inherit a handler and the warning 'No handlers could be found for logger "generator_httpd" ' will be eliminated.