### PR TITLE
Add request headers and GET/POST arguments to webhook

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -139,7 +139,7 @@ class InputChannel(Channel):
         for (label, text) in kwargs.items():
             if label and text:
                 payload["cardsV2"][0]["card"]["sections"][1]["widgets"].append(
-                    decorated_text(label=label, text=text)
+                    decorated_text(label=label, text='{}'.format(text))
                 )
 
         return payload

--- a/channel.py
+++ b/channel.py
@@ -138,8 +138,9 @@ class InputChannel(Channel):
 
         for (label, text) in kwargs.items():
             if label and text:
+                message_text = simplejson.dumps(text) if isinstance(text, dict) else '{}'.format(text)
                 payload["cardsV2"][0]["card"]["sections"][1]["widgets"].append(
-                    decorated_text(label=label, text='{}'.format(text))
+                    decorated_text(label=label, text=message_text)
                 )
 
         return payload

--- a/channel.py
+++ b/channel.py
@@ -39,9 +39,6 @@ class InputChannel(Channel):
 
     def format_webhook_canaryalert(self,canarydrop=None, protocol=settings.PROTOCOL,
                                    host=settings.PUBLIC_DOMAIN, **kwargs):
-        print('format_webhook_canaryalert(..., **kwargs={kwargs})'.format(
-            kwargs=kwargs
-        ))
         payload = {}
         if not host or host == '':
             host=settings.PUBLIC_IP
@@ -234,7 +231,6 @@ Manage your settings for this Canarydrop:
         return msg
 
     def dispatch(self, **kwargs):
-        print('channel.py:InputChannel.dispatch(**kwargs={})'.format(kwargs))
         self.switchboard.dispatch(input_channel=self.name, **kwargs)
 
 

--- a/channel.py
+++ b/channel.py
@@ -39,6 +39,9 @@ class InputChannel(Channel):
 
     def format_webhook_canaryalert(self,canarydrop=None, protocol=settings.PROTOCOL,
                                    host=settings.PUBLIC_DOMAIN, **kwargs):
+        print('format_webhook_canaryalert(..., **kwargs={kwargs})'.format(
+            kwargs=kwargs
+        ))
         payload = {}
         if not host or host == '':
             host=settings.PUBLIC_IP
@@ -231,6 +234,7 @@ Manage your settings for this Canarydrop:
         return msg
 
     def dispatch(self, **kwargs):
+        print('channel.py:InputChannel.dispatch(**kwargs={})'.format(kwargs))
         self.switchboard.dispatch(input_channel=self.name, **kwargs)
 
 

--- a/channel_http.py
+++ b/channel_http.py
@@ -57,19 +57,29 @@ class CanarytokenPage(resource.Resource, InputChannel):
             request_headers = {
                 k.decode(): flatten_singletons([s.decode() for s in v])
                 for k, v in request.requestHeaders.getAllRawHeaders()
-                if k not in [
-                    'User-Agent',
-                    'x-forwarded-for',
-                ]
+                # if k not in [
+                #     'User-Agent',
+                #     'X-Forwarded-For',
+                #     'X-Real-Ip',
+                # ]
             }
             useragent = request.getHeader('User-Agent')
             src_ip    = request.getHeader('x-forwarded-for')
             #location and refere are for cloned sites
             location  = request.args.get('l', [None])[0]
             referer   = request.args.get('r', [None])[0]
+            request_args = {
+                k: v
+                for k, v in request.args.iteritems()
+                if k not in [
+                    'l', 'r', 'ts_key', 'canarydrop', 'src_ip', 
+                    'useragent', 'location', 'referer', 'request_headers'
+                ]
+            }
             self.dispatch(canarydrop=canarydrop, src_ip=src_ip,
                           useragent=useragent, location=location,
-                          referer=referer, request_headers=request_headers)
+                          referer=referer, request_headers=request_headers, 
+                          request_args=request_args)
 
             if 'redirect_url' in canarydrop._drop and canarydrop._drop['redirect_url']:
                 # if fast redirect

--- a/channel_http.py
+++ b/channel_http.py
@@ -37,7 +37,6 @@ class CanarytokenPage(resource.Resource, InputChannel):
         return Resource.getChild(self, name, request)
 
     def render_GET(self, request):
-        print('channel_http.py:CanarytokenPage.render_GET({})'.format(request))
         #A GET request to a token URL can trigger one of a few responses:
         # 1. Check if link has been clicked on (rather than loaded from an
         #    <img>) by looking at the Accept header, then:
@@ -64,20 +63,8 @@ class CanarytokenPage(resource.Resource, InputChannel):
             request_headers = {
                 k.decode(): flatten_singletons([s.decode() for s in v])
                 for k, v in request.requestHeaders.getAllRawHeaders()
-                # if k not in [
-                #     'User-Agent',
-                #     'X-Forwarded-For',
-                #     'X-Real-Ip',
-                # ]
             }
