### PR TITLE
T5211 py3 port google chat webhook formatting

### DIFF
--- a/canarytokens/channel.py
+++ b/canarytokens/channel.py
@@ -20,13 +20,13 @@ from canarytokens.models import (
     GoogleChatCard,
     GoogleChatCardV2,
     GoogleChatHeader,
-    GoogleChatPayload,
     GoogleChatSection,
     Memo,
     SlackAttachment,
     SlackField,
     TokenAlertDetailGeneric,
     TokenAlertDetails,
+    TokenAlertDetailsGoogleChat,
     TokenAlertDetailsSlack,
     TokenTypes,
 )
@@ -55,7 +55,9 @@ def format_as_slack_canaryalert(details: TokenAlertDetails) -> TokenAlertDetails
     )
 
 
-def format_as_googlechat_canaryalert(details: TokenAlertDetails) -> GoogleChatPayload:
+def format_as_googlechat_canaryalert(
+    details: TokenAlertDetails,
+) -> TokenAlertDetailsGoogleChat:
     # construct google chat alert , top section
     top_section = GoogleChatSection(header="Alert Details")
     top_section.add_widgets(
@@ -82,7 +84,7 @@ def format_as_googlechat_canaryalert(details: TokenAlertDetails) -> GoogleChatPa
         sections=[top_section, additional_section],
     )
     # make google chat payload
-    return GoogleChatPayload(
+    return TokenAlertDetailsGoogleChat(
         cardsV2=[GoogleChatCardV2(cardId="unique-card-id", card=card)]
     )
 
@@ -252,7 +254,9 @@ class InputChannel(Channel):
         canarydrop: Canarydrop,
         protocol: str,
         host: str,  # DESIGN: Shift this to settings. Do we need to have this logic here?
-    ) -> Union[TokenAlertDetailsSlack, TokenAlertDetailGeneric, GoogleChatPayload]:
+    ) -> Union[
+        TokenAlertDetailsSlack, TokenAlertDetailGeneric, TokenAlertDetailsGoogleChat
+    ]:
         # TODO: Need to add `host` and `protocol` that can be used to manage the token.
         googlechat_hook_base_url = "https://chat.googleapis.com"
         details = cls.gather_alert_details(

--- a/canarytokens/channel.py
+++ b/canarytokens/channel.py
@@ -16,6 +16,12 @@ from canarytokens.canarydrop import Canarydrop
 # from canarytokens.exceptions import DuplicateChannel
 from canarytokens.models import (
     AnyTokenHit,
+    GoogleChatAlertDetailsSectionData,
+    GoogleChatCard,
+    GoogleChatCardV2,
+    GoogleChatHeader,
+    GoogleChatPayload,
+    GoogleChatSection,    
     Memo,
     SlackAttachment,
     SlackField,
@@ -48,6 +54,36 @@ def format_as_slack_canaryalert(details: TokenAlertDetails) -> TokenAlertDetails
         attachments=attchments,
     )
 
+def format_as_googlechat_canaryalert(details: TokenAlertDetails) -> GoogleChatPayload:
+    # construct google chat alert , top section
+    top_section = GoogleChatSection(header="Alert Details")
+    top_section.add_widgets(
+        widgets_info=GoogleChatAlertDetailsSectionData(
+            channel=details.channel,
+            time=details.time.strftime("%Y-%m-%d %H:%M:%S (UTC)"),
+            canarytoken=details.token,
+            token_reminder=details.memo,
+            manage_url=details.manage_url,
+        ).get_googlechat_data()
+    )
+    # construct google chat alert , additional section
+    additional_section = GoogleChatSection(header="Additional Details")
+    additional_section.add_widgets(widgets_info=details.additional_data)
+
+    # construct google chat alert card
+    card = GoogleChatCard(
+        header=GoogleChatHeader(
+            title="Canarytoken Triggered",
+            imageUrl="https://s3-eu-west-1.amazonaws.com/email-images.canary.tools/canary-logo-round.png",
+            imageType="CIRCLE",
+            imageAltText="Thinkst Canary",
+        ),
+        sections=[top_section, additional_section],
+    )
+    # make google chat payload
+    return GoogleChatPayload(
+        cardsV2=[GoogleChatCardV2(cardId="unique-card-id", card=card)]
+    )
 
 class Channel(object):
     CHANNEL = "Base"
@@ -216,6 +252,7 @@ class InputChannel(Channel):
         host: str,  # DESIGN: Shift this to settings. Do we need to have this logic here?
     ) -> Union[TokenAlertDetailsSlack, TokenAlertDetailGeneric]:
         # TODO: Need to add `host` and `protocol` that can be used to manage the token.
