### PR TITLE
Ignore 'asn' key of IPInfo response for map marker

### DIFF
--- a/templates/history.html
+++ b/templates/history.html
@@ -432,7 +432,7 @@
 
             var content = '';
             for(info in geo_info[x]){
-              if(geo_info[x][info]==undefined || info == 'org' || info == 'postal' || info=='hostname'){
+              if(geo_info[x][info]==undefined || info == 'org' || info == 'postal' || info=='hostname' || info == 'asn'){
                 continue;
               }
               if(info=='ip'){


### PR DESCRIPTION
This change removes a minor bug where the ASN object is not being parsed and is displayed as-is in a map marker
![image](https://user-images.githubusercontent.com/3139249/140494978-779dbae7-04d9-48c2-9db1-4f7443a8e8c5.png)

Ignoring the `asn` key fixes this.
![image](https://user-images.githubusercontent.com/3139249/140495102-95407b06-286a-4f77-b170-bf1b1a1efb70.png)
