### PR TITLE
T4627: Allow referer to be bytes

### DIFF
--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1387,22 +1387,22 @@ class CustomImageTokenHit(TokenHit):
 class ClonedWebTokenHit(TokenHit):
     token_type: Literal[TokenTypes.CLONEDSITE] = TokenTypes.CLONEDSITE
     # TODO fix API spelling to 'referrer' (comes from JS document.referrer)
-    referer: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
-    location: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
+    referer: Optional[Union[PseudoUrl, HttpUrl, Literal[""], Literal[b""]]]
+    location: Optional[Union[PseudoUrl, HttpUrl, Literal[""], Literal[b""]]]
 
 
 class SlowRedirectTokenHit(TokenHit):
     token_type: Literal[TokenTypes.SLOW_REDIRECT] = TokenTypes.SLOW_REDIRECT
-    referer: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
-    location: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
+    referer: Optional[Union[PseudoUrl, HttpUrl, Literal[""], Literal[b""]]]
+    location: Optional[Union[PseudoUrl, HttpUrl, Literal[""], Literal[b""]]]
     useragent: str
     additional_info: AdditionalInfo = AdditionalInfo()
 
 
 class FastRedirectTokenHit(TokenHit):
     token_type: Literal[TokenTypes.FAST_REDIRECT] = TokenTypes.FAST_REDIRECT
-    referer: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
-    location: Optional[Union[PseudoUrl, HttpUrl, Literal[""]]]
+    referer: Optional[Union[PseudoUrl, HttpUrl, Literal[""], Literal[b""]]]
+    location: Optional[Union[PseudoUrl, HttpUrl, Literal[""], Literal[b""]]]
     useragent: str
     additional_info: AdditionalInfo = AdditionalInfo()
 


### PR DESCRIPTION
Allow blank bytes in Cloned Web token hit location/referer values and similar.