### PR TITLE
T5610: Backwards compatibility

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     ports:
       - "5354:5354/udp"
       - "51820:51820/udp"
-      - "8000:8000"
+      - "8082:8082"
     # Overrides default command so things don't shut down after the process ends.
     entrypoint: /usr/local/share/docker-init.sh
     command: sleep infinity

--- a/canarytokens/canarydrop.py
+++ b/canarytokens/canarydrop.py
@@ -89,7 +89,7 @@ class Canarydrop(BaseModel):
     alert_webhook_url: Union[HttpUrl, None, Literal[""]]
 
     # web image specific stuff
-    web_image_enabled: Optional[bool]
+    web_image_enabled: bool = False
     web_image_path: Optional[Path]
     # Slow/Fast redirect specific stuff
     redirect_url: Optional[HttpUrl]

--- a/canarytokens/canarydrop.py
+++ b/canarytokens/canarydrop.py
@@ -94,7 +94,7 @@ class Canarydrop(BaseModel):
     # Slow/Fast redirect specific stuff
     redirect_url: Optional[HttpUrl]
     # Clonedsite specific stuff
-    clonedsite: Optional[HttpUrl]
+    clonedsite: Optional[str]
     # Kubeconfig specific stuff
     kubeconfig: Optional[str]
     # SQL specific stuff

--- a/canarytokens/canarydrop.py
+++ b/canarytokens/canarydrop.py
@@ -75,7 +75,7 @@ class Canarydrop(BaseModel):
     type: TokenTypes
     user: Union[User, Anonymous] = Anonymous()
 
-    token_url: Optional[str]
+    # token_url: Optional[str]
     generated_url: Optional[str]
     generated_hostname: Optional[str]
 

--- a/canarytokens/channel_dns.py
+++ b/canarytokens/channel_dns.py
@@ -329,4 +329,4 @@ class ChannelDNS(InputChannel):
     #     return additional_report
 
     def _handleMySqlErr(self, result):
-        log.error("Error dispatching MySQL alert: {}".format(result))
+        log.error(f"Error dispatching MySQL alert: {result}")

--- a/canarytokens/channel_input_mtls.py
+++ b/canarytokens/channel_input_mtls.py
@@ -97,7 +97,7 @@ class mTLS(basic.LineReceiver):
             )
 
         except CertificateError as e:
-            log.error("CertificateError Exception: {}".format(e))
+            log.error(f"CertificateError Exception: {e}")
             self.sendLine(b"HTTP/1.1 403 Forbidden")
             self.sendLine(self.headers())
             self.sendLine(b"")
@@ -106,7 +106,7 @@ class mTLS(basic.LineReceiver):
             self.transport.write(json.dumps(response).encode())
             self.transport.loseConnection()
         except Exception as e:
-            log.error("Exception send_response: {}".format(e))
+            log.error(f"Exception send_response: {e}")
             self.sendLine(b"HTTP/1.1 400 Bad Request")
             self.sendLine(self.headers())
             self.sendLine(b"")

--- a/canarytokens/channel_input_smtp.py
+++ b/canarytokens/channel_input_smtp.py
@@ -170,7 +170,7 @@ class CanaryESMTP(smtp.ESMTP):
                 )
             )
         except Exception as e:
-            log.error(e)
+            log.error(f"Error in SMTP channel while validating To field: {e}")
 
         raise smtp.SMTPBadRcpt(user)
 

--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -258,15 +258,11 @@ class EmailOutputChannel(OutputChannel):
             if response.status_code not in [202, 200]:
                 sent_successfully = False
                 log.error(
-                    "status code: {status_code}. Body: {body}",
-                    status_code=response.status_code,
-                    body=response.body,
+                    f"status code: {response.status_code}. Body: {response.body}",
                 )
         except HTTPError as e:
             log.error(
-                "A sendgrid error occurred. Status code: {status_code} {data}",
-                status_code=e.status_code,
-                data=e.to_dict,
+                f"A sendgrid error occurred. Status code: {e.status_code} {e.to_dict}",
             )
         else:
             sent_successfully = True
