### PR TITLE
generate frontend: update docs link

### DIFF
--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -90,7 +90,7 @@
         </h3>
         <div style="display:flex; justify-content:space-between">
           <a href="http://blog.thinkst.com/p/canarytokensorg-quick-free-detection.html" target="_blank">What is this and why should I care?</a>
-          <a style="margin-left: 50px;" href="https://docs.canarytokens.org" target="_blank">Documentation</a>
+          <a style="margin-left: 50px;" href="https://docs.canarytokens.org/guide/" target="_blank">Documentation</a>
         </div>
       </div>
 


### PR DESCRIPTION
The docs _forntage_ is frankly useless.
Project introduction is already in docs,
and the generate page gives some idea as well.

Autopilot first user experience was:
'oh this is a random page and it wants me to
go back to the main page where I came from
using this green button, I will press the docs
button in the navbar instead,
..and reach the same page..'