### PR TITLE
Fix email banner link

### DIFF
--- a/templates/emails/notification.html
+++ b/templates/emails/notification.html
@@ -203,7 +203,7 @@
                   </td>
                 </tr>
               </table>
-              <a href="http://canarytokens.com" style="text-align: center"><img alt="Canary" width="100%" src="http://thinkst.com/images/tokens-banner.gif", _external=True)/></a>
+              <a href="https://canary.tools" style="text-align: center"><img alt="Canary" width="100%" src="http://thinkst.com/images/tokens-banner.gif", _external=True)/></a>
             </td>
           </tr>
         </table>


### PR DESCRIPTION
The banner at the bottom of the email notification points at `https://canary.tools` in the image, so the link should aim there too.