### PR TITLE
T4627: Fix zip hit model and error log format str

### DIFF
--- a/canarytokens/channel_http.py
+++ b/canarytokens/channel_http.py
@@ -110,10 +110,7 @@ class CanarytokenPage(InputChannel, resource.Resource):
             )
         except ValidationError as e:
             log.critical(
-                "Failed to parse HTTP token hit. Token: {token} Hit Info: {hit_info} Error: {e}",
-                token=canarydrop.canarytoken.value(),
-                hit_info=hit_info,
-                e=e,
+                f"Failed to parse HTTP token hit. Token: {canarydrop.canarytoken.value()} Hit Info: {hit_info} Error: {e}",
                 log_failure=Failure(e),
             )
             return

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -461,7 +461,7 @@ class DNSTokenRequest(TokenRequest):
                 "token_type": TokenTypes.DNS,
                 "memo": "Reminder note when this token is triggered",
                 "email": "username@domain.com",
-                "webhook_url": "https://hooks.slack.com/test",
+                "webhook_url": "https://slack.com/api/api.test",
             },
         }
 
@@ -595,7 +595,7 @@ class Log4ShellTokenRequest(TokenRequest):
                 "token_type": TokenTypes.LOG4SHELL,
                 "memo": "Reminder note when this token is triggered",
                 "email": "username@domain.com",
-                "webhook_url": "https://hooks.slack.com/test",
+                "webhook_url": "https://slack.com/api/api.test",
             },
         }
 
@@ -749,7 +749,7 @@ class DNSTokenResponse(TokenResponse):
                 "token_type": TokenTypes.DNS,
                 "memo": "Reminder note when this token is triggered",
                 "email": "username@domain.com",
-                "webhook_url": "https://hooks.slack.com/test",
+                "webhook_url": "https://slack.com/api/api.test",
             },
         }
 
@@ -835,7 +835,7 @@ class FastRedirectTokenResponse(TokenResponse):
                 "token_type": TokenTypes.DNS,
                 "memo": "Reminder note when this token is triggered",
                 "email": "username@domain.com",
-                "webhook_url": "https://hooks.slack.com/test",
+                "webhook_url": "https://slack.com/api/api.test",
             },
         }
 
@@ -874,7 +874,7 @@ class Log4ShellTokenResponse(TokenResponse):
                 "token_type": TokenTypes.LOG4SHELL,
                 "memo": "Added to user login portal.",
                 "email": "username@domain.com",
-                "webhook_url": "https://hooks.slack.com/test",
+                "webhook_url": "https://slack.com/api/api.test",
             },
         }
 

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1351,7 +1351,7 @@ class MsWordDocumentTokenHit(TokenHit):
 
 class WindowsDirectoryTokenHit(TokenHit):
     token_type: Literal[TokenTypes.WINDOWS_DIR] = TokenTypes.WINDOWS_DIR
-    src_data: Optional[dict[str, str]]
+    src_data: Optional[dict]
 
 
 class MsExcelDocumentTokenHit(TokenHit):
@@ -1370,8 +1370,8 @@ class SQLServerTokenHit(TokenHit):
 class WebBugTokenHit(TokenHit):
     token_type: Literal[TokenTypes.WEB] = TokenTypes.WEB
     useragent: str
-    request_headers: Optional[dict[str, str]]
-    request_args: Optional[dict[str, str]]
+    request_headers: Optional[dict]
+    request_args: Optional[dict]
     additional_info: AdditionalInfo = AdditionalInfo()
 
     class Config:

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1409,7 +1409,7 @@ class FastRedirectTokenHit(TokenHit):
 
 class Log4ShellTokenHit(TokenHit):
     token_type: Literal[TokenTypes.LOG4SHELL] = TokenTypes.LOG4SHELL
-    src_data: dict[str, str]
+    src_data: dict
 
 
 class QRCodeTokenHit(TokenHit):

--- a/tests/integration/test_against_token_server.py
+++ b/tests/integration/test_against_token_server.py
@@ -462,7 +462,7 @@ def test_fast_redirect_token(target: str, version, runv2, runv3) -> None:
     run_or_skip(version, runv2=runv2, runv3=runv3)
     # Create a fast redirect token request
     token_request = FastRedirectTokenRequest(
-        webhook_url=HttpUrl(url="https://hooks.slack.com/test", scheme="https"),
+        webhook_url=HttpUrl(url="https://slack.com/api/api.test", scheme="https"),
         memo=Memo("Test stuff break stuff test stuff sometimes build stuff"),
         redirect_url=target,
     )

--- a/tests/units/test_frontend.py
+++ b/tests/units/test_frontend.py
@@ -84,7 +84,7 @@ def test_generate_dns_token(test_client: TestClient) -> None:
     dns_request_token = models.DNSTokenRequest(
         token_type=TokenTypes.DNS,
         email="test@test.com",
-        webhook_url="https://hooks.slack.com/test",
+        webhook_url="https://slack.com/api/api.test",
         memo="test stuff break stuff fix stuff test stuff",
     )
     resp = test_client.post("/generate", json=json.loads(dns_request_token.json()))