+        googlechat_hook_base_url = "https://chat.googleapis.com"
         details = cls.gather_alert_details(
             canarydrop,
             protocol=protocol,
@@ -225,6 +262,10 @@ class InputChannel(Channel):
             "https://hooks.slack.com" in canarydrop.alert_webhook_url
         ):
             return format_as_slack_canaryalert(details=details)
+        elif canarydrop.alert_webhook_url and (
+            str(canarydrop.alert_webhook_url).startswith(googlechat_hook_base_url)
+        ):
+            return format_as_googlechat_canaryalert(details=details)            
         else:
             return TokenAlertDetailGeneric(**details.dict())
 

--- a/canarytokens/channel.py
+++ b/canarytokens/channel.py
@@ -252,7 +252,7 @@ class InputChannel(Channel):
         canarydrop: Canarydrop,
         protocol: str,
         host: str,  # DESIGN: Shift this to settings. Do we need to have this logic here?
-    ) -> Union[TokenAlertDetailsSlack, TokenAlertDetailGeneric]:
+    ) -> Union[TokenAlertDetailsSlack, TokenAlertDetailGeneric, GoogleChatPayload]:
         # TODO: Need to add `host` and `protocol` that can be used to manage the token.
         googlechat_hook_base_url = "https://chat.googleapis.com"
         details = cls.gather_alert_details(

--- a/canarytokens/channel.py
+++ b/canarytokens/channel.py
@@ -21,7 +21,7 @@ from canarytokens.models import (
     GoogleChatCardV2,
     GoogleChatHeader,
     GoogleChatPayload,
-    GoogleChatSection,    
+    GoogleChatSection,
     Memo,
     SlackAttachment,
     SlackField,
@@ -54,6 +54,7 @@ def format_as_slack_canaryalert(details: TokenAlertDetails) -> TokenAlertDetails
         attachments=attchments,
     )
 
+
 def format_as_googlechat_canaryalert(details: TokenAlertDetails) -> GoogleChatPayload:
     # construct google chat alert , top section
     top_section = GoogleChatSection(header="Alert Details")
@@ -84,6 +85,7 @@ def format_as_googlechat_canaryalert(details: TokenAlertDetails) -> GoogleChatPa
     return GoogleChatPayload(
         cardsV2=[GoogleChatCardV2(cardId="unique-card-id", card=card)]
     )
+
 
 class Channel(object):
     CHANNEL = "Base"
@@ -265,7 +267,7 @@ class InputChannel(Channel):
         elif canarydrop.alert_webhook_url and (
             str(canarydrop.alert_webhook_url).startswith(googlechat_hook_base_url)
         ):
-            return format_as_googlechat_canaryalert(details=details)            
+            return format_as_googlechat_canaryalert(details=details)
         else:
             return TokenAlertDetailGeneric(**details.dict())
 

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -48,6 +48,10 @@ CANARYTOKEN_ALPHABET = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
                         '4', '5', '6', '7', '8', '9']
 # fmt: on
 CANARYTOKEN_LENGTH = 25  # equivalent to 128-bit id
