### PR TITLE
Remove invalid CSS

### DIFF
--- a/templates/manage_new.html
+++ b/templates/manage_new.html
@@ -399,7 +399,7 @@
     <div class="row">
       <div class="col-md-2"></div>
         <div class="col-md-8">
-          <div class="alert alert-success" role="alert" style="text-align: center;" style="align">
+          <div class="alert alert-success" role="alert" style="text-align: center;">
             <strong>We hope you are enjoying the free version of Canarytokens!</strong> <br> For more (non-public) tokens, support, mass-deployment-tools and better management of your deployed tokens, check out our commercial Canarytoken offering at <a href="https://canary.tools/canarytokens">https://canary.tools/canarytokens</a>.
           </div>
         </div>


### PR DESCRIPTION
Previously identified as a typo, this is not valid CSS at all and should be removed.