@@ -94,7 +94,7 @@ def test_generate_dns_token(test_client: TestClient) -> None:
 def test_generate_log4shell_token(test_client: TestClient) -> None:
     log4shell_request_token = models.Log4ShellTokenRequest(
         email="test@test.com",
-        webhook_url="https://hooks.slack.com/test",
+        webhook_url="https://slack.com/api/api.test",
         memo="test stuff break stuff fix stuff test stuff",
     )
     resp = test_client.post(
@@ -550,7 +550,7 @@ def test_authorised_page_access(
         "/generate",
         data=DNSTokenRequest(
             email="test@test.com",
-            webhook_url="https://hooks.slack.com/test",
+            webhook_url="https://slack.com/api/api.test",
             memo="test stuff break stuff fix stuff test stuff",
             redirect_url="https://youtube.com",
             clonedsite="https://test.com",
@@ -716,7 +716,7 @@ def test_block_user(
     # try to make with test_target, make sure it fails
     token_request = WebBugTokenRequest(
         email=test_target,
-        webhook_url="https://hooks.slack.com/test",
+        webhook_url="https://slack.com/api/api.test",
         memo="test stuff break stuff fix stuff test stuff",
         redirect_url="https://youtube.com",
         clonedsite="https://test.com",

--- a/tests/units/test_models.py
+++ b/tests/units/test_models.py
@@ -63,7 +63,7 @@ def test_token_request(token_type, _type):
     data = {
         "token_type": token_type,
         "email": None,
-        "webhook_url": "https://hooks.slack.com/test",
+        "webhook_url": "https://slack.com/api/api.test",
         "memo": "We are v3",
     }
     _ = _type(**data)
@@ -251,7 +251,7 @@ def test_additional_info():
 def test_fast_redirect_request():
     data = {
         "token_type": "fast_redirect",
-        "webhook_url": "https://hooks.slack.com/test",
+        "webhook_url": "https://slack.com/api/api.test",
         "memo": "Test stuff break stuff test stuff sometimes build stuff",
         "redirect_url": "https://www.youtube.com",
     }
@@ -264,7 +264,7 @@ def test_fast_redirect_request():
 def test_dns_request():
     data = {
         "token_type": "dns",
-        "webhook_url": "https://hooks.slack.com/test",
+        "webhook_url": "https://slack.com/api/api.test",
         "memo": "Test stuff break stuff test stuff sometimes build stuff",
     }
     from pydantic import parse_obj_as

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -28,7 +28,7 @@ from tests.utils import make_token_alert_detail
 
 def test_add_delete_webhook(setup_db):
     token_value = Canarytoken.generate()
-    webhook_url = "https://hooks.slack.com/test"
+    webhook_url = "https://slack.com/api/api.test"
     ret = add_webhook_token_idx(webhook_url, canarytoken=token_value)
     assert ret == 1
     delete_webhook_tokens(webhook=webhook_url)
@@ -43,7 +43,7 @@ def test_add_hit_get_canarytoken(setup_db):
         alert_email_enabled=True,
         alert_email_recipient="test@test.com",
         alert_webhook_enabled=True,
-        alert_webhook_url="https://hooks.slack.com/test",
+        alert_webhook_url="https://slack.com/api/api.test",
         canarytoken=canarytoken,
         memo="stuff happened",
         browser_scanner_enabled=False,
@@ -72,7 +72,7 @@ def test_add_hit_get_canarytoken_wrong_type(setup_db):
         alert_email_enabled=True,
         alert_email_recipient="test@test.com",
         alert_webhook_enabled=True,
-        alert_webhook_url="https://hooks.slack.com/test",
+        alert_webhook_url="https://slack.com/api/api.test",
         canarytoken=canarytoken,
         memo="stuff happened",
         browser_scanner_enabled=False,
@@ -111,7 +111,7 @@ def test_remove_tokens_with_email_x(setup_db):
         alert_email_enabled=True,
         alert_email_recipient=email,
         alert_webhook_enabled=True,
-        alert_webhook_url="https://hooks.slack.com/test",
+        alert_webhook_url="https://slack.com/api/api.test",
         canarytoken=canarytoken,
         memo="stuff happened",
         browser_scanner_enabled=False,
@@ -144,7 +144,7 @@ def test_remove_tokens_with_webhook_x():
     a particular webhook. This tests the creation and purging of a token
     by webhook idx.
     """
-    webhook = "https://hooks.slack.com/test"
+    webhook = "https://slack.com/api/api.test"
 
     canarytoken = Canarytoken()
     canarydrop = Canarydrop(
@@ -179,7 +179,7 @@ def test_remove_tokens_with_webhook_x():
 
 
 def test_get_canarydrop_from_auth(setup_db):
-    webhook = "https://hooks.slack.com/test"
+    webhook = "https://slack.com/api/api.test"
 
     canarytoken = Canarytoken()
     canarydrop = Canarydrop(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -508,7 +508,7 @@ def make_token_alert_detail(
 def get_token_request(token_request_type: AnyTokenRequest) -> AnyTokenRequest:
     return token_request_type(
         email="test@test.com",
-        webhook_url="https://hooks.slack.com/test",
+        webhook_url="https://slack.com/api/api.test",
         memo="test stuff break stuff fix stuff test stuff",
         redirect_url="https://youtube.com",
         clonedsite="https://test.com",


### PR DESCRIPTION
When we receive Windows Directory token fires the token history is loaded, and sometimes the value in a `dict` is `None`. This PR makes our model validation less strict for that case.

Additionally, there was an error log that was not formatting correctly, so that has been fixed too.