+CANARYTOKEN_RE = re.compile(
+    ".*([" + "".join(CANARYTOKEN_ALPHABET) + "]{" + str(CANARYTOKEN_LENGTH) + "}).*",
+    re.IGNORECASE,
+)
 
 CANARY_PDF_TEMPLATE_OFFSET: int = 793
 
@@ -66,6 +70,10 @@ class Hostname(ConstrainedStr):
     regex = re.compile(
         r"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{1,61}[a-zA-Z0-9])\.){1,61}([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{1,61}[A-Za-z0-9]){1,253}$"
     )
+
+class Canarytoken(ConstrainedStr):
+    max_length: int = CANARYTOKEN_LENGTH
+    regex = CANARYTOKEN_RE
 
 
 class PseudoUrl(ConstrainedStr):
@@ -1515,6 +1523,84 @@ class SlackAttachment(BaseModel):
         # HACK: We can do better here.
         data["fallback"] = f"Canarytoken Triggered: {data['title_link']}"
         super().__init__(**data)
+
+class GoogleChatDecoratedText(BaseModel):
+    topLabel: str = ""
+    text: str = ""
+
+
+class GoogleChatWidget(BaseModel):
+    decoratedText: GoogleChatDecoratedText
+
+
+class GoogleChatAlertDetailsSectionData(BaseModel):
+    channel: str = ""
+    time: datetime
+    canarytoken: Canarytoken
+    token_reminder: Memo
+    manage_url: HttpUrl
+
+    @validator("time", pre=True)
+    def validate_time(cls, value):
+        if isinstance(value, str):
+            return datetime.strptime(value, "%Y-%m-%d %H:%M:%S (UTC)")
+        return value
+
+    def get_googlechat_data(self) -> Dict[str, str]:
+        data = json_safe_dict(self)
+        data["Channel"] = data.pop("channel", "")
+        data["Time"] = data.pop("time", "")
+        data["Canarytoken"] = data.pop("canarytoken", "")
+        data["Token Reminder"] = data.pop("token_reminder", "")
+        data["Manage URL"] = '<a href="{manage_url}">{manage_url}</a>'.format(
+            manage_url=data.pop("manage_url", "")
+        )
+        return data
+
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.strftime("%Y-%m-%d %H:%M:%S (UTC)"),
+        }
+
+
+class GoogleChatHeader(BaseModel):
+    title: str = "Canarytoken Triggered"
+    imageUrl: HttpUrl
+    imageType: str = "CIRCLE"
+    imageAltText: str = "Thinkst Canary"
+
+
+class GoogleChatSection(BaseModel):
+    header: str = ""
+    collapsible: bool = False
+    widgets: List[GoogleChatWidget] = []
+
+    def add_widgets(self, widgets_info: Optional[Dict[str, str]] = {}) -> None:
+        for (label, text) in widgets_info.items():
+            if not label or not text:
+                continue
+            self.widgets.append(
+                GoogleChatWidget(
+                    decoratedText=GoogleChatDecoratedText(topLabel=label, text=text)
+                )
+            )
+
+
+class GoogleChatCard(BaseModel):
+    header: GoogleChatHeader
+    sections: List[GoogleChatSection] = []
+
+
+class GoogleChatCardV2(BaseModel):
+    cardId: str = "unique-card-id"
+    card: GoogleChatCard
+
+
+class GoogleChatPayload(BaseModel):
+    cardsV2: List[GoogleChatCardV2]
+
+    def json_safe_dict(self) -> Dict[str, str]:
+        return json_safe_dict(self)
 
 
 class TokenAlertDetailsSlack(BaseModel):

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -71,6 +71,7 @@ class Hostname(ConstrainedStr):
         r"^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{1,61}[a-zA-Z0-9])\.){1,61}([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]{1,61}[A-Za-z0-9]){1,253}$"
     )
 
+
 class Canarytoken(ConstrainedStr):
     max_length: int = CANARYTOKEN_LENGTH
     regex = CANARYTOKEN_RE