@@ -332,7 +328,7 @@ class EmailOutputChannel(OutputChannel):
             # Raise an error if the returned status is 4xx or 5xx
             response.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            log.error("A mailgun error occurred: %s - %s" % (e.__class__, e))
+            log.error(f"A mailgun error occurred: {e.__class__} - {e}")
         else:
             sent_successfully = True
             message_id = response.json().get("id")

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1386,22 +1386,22 @@ class CustomImageTokenHit(TokenHit):
 class ClonedWebTokenHit(TokenHit):
     token_type: Literal[TokenTypes.CLONEDSITE] = TokenTypes.CLONEDSITE
     # TODO fix API spelling to 'referrer' (comes from JS document.referrer)
-    referer: Union[HttpUrl, PseudoUrl]
-    location: HttpUrl
+    referer: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
+    location: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
 
 
 class SlowRedirectTokenHit(TokenHit):
     token_type: Literal[TokenTypes.SLOW_REDIRECT] = TokenTypes.SLOW_REDIRECT
-    referer: Optional[Union[PseudoUrl, HttpUrl]]
-    location: Optional[HttpUrl]
+    referer: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
+    location: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
     useragent: str
     additional_info: AdditionalInfo = AdditionalInfo()
 
 
 class FastRedirectTokenHit(TokenHit):
     token_type: Literal[TokenTypes.FAST_REDIRECT] = TokenTypes.FAST_REDIRECT
-    referer: Union[PseudoUrl, HttpUrl, None]
-    location: Optional[HttpUrl]
+    referer: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
+    location: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
     useragent: str
     additional_info: AdditionalInfo = AdditionalInfo()
 

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1392,8 +1392,8 @@ class ClonedWebTokenHit(TokenHit):
 
 class SlowRedirectTokenHit(TokenHit):
     token_type: Literal[TokenTypes.SLOW_REDIRECT] = TokenTypes.SLOW_REDIRECT
-    referer: Union[PseudoUrl, HttpUrl]
-    location: HttpUrl
+    referer: Optional[Union[PseudoUrl, HttpUrl]]
+    location: Optional[HttpUrl]
     useragent: str
     additional_info: AdditionalInfo = AdditionalInfo()
 

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -69,8 +69,9 @@ def get_canarydrop(canarytoken: tokens.Canarytoken) -> Optional[cand.Canarydrop]
 
 def get_canarydrop_and_authenticate(*, token: str, auth: str) -> cand.Canarydrop:
     """Fetches a drop given a `token` and it's associated `auth`."""
