### PR TITLE
Add Google Chat webhook formatting

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -120,7 +120,7 @@ class InputChannel(Channel):
         for (label, text) in [
             ('Channel', self.name),
             ('Time', datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S (UTC)")),
-            ('Canarytoken', canarydrop.canarytoken),
+            ('Canarytoken', canarydrop.canarytoken.value()),
             ('Token Reminder', canarydrop.memo),
             ('Manage URL', '<a href="{protocol}://{host}/manage?token={token}&auth={auth}">{protocol}://{host}/manage?token={token}&auth={auth}</a>' \
                                 .format(protocol=protocol,
@@ -136,8 +136,7 @@ class InputChannel(Channel):
             section(header='Additional Details')
         )
 
-        for label in kwargs:
-            text = kwargs[label]
+        for (label, text) in kwargs.items():
             payload["cardsV2"][0]["card"]["sections"][1]["widgets"].append(
                 decorated_text(label=label, text=text)
             )

--- a/channel.py
+++ b/channel.py
@@ -100,12 +100,6 @@ class InputChannel(Channel):
         }
         if not host or host == '':
             host=settings.PUBLIC_IP
-        
-        paragraph_text = lambda text: {
-            "textParagraph": {
-                "text": text,
-            }
-        }
 
         decorated_text = lambda label, text: {
             "decoratedText": {

--- a/channel.py
+++ b/channel.py
@@ -137,9 +137,10 @@ class InputChannel(Channel):
         )
 
         for (label, text) in kwargs.items():
-            payload["cardsV2"][0]["card"]["sections"][1]["widgets"].append(
-                decorated_text(label=label, text=text)
-            )
+            if label and text:
+                payload["cardsV2"][0]["card"]["sections"][1]["widgets"].append(
+                    decorated_text(label=label, text=text)
+                )
 
         return payload
 

--- a/channel_output_webhook.py
+++ b/channel_output_webhook.py
@@ -37,10 +37,15 @@ class WebhookOutputChannel(OutputChannel):
     def do_send_alert(self, input_channel=None, canarydrop=None, **kwargs):
 
         slack = "https://hooks.slack.com"
+        google_chat = "https://chat.googleapis.com/"
 
         try:
             if (slack in canarydrop['alert_webhook_url']):
                 payload = input_channel.format_slack_canaryalert(
+                                            canarydrop=canarydrop,
+                                            **kwargs)
+            elif (google_chat in canarydrop['alert_webhook_url']):
+                payload = input_channel.format_googlechat_canaryalert(
                                             canarydrop=canarydrop,
                                             **kwargs)
             else:

--- a/queries.py
+++ b/queries.py
@@ -520,7 +520,8 @@ def is_webhook_valid(url):
         return False
 
     slack = "https://hooks.slack.com"
-    if (slack in url):
+    google_chat = "https://chat.googleapis.com/"
+    if (slack in url or google_chat in url):
         payload = {'text': 'Validating new canarytokens webhook'}
     else:
         payload = {"manage_url": "http://example.com/test/url/for/webhook",

--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -1279,7 +1279,7 @@ START REPLICA;
                           $('#memo_errors').show();
                           $('textarea[name=memo]').addClass('error-outline').removeClass('success-outline');
                       } else if (data['Error'] == '3'){
-                          $('#endpoints_errors').html('<p>Invalid webhook supplied, confirm you can POST to this URL with:</p><p><pre>curl -H "Content-Type: application/json" -d \'{"":""}\' URL</pre></p>');
+                          $('#endpoints_errors').html('<p>Invalid webhook supplied, confirm you can POST to this URL with:</p><p><pre>curl -H "Content-Type: application/json" -d \'{"text":"test"}\' URL</pre></p>');
                           $('#endpoints_errors').show();
                           $('#endpoints').addClass('error-outline').removeClass('success-outline');
                       } else if (data['Error'] == '4'){


### PR DESCRIPTION
Enable integration with Google Chat by formatting our validation message and alerts in a compatible way for `https://chat.googleapis.com/` webhook URLs:

<img width="570" alt="Screenshot 2022-12-06 at 12 37 02" src="https://user-images.githubusercontent.com/5555832/205889976-b1601697-1f6e-40f1-9874-f5354a79dead.png">

The command shown in the validation error message now also works with Google Chat:
<img width="605" alt="Screenshot 2022-12-06 at 12 47 07" src="https://user-images.githubusercontent.com/5555832/205890993-ddd3212e-b0bb-453d-8e52-af61810d19b5.png">
<img width="368" alt="Screenshot 2022-12-06 at 12 46 59" src="https://user-images.githubusercontent.com/5555832/205891009-2cca2351-8ece-4331-b9d9-2e7952361dbd.png">