-            request_args = {
-                k: flatten_singletons(v)
-                for k, v in request.args.iteritems()
-                if k not in [
-                    'l', 'r', 'ts_key', 'canarydrop', 'src_ip', 
-                    'useragent', 'location', 'referer', 'request_headers'
-                ]
-            }
+            request_args = {k: ','.join(v) for k, v in request.args.iteritems()}
             self.dispatch(canarydrop=canarydrop, src_ip=src_ip,
                           useragent=useragent, location=location,
                           referer=referer, request_headers=request_headers, 
@@ -124,7 +111,6 @@ class CanarytokenPage(resource.Resource, InputChannel):
         return self.GIF
 
     def render_POST(self, request):
-        print('channel_http.py:CanarytokenPage.render_POST({})'.format(request))
         try:
             token = Canarytoken(value=request.path)
             canarydrop = Canarydrop(**get_canarydrop(canarytoken=token.value()))

--- a/channel_http.py
+++ b/channel_http.py
@@ -53,6 +53,15 @@ class CanarytokenPage(resource.Resource, InputChannel):
                 canarydrop._drop['hit_time'] = request.args.get('ts_key', [None])[0]
             else:
                 canarydrop._drop['hit_time'] = datetime.datetime.utcnow().strftime("%s.%f")
+            flatten_singletons = lambda l: l[0] if len(l) == 1 else l
+            request_headers = {
+                k.decode(): flatten_singletons([s.decode() for s in v])
+                for k, v in request.requestHeaders.getAllRawHeaders()
+                if k not in [
+                    'User-Agent',
+                    'x-forwarded-for',
+                ]
+            }
             useragent = request.getHeader('User-Agent')
             src_ip    = request.getHeader('x-forwarded-for')
             #location and refere are for cloned sites
@@ -60,7 +69,7 @@ class CanarytokenPage(resource.Resource, InputChannel):
             referer   = request.args.get('r', [None])[0]
             self.dispatch(canarydrop=canarydrop, src_ip=src_ip,
                           useragent=useragent, location=location,
-                          referer=referer)
+                          referer=referer, request_headers=request_headers)
 
             if 'redirect_url' in canarydrop._drop and canarydrop._drop['redirect_url']:
                 # if fast redirect

--- a/channel_output_webhook.py
+++ b/channel_output_webhook.py
@@ -60,12 +60,18 @@ class WebhookOutputChannel(OutputChannel):
 
         def handle_response(response):
             if response.code != 200:
-                log.error("Failed sending request to webhook {url} with code {error}".format(url=canarydrop['alert_webhook_url'],error=response.code))
+                log.error("Failed sending request to webhook {url} with code {error}. Payload: {payload}".format(
+                    url=canarydrop['alert_webhook_url'],
+                    error=response.code,
+                    payload=payload))
             else:
                 log.info('Webhook sent to {url}'.format(url=canarydrop['alert_webhook_url']))
 
         def handle_error(result):
-            log.error("Failed sending request to webhook {url} with error {error}".format(url=canarydrop['alert_webhook_url'],error=result))
+            log.error("Failed sending request to webhook {url} with error {error}. Payload: {payload}".format(
+                url=canarydrop['alert_webhook_url'],
+                error=result,
+                payload=payload))
 
         agent = Agent(reactor)
         body = BytesProducer(payload)

--- a/channel_output_webhook.py
+++ b/channel_output_webhook.py
@@ -35,6 +35,10 @@ class WebhookOutputChannel(OutputChannel):
 
 
     def do_send_alert(self, input_channel=None, canarydrop=None, **kwargs):
+        print('do_send_alert(input_channel={input_channel}, canarydrop, **kwargs={kwargs})'.format(
+            input_channel=input_channel,
+            kwargs=kwargs
+        ))
 
         slack_hook_base_url = "https://hooks.slack.com"
         googlechat_hook_base_url = "https://chat.googleapis.com/"

--- a/channel_output_webhook.py
+++ b/channel_output_webhook.py
@@ -35,11 +35,6 @@ class WebhookOutputChannel(OutputChannel):
 
 
     def do_send_alert(self, input_channel=None, canarydrop=None, **kwargs):
-        print('do_send_alert(input_channel={input_channel}, canarydrop, **kwargs={kwargs})'.format(
-            input_channel=input_channel,
-            kwargs=kwargs
-        ))
-
         slack_hook_base_url = "https://hooks.slack.com"
         googlechat_hook_base_url = "https://chat.googleapis.com/"
 


### PR DESCRIPTION
Add request headers and GET/POST arguments to webhook, make errors on delivery more useful, and  sanitise components of the Google Chat webhook.