### PR TITLE
T5017: Fix incident sorting

### DIFF
--- a/httpd_site.py
+++ b/httpd_site.py
@@ -729,9 +729,8 @@ class HistoryPage(resource.Resource):
                 raise NoCanarytokenPresent()
             if canarydrop.get('triggered_list', None):
                 for timestamp in canarydrop['triggered_list'].keys():
-                    formatted_timestamp = datetime.datetime.fromtimestamp(
+                    canarydrop['triggered_list'][timestamp]['timestamp'] = datetime.datetime.fromtimestamp(
                                 float(timestamp)).strftime('%Y %b %d %H:%M:%S.%f (UTC)')
-                    canarydrop['triggered_list'][formatted_timestamp] = canarydrop['triggered_list'].pop(timestamp)
 
             if canarydrop.get('memo'):
                 canarydrop['memo'] = unicode(canarydrop['memo'], "utf8")

--- a/templates/history.html
+++ b/templates/history.html
@@ -107,7 +107,7 @@
 {% for item in canarydrop['triggered_list']|sort(reverse=True) %}
           <div class="incident-item expand" id="item-{{item}}">
                 <p class="details-header">
-                <b>Date:</b> {{ item|e }}
+                <b>Date:</b> {{ canarydrop['triggered_list'][item]['timestamp'] }}
                 <b>IP:</b> {{ canarydrop['triggered_list'][item]['src_ip'] }}
   {% if canarydrop['type'] == 'aws_keys' %}
                                   <b>Channel:</b> AWS API Key Token


### PR DESCRIPTION
This PR fixes an issue where incident history was out of order due to a sorting bug. We now sort on raw hit epoch time and attach the formatted date to that.

Example of bug:
<img width="762" alt="image (6) (1)" src="https://github.com/thinkst/canarytokens/assets/5555832/06ca77ca-9536-44de-b5a0-5309ca73ae63">


# Testing:
Tested in a local `canarytokens-docker` instance with manually generated trigger history to show many month names:
![Screenshot 2023-06-16 at 00 20 40](https://github.com/thinkst/canarytokens/assets/5555832/eb85d192-460a-4962-81ac-8271554026f1)