@@ -1523,6 +1524,7 @@ class SlackAttachment(BaseModel):
         # HACK: We can do better here.
         data["fallback"] = f"Canarytoken Triggered: {data['title_link']}"
         super().__init__(**data)
+
 
 class GoogleChatDecoratedText(BaseModel):
     topLabel: str = ""

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1598,7 +1598,7 @@ class GoogleChatCardV2(BaseModel):
     card: GoogleChatCard
 
 
-class GoogleChatPayload(BaseModel):
+class TokenAlertDetailsGoogleChat(BaseModel):
     cardsV2: List[GoogleChatCardV2]
 
     def json_safe_dict(self) -> Dict[str, str]:

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -794,7 +794,7 @@ def validate_webhook(url, token_type: models.TokenTypes):
         models.TokenAlertDetails,
         models.TokenAlertDetailsSlack,
         models.GoogleChatPayload,
-    ]    
+    ]
     if slack in url:
         payload = models.TokenAlertDetailsSlack(
             attachments=[
@@ -818,14 +818,12 @@ def validate_webhook(url, token_type: models.TokenTypes):
                 imageType="CIRCLE",
                 imageAltText="Thinkst Canary",
             ),
-            sections=[
-                models.GoogleChatSection(header="Testing Webhook"),
-            ],
+            sections=[],
         )
         # make google chat payload
         payload = models.GoogleChatPayload(
             cardsV2=[models.GoogleChatCardV2(cardId="unique-card-id", card=card)]
-        )        
+        )
     else:
         payload = models.TokenAlertDetails(
             manage_url=HttpUrl(

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -789,7 +789,12 @@ def validate_webhook(url, token_type: models.TokenTypes):
     url -- Webhook url
     """
     slack = "https://hooks.slack.com"
-    payload: Union[models.TokenAlertDetails, models.TokenAlertDetailsSlack]
+    googlechat_hook_base_url = "https://chat.googleapis.com"
+    payload: Union[
+        models.TokenAlertDetails,
+        models.TokenAlertDetailsSlack,
+        models.GoogleChatPayload,
+    ]    
     if slack in url:
         payload = models.TokenAlertDetailsSlack(
             attachments=[
@@ -804,6 +809,23 @@ def validate_webhook(url, token_type: models.TokenTypes):
                 )
             ]
         )
+    elif url.startswith(googlechat_hook_base_url):
+        # construct google chat alert card
+        card = models.GoogleChatCard(
+            header=models.GoogleChatHeader(
+                title="Validating new canarytokens webhook",
+                imageUrl="https://s3-eu-west-1.amazonaws.com/email-images.canary.tools/canary-logo-round.png",
+                imageType="CIRCLE",
+                imageAltText="Thinkst Canary",
+            ),
+            sections=[
+                models.GoogleChatSection(header="Testing Webhook"),
+            ],
+        )
+        # make google chat payload
+        payload = models.GoogleChatPayload(
+            cardsV2=[models.GoogleChatCardV2(cardId="unique-card-id", card=card)]
+        )        
     else:
         payload = models.TokenAlertDetails(
             manage_url=HttpUrl(

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -793,9 +793,9 @@ def validate_webhook(url, token_type: models.TokenTypes):
     payload: Union[
         models.TokenAlertDetails,
         models.TokenAlertDetailsSlack,
-        models.GoogleChatPayload,
+        models.TokenAlertDetailsGoogleChat,
     ]
-    if slack in url:
+    if url.startswith(slack):
         payload = models.TokenAlertDetailsSlack(
             attachments=[
                 models.SlackAttachment(
@@ -821,7 +821,7 @@ def validate_webhook(url, token_type: models.TokenTypes):
             sections=[],
         )
         # make google chat payload
-        payload = models.GoogleChatPayload(
+        payload = models.TokenAlertDetailsGoogleChat(
             cardsV2=[models.GoogleChatCardV2(cardId="unique-card-id", card=card)]
         )
     else:

--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -1310,9 +1310,6 @@ START REPLICA;
                     $('#file_upload_errors').html("File too large.");
                     $('.fileupload-wrapper').addClass('error-outline').removeClass('success-outline');
                     $('#file_upload_errors').show();
-                  } else if (jqXhr['responseJSON'] && jqXhr['responseJSON']['detail']){
-                    $('#file_upload_errors').html("An error has occurred: " + jqXhr['responseJSON']['detail'] + ".");
-                    $('#file_upload_errors').show();
                   } else{
                     $('#file_upload_errors').html("An error has occurred: " + errorThrown + ".");
                     $('#file_upload_errors').show();

--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -1310,6 +1310,9 @@ START REPLICA;
                     $('#file_upload_errors').html("File too large.");
                     $('.fileupload-wrapper').addClass('error-outline').removeClass('success-outline');
                     $('#file_upload_errors').show();
+                  } else if (jqXhr['responseJSON'] && jqXhr['responseJSON']['detail']){
+                    $('#file_upload_errors').html("An error has occurred: " + jqXhr['responseJSON']['detail'] + ".");
+                    $('#file_upload_errors').show();
                   } else{
                     $('#file_upload_errors').html("An error has occurred: " + errorThrown + ".");
                     $('#file_upload_errors').show();

--- a/tests/units/test_channel_output_webhook.py
+++ b/tests/units/test_channel_output_webhook.py
@@ -138,7 +138,6 @@ def test_broken_2_webhook(setup_db, webhook_receiver, settings: Settings):
     )
 
 
-
 def test_googlechat_webhook_format(setup_db, webhook_receiver, settings: Settings):
 
     switchboard = Switchboard()

--- a/tests/units/test_channel_output_webhook.py
+++ b/tests/units/test_channel_output_webhook.py
@@ -2,6 +2,7 @@
 from twisted.logger import capturedLogs
 
 from canarytokens.canarydrop import Canarydrop
+from canarytokens.channel import format_as_googlechat_canaryalert
 from canarytokens.channel_dns import ChannelDNS
 from canarytokens.channel_output_webhook import WebhookOutputChannel
 from canarytokens.models import TokenTypes
@@ -135,3 +136,77 @@ def test_broken_2_webhook(setup_db, webhook_receiver, settings: Settings):
     assert any(
         ["Failed sending request to webhook" in log["log_format"] for log in captured]
     )
+
+
+
+def test_googlechat_webhook_format(setup_db, webhook_receiver, settings: Settings):
+
+    switchboard = Switchboard()
+    input_channel = ChannelDNS(
+        switchboard=switchboard,
+        settings=settings,
+        backend_hostname="test.com",
+        backend_scheme="https",
+        listen_domain=settings.LISTEN_DOMAIN,
+    )
+
+    cd = Canarydrop(
+        type=TokenTypes.DNS,
+        generate=True,
+        alert_email_enabled=False,
+        alert_email_recipient="email@test.com",
+        alert_webhook_enabled=False,
+        alert_webhook_url=webhook_receiver,
+        canarytoken=Canarytoken(),
+        memo="memo",
+        browser_scanner_enabled=False,
+    )
+    token_hit = Canarytoken.create_token_hit(
+        token_type=TokenTypes.DNS,
+        input_channel="not_valid",
+        src_ip="127.0.0.1",
+        hit_info={"some": "data"},
+    )
+    cd.add_canarydrop_hit(token_hit=token_hit)
+    details = input_channel.gather_alert_details(
+        cd,
+        protocol=input_channel.backend_scheme,
+        host=input_channel.backend_hostname,
+    )
+    print("Webhook details = {}".format(details))
+    webhook_payload = format_as_googlechat_canaryalert(details=details)
+    webhook_payload_json = webhook_payload.json_safe_dict()
+    print("Webhook_payload json = {}".format(webhook_payload.json()))
+
+    assert "cardsV2" in webhook_payload_json.keys()
+    assert type(webhook_payload_json["cardsV2"]) is list
+    assert len(webhook_payload_json["cardsV2"]) == 1
+    for key in ["cardId", "card"]:
+        assert key in webhook_payload_json["cardsV2"][0].keys()
+    assert type(webhook_payload_json["cardsV2"][0]["cardId"]) is str
+    assert type(webhook_payload_json["cardsV2"][0]["card"]) is dict
+    for key in ["header", "sections"]:
+        assert key in webhook_payload_json["cardsV2"][0]["card"].keys()
+    assert type(webhook_payload_json["cardsV2"][0]["card"]["header"]) is dict
+    for key in ["title", "imageUrl", "imageType", "imageAltText"]:
+        assert key in webhook_payload_json["cardsV2"][0]["card"]["header"].keys()
+        assert type(webhook_payload_json["cardsV2"][0]["card"]["header"][key]) is str
+    assert type(webhook_payload_json["cardsV2"][0]["card"]["sections"]) is list
+    assert len(webhook_payload_json["cardsV2"][0]["card"]["sections"]) == 2
+    assert type(webhook_payload_json["cardsV2"][0]["card"]["sections"][0]) is dict
+    for key in ["header", "collapsible", "widgets"]:
+        assert key in webhook_payload_json["cardsV2"][0]["card"]["sections"][0].keys()
+    assert (
+        type(webhook_payload_json["cardsV2"][0]["card"]["sections"][0]["header"]) is str
+    )
+    assert (
+        type(webhook_payload_json["cardsV2"][0]["card"]["sections"][0]["collapsible"])
+        is bool
+    )
+    assert (
+        type(webhook_payload_json["cardsV2"][0]["card"]["sections"][0]["widgets"])
+        is list
+    )
+    assert type(webhook_payload_json["cardsV2"][0]["card"]["sections"][1]) is dict
+    for key in ["header", "collapsible", "widgets"]:
+        assert key in webhook_payload_json["cardsV2"][0]["card"]["sections"][1].keys()

--- a/tests/units/test_channel_output_webhook.py
+++ b/tests/units/test_channel_output_webhook.py
@@ -5,7 +5,7 @@ from canarytokens.canarydrop import Canarydrop
 from canarytokens.channel import format_as_googlechat_canaryalert
 from canarytokens.channel_dns import ChannelDNS
 from canarytokens.channel_output_webhook import WebhookOutputChannel
-from canarytokens.models import GoogleChatPayload, TokenTypes
+from canarytokens.models import TokenAlertDetailsGoogleChat, TokenTypes
 from canarytokens.settings import Settings
 from canarytokens.switchboard import Switchboard
 from canarytokens.tokens import Canarytoken
@@ -252,4 +252,4 @@ def test_canaryalert_googlechat_webhook(setup_db, webhook_receiver, settings: Se
         protocol=input_channel.backend_scheme,
         host=input_channel.backend_hostname,
     )
-    assert isinstance(canaryalert_webhook_payload, GoogleChatPayload)
+    assert isinstance(canaryalert_webhook_payload, TokenAlertDetailsGoogleChat)


### PR DESCRIPTION
port google chat webhook to python 3

Enable integration with Google Chat by formatting our validation message and alerts in a compatible way for `https://chat.googleapis.com` webhook URLs:
![Screenshot 2023-02-07 at 22 21 49](https://user-images.githubusercontent.com/103185449/217359502-0d34f004-2be4-4917-a110-4cc054bdd7d4.png)

The command shown in the validation error message now also works with Google Chat:
![Screenshot 2023-02-07 at 22 24 14](https://user-images.githubusercontent.com/103185449/217359689-0b2e3c22-9dab-4748-90a6-9d1f1a7b215d.png)
