### PR TITLE
T6376: Consolidate IPInfo calls

### DIFF
--- a/canarytokens/channel_http.py
+++ b/canarytokens/channel_http.py
@@ -101,7 +101,7 @@ class CanarytokenPage(InputChannel, resource.Resource):
         http_general_info, src_data = handler(request)
 
         # TODO we should fail gracefully when third party dependency fails
-        geo_info = queries.get_geoinfo_from_ip(ip=http_general_info["src_ip"])
+        geo_info = queries.get_geoinfo(ip=http_general_info["src_ip"])
 
         hit_info = {
             "token_type": canarydrop.type,

--- a/canarytokens/channel_input_smtp.py
+++ b/canarytokens/channel_input_smtp.py
@@ -92,7 +92,7 @@ class CanaryMessage:
             time_of_hit=datetime.utcnow().strftime("%s.%f"),
             input_channel="SMTP",
             src_ip=self.esmtp.src_ip,
-            geo_info=queries.get_geoinfo_from_ip(ip=self.esmtp.src_ip),
+            geo_info=queries.get_geoinfo(ip=self.esmtp.src_ip),
             is_tor_relay=queries.is_tor_relay(ip=self.esmtp.src_ip),
             mail=SMTPMailField(
                 recipients=[o.decode() for o in self.esmtp.mail["recipients"]],

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -375,6 +375,10 @@ def get_geoinfo(ip: str):
 
 
 def get_geoinfo_from_ip(ip: str) -> Dict[str, str]:
+    """
+    Performs IP info lookup if cache check failed.
+    Don't use directly, use get_geoinfo() instead.
+    """
     try:
         # This should be async
         resp = requests.get(

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -329,7 +329,7 @@ class Canarytoken(object):
             src_ip = data["ip"][0]
             # DESIGN/TODO: this makes a call to third party ensure we happy with fails here
             #              and have default.
-            geo_info = queries.get_geoinfo_from_ip(ip=src_ip)
+            geo_info = queries.get_geoinfo(ip=src_ip)
             is_tor_relay = queries.is_tor_relay(src_ip)
             user_agent = data["user_agent"][0]
             hit_info = {
@@ -417,7 +417,7 @@ class Canarytoken(object):
         data = {k.decode(): [o.decode() for o in v] for k, v in request.args.items()}
         hit_time = datetime.utcnow().strftime("%s.%f")
         src_ip = data["ip"][0]
-        geo_info = queries.get_geoinfo_from_ip(ip=src_ip)
+        geo_info = queries.get_geoinfo(ip=src_ip)
         is_tor_relay = queries.is_tor_relay(src_ip)
         user_agent = data["user_agent"][0]
         hit_info = {
@@ -732,7 +732,7 @@ class Canarytoken(object):
         is_tor_relay = None
         if src_ip and ("safety_net" not in hit_info or not hit_info["safety_net"]):
             hit_info["src_ip"] = src_ip
-            geo_info = queries.get_geoinfo_from_ip(ip=src_ip)
+            geo_info = queries.get_geoinfo(ip=src_ip)
             is_tor_relay = queries.is_tor_relay(src_ip)
         hit_info["geo_info"] = geo_info
         hit_info["is_tor_relay"] = is_tor_relay


### PR DESCRIPTION
## Proposed changes

We're not using the geo ip cache properly. This PR makes sure we call the right function everywhere so that we check the cache first before querying IPInfo. This should reduce failures to extract location data when that service does not respond quickly. This will also simplify the future change to doing this async.

## Types of changes
What types of changes does your code introduce to this repository?
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)