### PR TITLE
Filter out spam of log errors being posted to webhook

### DIFF
--- a/channel_dns.py
+++ b/channel_dns.py
@@ -21,7 +21,13 @@ class DNSServerFactory(server.DNSServerFactory, object):
             return
 
         query = message.queries[0]
-        src_ip = address[0]
+        if address:
+            src_ip = address[0]
+            if address[1] == 0:
+                log.debug(('Dropping request from {src} because source port is 0').format(src=src_ip))
+                return None
+        else:
+            src_ip = protocol.transport.socket.getpeername()[0]
 
         log.info('Query: {} sent {}'.format(src_ip, query))
         return self.resolver.query(query, src_ip).addCallback(

--- a/channel_input_bitcoin.py
+++ b/channel_input_bitcoin.py
@@ -31,7 +31,7 @@ class ChannelBitcoin(InputChannel):
             for bitcoin_account in get_all_bitcoin_accounts():
                 self.poll(bitcoin_account=bitcoin_account)
         except Exception as e:
-            log.error('Bitcoin error: {error}'.format(error=e))
+            log.warn('Bitcoin error: {error}'.format(error=e))
 
     def poll(self, bitcoin_account=None):
         try:

--- a/channel_input_imgur.py
+++ b/channel_input_imgur.py
@@ -46,7 +46,7 @@ class ChannelImgur(InputChannel):
                 imgur_token['count'] = count
                 save_imgur_token(imgur_token=imgur_token)
         except Exception as e:
-            log.error('Imgur error: {error}'.format(error=e))
+            log.warn('Imgur error: {error}'.format(error=e))
 
     def schedule_poll(self, imgur_token=None, delay=None):
         d = deferLater(reactor, delay, self.request_imgur_count, imgur_token)
@@ -72,7 +72,7 @@ class ChannelImgur(InputChannel):
                 imgur_token['count'] = count
                 save_imgur_token(imgur_token=imgur_token)
         except Exception as e:
-            log.error('Imgur error: {error}'.format(error=e))
+            log.warn('Imgur error: {error}'.format(error=e))
 
     def format_additional_data(self, **kwargs):
         log.info(kwargs)

--- a/queries.py
+++ b/queries.py
@@ -253,7 +253,7 @@ def get_geoinfo(ip):
             add_ip_to_cache(ip, resp)
             return resp
         except Exception as e:
-            log.error('Error getting geo ip: {err}'.format(err=e))
+            log.warn('Error getting geo ip: {err}'.format(err=e))
             return ""
 
 def get_geoinfo_from_ip(ip):


### PR DESCRIPTION
After running canarytokens.org with the new ability to post error level
log lines to a webhook, we noticed that there were a couple of message
types that were coming through as spam. These messages were not helpful
at all to receive. 
The fixes range from simply changing the log level to `warn` for the
bitcoin, imgur and GeoIP spam. 

To fixing a bug in the DNS channel code that would lead to a traceback like so:
`exceptions.TypeError: 'NoneType' object has no attribute '__getitem__'`
This would happen whenever the src_ip was not correctly handled and was a 
bug previously fixed at Thinkst in another repo that uses a DNS channel.

There are also 2x new direct string matching filters in the loghandlers
code that takes away two separate spam cases that we do not believe
needs to be sent to the webhook as they are not actionable.