### PR TITLE
Update _log4_shell detector to avoid false positives

### DIFF
--- a/channel_dns.py
+++ b/channel_dns.py
@@ -213,7 +213,7 @@ class ChannelDNS(InputChannel):
 
     def _log4_shell(self, computer_name=None):
         data = {}
-        if len(computer_name) <= 1:
+        if len(computer_name) <= 1 or computer_name[0] != 'x':
             computer_name = 'Not Obtained'
         else:
             computer_name = computer_name[1:]


### PR DESCRIPTION
(This problem is mentioned in #121)

Currently, the _log4_shell detector generates false positives if an NS record is queried for the domain in the token.

Those queries are like `ns1.L4j.<TokenValue>.canarytokens.com`, and because this part of the code does not validate that the most left label starts with x, it is falsely reported as log4shell (with `computer_name=s1`)

This fix checks that the leftmost label starts with an x.