### PR TITLE
Add Google Chat webhook formatting

### DIFF
--- a/channel_output_webhook.py
+++ b/channel_output_webhook.py
@@ -37,10 +37,15 @@ class WebhookOutputChannel(OutputChannel):
     def do_send_alert(self, input_channel=None, canarydrop=None, **kwargs):
 
         slack = "https://hooks.slack.com"
+        google_chat = "https://chat.googleapis.com/"
 
         try:
             if (slack in canarydrop['alert_webhook_url']):
                 payload = input_channel.format_slack_canaryalert(
+                                            canarydrop=canarydrop,
+                                            **kwargs)
+            elif (google_chat in canarydrop['alert_webhook_url']):
+                payload = input_channel.format_googlechat_canaryalert(
                                             canarydrop=canarydrop,
                                             **kwargs)
             else:

--- a/queries.py
+++ b/queries.py
@@ -520,7 +520,8 @@ def is_webhook_valid(url):
         return False
 
     slack = "https://hooks.slack.com"
-    if (slack in url):
+    google_chat = "https://chat.googleapis.com/"
+    if (slack in url or google_chat in url):
         payload = {'text': 'Validating new canarytokens webhook'}
     else:
         payload = {"manage_url": "http://example.com/test/url/for/webhook",


### PR DESCRIPTION
Enable integration with Google Chat by formatting our validation message and alerts in a compatible way for `https://chat.googleapis.com/` webhook URLs.