### PR TITLE
T4627 Migrate tokens v3 to docker compose v2

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -91,9 +91,9 @@ jobs:
           sed "s/thinkst\/canarytokens:dev_v3/thinkst\/canarytokens:${GITHUB_REF##*/}/g" docker-compose-v3-letsencrypt.yml.tpl > docker-compose-v3-letsencrypt.yml
           sed -i'' "s/CANARY_DEV_BUILD_ID=.*/CANARY_DEV_BUILD_ID=${GITHUB_SHA:0:8}/" frontend.env
           sudo docker pull thinkst/canarytokens:${GITHUB_REF##*/}
-          sudo docker-compose -f docker-compose-v3-letsencrypt.yml pull
-          sudo docker-compose -f docker-compose-v3-letsencrypt.yml down
-          sudo docker-compose -f docker-compose-v3-letsencrypt.yml up -d
+          sudo docker compose -f docker-compose-v3-letsencrypt.yml pull
+          sudo docker compose -f docker-compose-v3-letsencrypt.yml down
+          sudo docker compose -f docker-compose-v3-letsencrypt.yml up -d
           sudo docker system prune -f -a
 
   staging-deploy:
@@ -110,7 +110,7 @@ jobs:
           sed "s/thinkst\/canarytokens:dev/thinkst\/canarytokens:${GITHUB_REF##*/}/g" docker-compose-v3-letsencrypt.yml.tpl > docker-compose-v3-letsencrypt.yml
           sed -i'' "s/CANARY_DEV_BUILD_ID=.*/CANARY_DEV_BUILD_ID=${GITHUB_SHA:0:8}/" frontend.env
           sudo docker pull thinkst/canarytokens:${GITHUB_REF##*/}
-          sudo docker-compose -f docker-compose-v3-letsencrypt.yml pull
-          sudo docker-compose -f docker-compose-v3-letsencrypt.yml down
-          sudo docker-compose -f docker-compose-v3-letsencrypt.yml up -d
+          sudo docker compose -f docker-compose-v3-letsencrypt.yml pull
+          sudo docker compose -f docker-compose-v3-letsencrypt.yml down
+          sudo docker compose -f docker-compose-v3-letsencrypt.yml up -d
           sudo docker system prune -f -a


### PR DESCRIPTION
This PR migrates our token v3 deploy workflows to docker compose v2 in preparation for landing tokens v3. The migration has already been tested