### PR TITLE
Report Generic Data in email alert

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -114,6 +114,9 @@ class InputChannel(Channel):
         if 'src_data' in kwargs and 'cmd_computer_name' in kwargs['src_data']:
             msg['cmd_computer_name'] = kwargs['src_data']['cmd_computer_name']
 
+        if 'src_data' in kwargs and 'generic_data' in kwargs['src_data']:
+            msg['generic_data'] = kwargs['src_data']['generic_data']
+
         if 'src_data' in kwargs and 'cmd_user_name' in kwargs['src_data']:
             msg['cmd_user_name'] = kwargs['src_data']['cmd_user_name']
 

--- a/channel_output_email.py
+++ b/channel_output_email.py
@@ -95,7 +95,10 @@ class EmailOutputChannel(OutputChannel):
 
         if 'log4_shell_computer_name' in self.data:
             vars['Log4JComputerName'] = self.data['log4_shell_computer_name']
-        
+
+        if 'generic_data' in self.data:
+            vars['GenericData'] = self.data['generic_data']
+
         if 'cmd_computer_name' in self.data and 'cmd_user_name' in self.data:
             vars['CMDInformation'] = 'User {user} executed "{process}" on the host {computer}'.format(
                 user=self.data['cmd_user_name'],

--- a/templates/emails/notification.html
+++ b/templates/emails/notification.html
@@ -142,7 +142,14 @@
                                             ){%endif%}
                                           </code></td>
                                       </tr>
-		       {% endif %}
+                      {% endif %}
+                      {% if BasicDetails['GenericData'] %}
+                                     <tr>
+                                        <td class="label" style="background: #eeeeee; font-weight: bold; _border: none; width: 180px; border: 1px solid #cccccc; padding: 5px;">Generic Data</td>
+                                        <td style="border: 1px solid #cccccc; padding: 5px;"><code>{{ BasicDetails['GenericData'] | e}}</code></td>
+                                      </tr>
+                      {% endif %}
+
 		       {% if BasicDetails.get('CanaryLocation', '') %}
                                       <tr>
                                         <td class="label" style="background: #eeeeee; font-weight: bold; _border: none; width: 180px; border: 1px solid #cccccc; padding: 5px;">Canary Location</td>


### PR DESCRIPTION
The Generic Data, encoded in the DNS query, is shown on the website, but was missing from the email alert.