### PR TITLE
Reduce ipinfo timeout to (2,2)

### DIFF
--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -376,7 +376,7 @@ def get_geoinfo_from_ip(ip: str) -> Dict[str, str]:
         resp = requests.get(
             "http://ipinfo.io/" + ip + "/json",
             auth=(_ip_info_api_key, "") if _ip_info_api_key else None,
-            timeout=(3, 3),
+            timeout=(2, 2),
         )
         resp.raise_for_status()
         info = resp.json()


### PR DESCRIPTION
## Proposed changes

Long waits for IPInfo are causing outages; this PR attempts to pre-emptively reduce the risk of similar outages on tokens v3.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)