-    canarydrop = get_canarydrop(tokens.Canarytoken(token))
-    if canarydrop is None:
+    try:
+        canarydrop = get_canarydrop(tokens.Canarytoken(token))
+    except NoCanarytokenPresent:
         raise CanarydropAuthFailure("Canarydrop associated with token is missing.")
     if not secrets.compare_digest(token, canarydrop.canarytoken.value()):
         raise CanarydropAuthFailure(

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -67,21 +67,18 @@ def get_canarydrop(canarytoken: tokens.Canarytoken) -> Optional[cand.Canarydrop]
     return cand.Canarydrop(**canarydrop)
 
 
-def get_canarydrop_from_auth(*, token: str, auth: str) -> cand.Canarydrop:
+def get_canarydrop_and_authenticate(*, token: str, auth: str) -> cand.Canarydrop:
     """Fetches a drop given a `token` and it's associated `auth`."""
-    canarytokens = DB.get_db().smembers(KEY_AUTH_IDX + auth)
-    if len(canarytokens) != 1:
-        raise CanarydropAuthFailure(
-            f"{len(canarytokens)} tokens are associated with this auth. Tokens {canarytokens}"
-        )
-    canarydrop = get_canarydrop(tokens.Canarytoken(canarytokens.pop()))
+    canarydrop = get_canarydrop(tokens.Canarytoken(token))
     if canarydrop is None:
-        raise CanarydropAuthFailure(
-            f"{len(canarytokens)} canarydrop associated with this auth is missing. Token(s) {canarytokens}"
-        )
+        raise CanarydropAuthFailure("Canarydrop associated with token is missing.")
     if not secrets.compare_digest(token, canarydrop.canarytoken.value()):
         raise CanarydropAuthFailure(
-            f"{len(canarytokens)} canarydrop associated with this auth has inconsistent token. Token(s) {canarytokens}"
+            "Canarydrop associated with this auth has inconsistent token."
+        )
+    if not secrets.compare_digest(auth, canarydrop.auth):
+        raise CanarydropAuthFailure(
+            "Canarydrop authentication failed, auth token does not match."
         )
     return canarydrop
 

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -534,7 +534,7 @@ class Canarytoken(object):
         return template.render(
             key=canarydrop.triggered_details.hits[-1].time_of_hit,
             canarytoken=canarydrop.canarytoken.value(),
-            redirect_url=str(canarydrop.redirect_url).encode("utf8"),
+            redirect_url=str(canarydrop.redirect_url),
         ).encode()
 
     @staticmethod

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -564,6 +564,7 @@ class Canarytoken(object):
     def _get_response_for_qr_code(
         canarydrop: canarydrop.Canarydrop, request: Request
     ) -> bytes:
+        request.setHeader("Content-Type", "image/gif")
         return GIF
 
     @staticmethod

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -370,10 +370,10 @@ async def generate(request: Request) -> AnyTokenResponse:  # noqa: C901  # gen i
         canarytoken = Canarytoken()
     canarydrop = Canarydrop(
         type=token_request_details.token_type,
-        alert_email_enabled=True,
+        alert_email_enabled=True if token_request_details.email else False,
         alert_email_recipient=token_request_details.email,
-        alert_webhook_enabled=True,
-        alert_webhook_url=token_request_details.webhook_url,
+        alert_webhook_enabled=True if token_request_details.webhook_url else False,
+        alert_webhook_url=token_request_details.webhook_url or "",
         canarytoken=canarytoken,
         memo=token_request_details.memo,
         browser_scanner_enabled=False,

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -410,7 +410,7 @@ async def generate(request: Request) -> AnyTokenResponse:  # noqa: C901  # gen i
     )
 
     # add generate random hostname an token
-    canarydrop.token_url = canarydrop.get_url(canary_domains=[canary_http_channel])
+    canarydrop.get_url(canary_domains=[canary_http_channel])
     canarydrop.generated_hostname = canarydrop.get_hostname()
 
     save_canarydrop(canarydrop)
@@ -449,7 +449,7 @@ async def manage_page_get(
         manage_template_params["wg_conf"] = wg_conf
         manage_template_params["wg_qr_code"] = qr_code
     elif canarydrop.type == TokenTypes.QR_CODE:
-        qr_code = segno.make(canarydrop.token_url).png_data_uri(scale=5)
+        qr_code = segno.make(canarydrop.generated_url).png_data_uri(scale=5)
         manage_template_params["qr_code"] = qr_code
 
     return templates.TemplateResponse("manage_new.html", manage_template_params)
@@ -571,7 +571,7 @@ def _(
         token=download_request_details.token,
         auth=download_request_details.auth,
         content=make_canary_msword(
-            canarydrop.token_url,
+            canarydrop.generated_url,
             template=Path(frontend_settings.TEMPLATES_PATH) / "template.docx",
         ),
         filename=f"{canarydrop.canarytoken.value()}.docx",
@@ -600,7 +600,7 @@ def _(
         token=download_request_details.token,
         auth=download_request_details.auth,
         content=make_canary_msexcel(
-            canarydrop.token_url,
+            canarydrop.generated_url,
             template=Path(frontend_settings.TEMPLATES_PATH) / "template.xlsx",
         ),
         filename=f"{canarydrop.canarytoken.value()}.xlsx",
@@ -762,7 +762,7 @@ def _(
     return DownloadQRCodeResponse(
         token=download_request_details.token,
         auth=download_request_details.auth,
-        content=segno.make(canarydrop.token_url).png_data_uri(scale=5),
+        content=segno.make(canarydrop.generated_url).png_data_uri(scale=5),
         filename=f"{canarydrop.canarytoken.value()}.png",
     )
 
@@ -783,7 +783,7 @@ def _(
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -801,7 +801,7 @@ def _(
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         token_usage=canarydrop.canarytoken.value(),
@@ -819,7 +819,7 @@ def _(
         email=canarydrop.alert_email_recipient or "",
         webhook_url=canarydrop.alert_webhook_url or "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         token_usage=canarydrop.canarytoken.value(),
@@ -837,7 +837,7 @@ def _(
         email=canarydrop.alert_email_recipient or "",
         webhook_url=canarydrop.alert_webhook_url or "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         token_usage=canarydrop.canarytoken.value(),
@@ -855,7 +855,7 @@ def _(
         email=canarydrop.alert_email_recipient or "",
         webhook_url=canarydrop.alert_webhook_url or "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         token_usage=canarydrop.canarytoken.value(),
@@ -872,7 +872,7 @@ def _(
         email=canarydrop.alert_email_recipient or "",
         webhook_url=canarydrop.alert_webhook_url or "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         token_usage=canarydrop.canarytoken.value(),
@@ -893,7 +893,7 @@ def _(
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -917,7 +917,7 @@ def _(
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -936,7 +936,7 @@ def _(token_request_details: SQLServerTokenRequest, canarydrop: Canarydrop):
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -973,7 +973,7 @@ def _create_aws_key_token_response(
     canarydrop.aws_secret_access_key = key["secret_access_key"]
     canarydrop.aws_region = key["region"]
     canarydrop.aws_output = key["output"]
-    canarydrop.token_url = f"{canary_http_channel}/{canarydrop.canarytoken.value()}"
+    canarydrop.generated_url = f"{canary_http_channel}/{canarydrop.canarytoken.value()}"
     save_canarydrop(canarydrop)
 
     return AWSKeyTokenResponse(
@@ -982,7 +982,7 @@ def _create_aws_key_token_response(
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -1031,13 +1031,13 @@ def _create_azure_id_token_response(
     canarydrop.cert = key["cert"]
     canarydrop.tenant_id = key["tenant_id"]
     canarydrop.cert_name = key["cert_name"]
-    canarydrop.token_url = f"{canary_http_channel}/{canarydrop.canarytoken.value()}"
+    canarydrop.generated_url = f"{canary_http_channel}/{canarydrop.canarytoken.value()}"
     save_canarydrop(canarydrop)
     return AzureIDTokenResponse(
         email=canarydrop.alert_email_recipient or "",
         webhook_url=canarydrop.alert_webhook_url or "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -1081,7 +1081,7 @@ def _(token_request_details: CCTokenRequest, canarydrop: Canarydrop) -> CCTokenR
         card_name=frontend_settings.EXTEND_CARD_NAME,
     )
     try:
-        cc = eapi.create_credit_card(token_url=canarydrop.token_url)
+        cc = eapi.create_credit_card(token_url=canarydrop.generated_url)
     except extendtoken.ExtendAPIRateLimitException:
         return response_error(
             4, "Credit Card Rate-Limiting currently in place. Please try again later."
@@ -1185,7 +1185,7 @@ def _(
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.get_hostname(nxdomain=True),
         url_components=list(canarydrop.get_url_components()),
@@ -1272,7 +1272,7 @@ def _(
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -1288,7 +1288,7 @@ def _(token_request_details: SvnTokenRequest, canarydrop: Canarydrop):
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -1304,7 +1304,7 @@ def _(token_request_details: MsWordDocumentTokenRequest, canarydrop: Canarydrop)
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -1320,7 +1320,7 @@ def _(token_request_details: MsExcelDocumentTokenRequest, canarydrop: Canarydrop
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
@@ -1335,12 +1335,12 @@ def _(token_request_details: QRCodeTokenRequest, canarydrop: Canarydrop):
         if canarydrop.alert_webhook_url
         else "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),
         # additional information for QRCode token response
-        qrcode_png=segno.make(canarydrop.token_url).png_data_uri(scale=5),
+        qrcode_png=segno.make(canarydrop.generated_url).png_data_uri(scale=5),
     )
 
 
@@ -1350,7 +1350,7 @@ def _(token_request_details: SMTPTokenRequest, canarydrop: Canarydrop):
         email=canarydrop.alert_email_recipient or "",
         webhook_url=canarydrop.alert_webhook_url or "",
         token=canarydrop.canarytoken.value(),
-        token_url=canarydrop.token_url,
+        token_url=canarydrop.generated_url,
         auth_token=canarydrop.auth,
         hostname=canarydrop.generated_hostname,
         url_components=list(canarydrop.get_url_components()),

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ switchboard:
 
 .PHONY: frontend
 frontend:
-	cd frontend; poetry run uvicorn app:app --reload --log-config log.ini
+	cd frontend; poetry run uvicorn app:app --reload --log-config log.ini --port 8082
 
 .PHONY: testv3
 testv3:

--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -1190,7 +1190,7 @@ START REPLICA;
         $('.btn-clipboard').removeClass('tooltip');
 
         var _handleWebResponse = function(data) {
-          $('#result_web').val(data['token_url']);
+          $('#result_web').val(data['generated_url']);
           $('#result_web').siblings('.refresh').on('click', function() {
             url = [data['url_components'][0].random(),
                    data['url_components'][1].random(),
@@ -1201,7 +1201,7 @@ START REPLICA;
         };
 
         var _handleFastRedirectResponse = function(data) {
-          $('#result_fast_redirect').val(data['token_url']);
+          $('#result_fast_redirect').val(data['generated_url']);
           $('#result_fast_redirect').siblings('.refresh').on('click', function() {
             url = [data['url_components'][0].random(),
                    data['url_components'][1].random(),
@@ -1212,7 +1212,7 @@ START REPLICA;
         };
 
         var _handleSlowRedirectResponse = function(data) {
-          $('#result_slow_redirect').val(data['token_url']);
+          $('#result_slow_redirect').val(data['generated_url']);
           $('#result_slow_redirect').siblings('.refresh').on('click', function() {
             url = [data['url_components'][0].random(),
                    data['url_components'][1].random(),

--- a/templates/manage_new.html
+++ b/templates/manage_new.html
@@ -552,13 +552,13 @@ START REPLICA;
       $('.btn-clipboard').removeClass('tooltip');
 
       var _handleWebResponse = function(data) {
-        $('#result_web').val(data['token_url']);
+        $('#result_web').val(data['generated_url']);
       };
       var _handleFastRedirectResponse = function(data) {
-        $('#result_fast_redirect').val(data['token_url']);
+        $('#result_fast_redirect').val(data['generated_url']);
       };
       var _handleSlowRedirectResponse = function(data) {
-        $('#result_slow_redirect').val(data['token_url']);
+        $('#result_slow_redirect').val(data['generated_url']);
       };
       var _handleDNSResponse = function(data) {
         $('#result_dns').val(data['generated_hostname']);

--- a/tests/units/test_channel_output_email.py
+++ b/tests/units/test_channel_output_email.py
@@ -2,7 +2,6 @@ import datetime
 from pathlib import Path
 
 from pydantic import EmailStr
-import pytest
 from twisted.logger import capturedLogs
 
 from canarytokens import queries
@@ -84,7 +83,6 @@ def test_log4shell_rendered_html(settings: SwitchboardSettings):
     assert "SRV01" in email_template
 
 
-@pytest.mark.skip()
 def test_sendgrid_send(
     settings: SwitchboardSettings, frontend_settings: FrontendSettings
 ):

--- a/tests/units/test_channel_output_email.py
+++ b/tests/units/test_channel_output_email.py
@@ -2,6 +2,7 @@ import datetime
 from pathlib import Path
 
 from pydantic import EmailStr
+import pytest
 from twisted.logger import capturedLogs
 
 from canarytokens import queries
@@ -83,6 +84,7 @@ def test_log4shell_rendered_html(settings: SwitchboardSettings):
     assert "SRV01" in email_template
 
 
+@pytest.mark.skip()
 def test_sendgrid_send(
     settings: SwitchboardSettings, frontend_settings: FrontendSettings
 ):

--- a/tests/units/test_frontend.py
+++ b/tests/units/test_frontend.py
@@ -536,7 +536,7 @@ def test_history_page(
     ],
 )
 def test_authorised_page_access(
-    param_type: PageRequest, endpoint: str, verb: str, test_client: TestClient
+    param_type: PageRequest, endpoint: str, verb: str, test_client: TestClient, setup_db
 ) -> None:
     """
     For all `endpoints` that are behind auth test

--- a/tests/units/test_frontend.py
+++ b/tests/units/test_frontend.py
@@ -306,7 +306,7 @@ def test_email_enable_token_settings_requests(
     assert setting_resp.status_code == 200
     assert "success" in setting_resp.content.decode()
 
-    canarydrop = queries.get_canarydrop_from_auth(
+    canarydrop = queries.get_canarydrop_and_authenticate(
         token=token_resp.token, auth=token_resp.auth_token
     )
     assert not canarydrop.alert_email_enabled
@@ -322,7 +322,7 @@ def test_email_enable_token_settings_requests(
     assert setting_resp.status_code == 200
     assert "success" in setting_resp.content.decode()
 
-    canarydrop = queries.get_canarydrop_from_auth(
+    canarydrop = queries.get_canarydrop_and_authenticate(
         token=token_resp.token, auth=token_resp.auth_token
     )
     assert canarydrop.alert_email_enabled
@@ -354,7 +354,7 @@ def test_webhook_enable_token_settings_requests(
     assert setting_resp.status_code == 200
     assert "success" in setting_resp.content.decode()
 
-    canarydrop = queries.get_canarydrop_from_auth(
+    canarydrop = queries.get_canarydrop_and_authenticate(
         token=token_resp.token, auth=token_resp.auth_token
     )
     assert not canarydrop.alert_webhook_enabled
@@ -369,7 +369,7 @@ def test_webhook_enable_token_settings_requests(
     assert setting_resp.status_code == 200
     assert "success" in setting_resp.content.decode()
 
-    canarydrop = queries.get_canarydrop_from_auth(
+    canarydrop = queries.get_canarydrop_and_authenticate(
         token=token_resp.token, auth=token_resp.auth_token
     )
     assert canarydrop.alert_webhook_enabled
@@ -402,7 +402,7 @@ def test_browser_scanner_enable_token_settings_requests(
     assert setting_resp.status_code == 200
     assert "success" in setting_resp.content.decode()
 
-    canarydrop = queries.get_canarydrop_from_auth(
+    canarydrop = queries.get_canarydrop_and_authenticate(
         token=token_resp.token, auth=token_resp.auth_token
     )
     assert not canarydrop.browser_scanner_enabled
@@ -417,7 +417,7 @@ def test_browser_scanner_enable_token_settings_requests(
     assert setting_resp.status_code == 200
     assert "success" in setting_resp.content.decode()
 
-    canarydrop = queries.get_canarydrop_from_auth(
+    canarydrop = queries.get_canarydrop_and_authenticate(
         token=token_resp.token, auth=token_resp.auth_token
     )
     assert canarydrop.browser_scanner_enabled
@@ -448,7 +448,7 @@ def test_web_image_enable_token_settings_requests(
     )
     assert setting_resp.status_code == 200
     assert "success" in setting_resp.content.decode()
-    canarydrop = queries.get_canarydrop_from_auth(
+    canarydrop = queries.get_canarydrop_and_authenticate(
         token=token_resp.token, auth=token_resp.auth_token
     )
     assert not canarydrop.web_image_enabled
@@ -462,7 +462,7 @@ def test_web_image_enable_token_settings_requests(
     )
     assert setting_resp.status_code == 200
     assert "success" in setting_resp.content.decode()
-    canarydrop = queries.get_canarydrop_from_auth(
+    canarydrop = queries.get_canarydrop_and_authenticate(
         token=token_resp.token, auth=token_resp.auth_token
     )
     assert canarydrop.web_image_enabled
@@ -508,20 +508,12 @@ def test_history_page(
     )
     token_info = token_response_type(**resp.json())
 
-    cd = canarydrop.Canarydrop(
-        type=token_info.token_type,
-        canarytoken=Canarytoken(value=token_info.token),
-        alert_email_enabled=False,
-        alert_email_recipient="email@test.com",
-        alert_webhook_enabled=False,
-        alert_webhook_url=None,
-        memo="memo",
-        browser_scanner_enabled=False,
-        redirect_url="https://youtube.com",
-    )
-    save_canarydrop(cd)
+    token = Canarytoken(token_info.token)
+    cd = queries.get_canarydrop(token)
+
     hit = get_basic_hit(cd.type)
     cd.add_canarydrop_hit(token_hit=hit)
+
     resp = test_client.get(
         "/history",
         params=HistoryPageRequest(

--- a/tests/units/test_frontend.py
+++ b/tests/units/test_frontend.py
@@ -628,7 +628,7 @@ def test_aws_keys_broken(
 
         # add generate random hostname an token
         canary_http_channel = f"http://{local_settings.DOMAINS[0]}"
-        cd.token_url = cd.get_url([canary_http_channel])
+        cd.get_url([canary_http_channel])
         cd.generated_hostname = cd.get_hostname()
         save_canarydrop(cd)
 
@@ -684,7 +684,7 @@ def test_aws_keys(
 
         # add generate random hostname an token
         canary_http_channel = f"http://{local_settings.DOMAINS[0]}"
-        cd.token_url = cd.get_url([canary_http_channel])
+        cd.get_url([canary_http_channel])
         cd.generated_hostname = cd.get_hostname()
         save_canarydrop(cd)
 

--- a/tests/units/test_pdfgen.py
+++ b/tests/units/test_pdfgen.py
@@ -5,8 +5,8 @@ from canarytokens.pdfgen import make_canary_pdf
 from canarytokens.settings import FrontendSettings
 
 
-@pytest.mark.skip()
-@pytest.mark.parametrize("_", range(1000))
+# change to >=1000 for statistical testing
+@pytest.mark.parametrize("_", range(1))
 def test_make_canary_pdf(frontend_settings: FrontendSettings, _: int):
     try:
         _ = make_canary_pdf(

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -19,7 +19,7 @@ from canarytokens.queries import (
     add_webhook_token_idx,
     delete_webhook_tokens,
     get_canarydrop,
-    get_canarydrop_from_auth,
+    get_canarydrop_and_authenticate,
     save_canarydrop,
 )
 from canarytokens.tokens import Canarytoken
@@ -194,13 +194,13 @@ def test_get_canarydrop_from_auth(setup_db):
         browser_scanner_enabled=False,
     )
     save_canarydrop(canarydrop)
-    new_drop = get_canarydrop_from_auth(
+    new_drop = get_canarydrop_and_authenticate(
         token=canarydrop.canarytoken.value(), auth=canarydrop.auth
     )
     assert new_drop.canarytoken.value() == canarydrop.canarytoken.value()
 
     with pytest.raises(CanarydropAuthFailure):
-        get_canarydrop_from_auth(
+        get_canarydrop_and_authenticate(
             token=canarydrop.canarytoken.value(), auth="wrongauthtoken"
         )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -77,7 +77,7 @@ if strtobool(os.getenv("LIVE", "False")):
     )
 else:
     v3 = V3(
-        canarytokens_sld="127.0.0.1:8000",
+        canarytokens_sld="127.0.0.1:8082",
         canarytokens_domain="127.0.0.1",
         canarytokens_dns_port=5354,
         canarytokens_http_port=8083,


### PR DESCRIPTION
Changes:
- Make all our `log.error` calls use format strings
- Change slow redirect token hit model to let location & referrer be optional
- Align some canarydrop defaults to v2
- Fix canarydrop fetch with auth for backwards compatibility
- Fix QR code token response mime type
- Make devcontainer use port 8082 for frontend