### PR TITLE
Fix deprecated policy key from AWS ID terraform

### DIFF
--- a/aws-token-infra/awsid.tf
+++ b/aws-token-infra/awsid.tf
@@ -195,14 +195,15 @@ output "base_url" {
 }
 
 
-# 
+#
 # Log storage
 #
-
 resource "aws_s3_bucket" "canarytoken_logs" {
   bucket        = "awskeytokentrailbucketall-${data.aws_caller_identity.current.account_id}"
   force_destroy = true
-
+}
+resource "aws_s3_bucket_policy" "canarytokens_logs_policy" {
+  bucket = aws_s3_bucket.canarytoken_logs.id
   policy = <<POLICY
 {
     "Version": "2012-10-17",


### PR DESCRIPTION
## Proposed changes

Fix terraform template by removing deprecated `policy` key and adding new `aws_s3_policy` resource. This fixes #131.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] Linked to the relevant github issue or github discussion
