### PR TITLE
Allow for token_id to be in GET arguments 

### DIFF
--- a/channel_http.py
+++ b/channel_http.py
@@ -49,7 +49,7 @@ class CanarytokenPage(resource.Resource, InputChannel):
         request.setHeader("Server", "Apache")
         try:
             manage_uris = ['generate', 'download', 'history', 'manage', 'resources', 'settings']
-            if any([x in request.path for x in manage_urls]):
+            if any([x in request.path for x in manage_uris]):
                 token = Canarytoken(value=request.path)
             else:
                 token = Canarytoken(value=request.uri)

--- a/channel_http.py
+++ b/channel_http.py
@@ -48,7 +48,11 @@ class CanarytokenPage(resource.Resource, InputChannel):
 
         request.setHeader("Server", "Apache")
         try:
-            token = Canarytoken(value=request.uri)
+            manage_uris = ['generate', 'download', 'history', 'manage', 'resources', 'settings']
+            if any([x in request.path for x in manage_urls]):
+                token = Canarytoken(value=request.path)
+            else:
+                token = Canarytoken(value=request.uri)
             canarydrop = Canarydrop(**get_canarydrop(canarytoken=token.value()))
             if request.args.get('ts_key',[None])[0]:
                 canarydrop._drop['hit_time'] = request.args.get('ts_key', [None])[0]

--- a/channel_http.py
+++ b/channel_http.py
@@ -48,8 +48,8 @@ class CanarytokenPage(resource.Resource, InputChannel):
 
         request.setHeader("Server", "Apache")
         try:
-            manage_uris = ['generate', 'download', 'history', 'manage', 'resources', 'settings']
-            if any([x in request.path for x in manage_uris]):
+            manage_uris = ['/generate', '/download?', '/history?', '/manage?', '/resources/', '/settings']
+            if any([request.path.find(x) == 0 for x in manage_uris]):
                 token = Canarytoken(value=request.path)
             else:
                 token = Canarytoken(value=request.uri)

--- a/channel_http.py
+++ b/channel_http.py
@@ -48,7 +48,7 @@ class CanarytokenPage(resource.Resource, InputChannel):
 
         request.setHeader("Server", "Apache")
         try:
-            token = Canarytoken(value=request.path)
+            token = Canarytoken(value=request.uri)
             canarydrop = Canarydrop(**get_canarydrop(canarytoken=token.value()))
             if request.args.get('ts_key',[None])[0]:
                 canarydrop._drop['hit_time'] = request.args.get('ts_key', [None])[0]


### PR DESCRIPTION
This PR allows for the HTTP token IDs to be put into GET arguments, so there can be more subtle API-style URLs designed (e.g., /api/v1/list_secrets?key=<tokenid>. As it is now looking within the entire `request.uri` as opposed to `request.path`, I had to filter out the token management pages, which would otherwise trigger an alert on access.