### PR TITLE
Add request headers and GET/POST arguments to webhook

### DIFF
--- a/channel.py
+++ b/channel.py
@@ -138,8 +138,9 @@ class InputChannel(Channel):
 
         for (label, text) in kwargs.items():
             if label and text:
+                message_text = simplejson.dumps(text) if isinstance(text, dict) else '{}'.format(text)
                 payload["cardsV2"][0]["card"]["sections"][1]["widgets"].append(
-                    decorated_text(label=label, text=text)
+                    decorated_text(label=label, text=message_text)
                 )
 
         return payload

--- a/channel_http.py
+++ b/channel_http.py
@@ -1,3 +1,4 @@
+import re
 import simplejson
 import datetime
 import os
@@ -58,9 +59,16 @@ class CanarytokenPage(resource.Resource, InputChannel):
             #location and refere are for cloned sites
             location  = request.args.get('l', [None])[0]
             referer   = request.args.get('r', [None])[0]
+            flatten_singletons = lambda l: l[0] if len(l) == 1 else l
+            request_headers = {
+                k.decode(): flatten_singletons([s.decode() for s in v])
+                for k, v in request.requestHeaders.getAllRawHeaders()
+            }
+            request_args = {k: ','.join(v) for k, v in request.args.iteritems()}
             self.dispatch(canarydrop=canarydrop, src_ip=src_ip,
                           useragent=useragent, location=location,
-                          referer=referer)
+                          referer=referer, request_headers=request_headers, 
+                          request_args=request_args)
 
             if 'redirect_url' in canarydrop._drop and canarydrop._drop['redirect_url']:
                 # if fast redirect

--- a/channel_output_webhook.py
+++ b/channel_output_webhook.py
@@ -35,7 +35,6 @@ class WebhookOutputChannel(OutputChannel):
 
 
     def do_send_alert(self, input_channel=None, canarydrop=None, **kwargs):
-
         slack_hook_base_url = "https://hooks.slack.com"
         googlechat_hook_base_url = "https://chat.googleapis.com/"
 
@@ -61,12 +60,18 @@ class WebhookOutputChannel(OutputChannel):
 
         def handle_response(response):
             if response.code != 200:
-                log.error("Failed sending request to webhook {url} with code {error}".format(url=canarydrop['alert_webhook_url'],error=response.code))
+                log.error("Failed sending request to webhook {url} with code {error}. Payload: {payload}".format(
+                    url=canarydrop['alert_webhook_url'],
+                    error=response.code,
+                    payload=payload))
             else:
                 log.info('Webhook sent to {url}'.format(url=canarydrop['alert_webhook_url']))
 
         def handle_error(result):
-            log.error("Failed sending request to webhook {url} with error {error}".format(url=canarydrop['alert_webhook_url'],error=result))
+            log.error("Failed sending request to webhook {url} with error {error}. Payload: {payload}".format(
+                url=canarydrop['alert_webhook_url'],
+                error=result,
+                payload=payload))
 
         agent = Agent(reactor)
         body = BytesProducer(payload)


### PR DESCRIPTION
* pass headers and request args in `additional_data`

* include webhook payload in failure logs

* ensure google chat alert components are strings, dump dicts to json