### PR TITLE
Add google chat webhook reporting based on slack webhook code

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -80,6 +80,19 @@ class InputChannel(Channel):
         payload['attachments'] = [attachment]
         return payload
 
+
+    def format_google_chat_canaryalert(self,canarydrop=None, protocol=settings.PROTOCOL,
+                                   host=settings.PUBLIC_DOMAIN, **kwargs):
+        if not host or host == '':
+            host=settings.PUBLIC_IP
+        manage_link = '{protocol}://{host}/manage?token={token}&auth={auth}'\
+                      .format(protocol=protocol,
+                           host=host,
+                           token=canarydrop['canarytoken'],
+                           auth= canarydrop['auth'])
+        return {"text": "<{manage_link}|Canarytoken Triggered> !\n  - Memo: {memo}\n  - Manage: {manage_link}>".format(name=self.name, memo=canarydrop.memo, manage_link=manage_link)}
+
+
     def format_canaryalert(self, canarydrop=None, protocol=settings.PROTOCOL,
                            host=settings.PUBLIC_DOMAIN, params=None, **kwargs):
         msg = {}
@@ -107,7 +120,7 @@ class InputChannel(Channel):
 
         if 'src_data' in kwargs and 'aws_keys_event_user_agent' in kwargs['src_data']:
             msg['useragent'] = kwargs['src_data']['aws_keys_event_user_agent']
-        
+
         if 'src_data' in kwargs and 'log4_shell_computer_name' in kwargs['src_data']:
             msg['log4_shell_computer_name'] = kwargs['src_data']['log4_shell_computer_name']
 

--- a/channel_output_webhook.py
+++ b/channel_output_webhook.py
@@ -36,11 +36,16 @@ class WebhookOutputChannel(OutputChannel):
 
     def do_send_alert(self, input_channel=None, canarydrop=None, **kwargs):
 
+        google_chat = "https://chat.googleapis.com"
         slack = "https://hooks.slack.com"
 
         try:
             if (slack in canarydrop['alert_webhook_url']):
                 payload = input_channel.format_slack_canaryalert(
+                                            canarydrop=canarydrop,
+                                            **kwargs)
+            elif (google_chat in canarydrop['alert_webhook_url']):
+                payload = input_channel.format_google_chat_canaryalert(
                                             canarydrop=canarydrop,
                                             **kwargs)
             else:

--- a/queries.py
+++ b/queries.py
@@ -520,7 +520,8 @@ def is_webhook_valid(url):
         return False
 
     slack = "https://hooks.slack.com"
-    if (slack in url):
+    google_chat = "https://chat.googleapis.com"
+    if (slack in url or google_chat in url):
         payload = {'text': 'Validating new canarytokens webhook'}
     else:
         payload = {"manage_url": "http://example.com/test/url/for/webhook",


### PR DESCRIPTION
Hi !

For my test purpose, I needed to integrate google chat webhooks to canarytoken.
I based my code on the slack integration from https://github.com/thinkst/canarytokens/pull/25 and it works fine.

I think it would be useful to have native support for google chat reporting on canarytoken just as we have slack support.

For now i kept the reported message simple and the text looks like:

```
Canarytoken Triggered !
  - Memo: MEMO
  - Manage: MANAGED_URL
```

Thank you,

