### PR TITLE
T5217: Update security.txt and T5221: Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+Thinkst welcomes bug reports and takes them seriously. Our primary reporting channel is security@thinkst.com, however security bugs in our open source software can also be reported on GitHub. We don't run a bug bounty for canarytokens.org, but we will send swag for fixable bugs and code contributions.
+
+If you report a security bug we will request a CVE on your behalf and it will be acknowledged in a GitHub Advisory. Denial-of-Service bugs are reportable but please don’t test them on our production system.
+
+Please make sure to include the following in your report:
+1. **Summary**: Short summary of the problem. Make the impact and severity as clear as possible. For example: An unsafe deserialization vulnerability allows any unauthenticated user to execute arbitrary code on the server.
+2. **Details**: Give all details on the vulnerability. Pointing to the incriminated source code is very helpful for the maintainer.
+3. **PoC**: Complete instructions, including specific configuration details, to reproduce the vulnerability.
+4. **Impact**: What kind of vulnerability is it? Who is impacted?

--- a/templates/security.txt
+++ b/templates/security.txt
@@ -1,5 +1,12 @@
+# Our primary reporting channel:
 Contact: mailto:security@thinkst.com
-Contact: https://github.com/thinkst/canarytokens/security/advisories/new
-Expires: 2023-12-31T21:59:00.000Z
 Encryption: https://thinkst.com/pgp/security.txt
 Preferred-Languages: en
+
+# Alternative channel for canarytokens.org vulnerabilities:
+Contact: https://github.com/thinkst/canarytokens/security/advisories/new
+Policy: https://github.com/thinkst/canarytokens/security/policy
+Acknowledgements : https://github.com/thinkst/canarytokens/security/advisories
+
+Expires: 2023-12-31T21:59:00.000Z
+Hiring: https://canary.tools/jobs


### PR DESCRIPTION
This PR adds a security policy to the canarytokens repo and updates the `security.txt` file to point to it.