### PR TITLE
T6374: Fix generic data handling

### DIFF
--- a/canarytokens/channel_output_webhook.py
+++ b/canarytokens/channel_output_webhook.py
@@ -51,7 +51,7 @@ class WebhookOutputChannel(OutputChannel):
         # Design: wrap in a retry?
         try:
             response = requests.post(
-                url=str(alert_webhook_url), json=payload, timeout=(3, 10)
+                url=str(alert_webhook_url), json=payload, timeout=(2, 2)
             )
             response.raise_for_status()
         except requests.exceptions.HTTPError:

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -39,14 +39,6 @@ sql_server_username = re.compile(
 mysql_username = re.compile(r"([A-Za-z0-9.-]*)\.M[0-9]{3}\.", re.IGNORECASE)
 linux_inotify = re.compile(r"([A-Za-z0-9.-]*)\.L[0-9]{2}\.", re.IGNORECASE)
 generic = re.compile(r"([A-Z2-7.-]*)\.G[0-9]{2}\.", re.IGNORECASE)
-dtrace_process = re.compile(
-    r"([0-9]+)\.([A-Za-z0-9-=]+)\.h\.([A-Za-z0-9.-=]+)\.c\.([A-Za-z0-9.-=]+)\.D1\.",
-    re.IGNORECASE,
-)
-dtrace_file_open = re.compile(
-    r"([0-9]+)\.([A-Za-z0-9-=]+)\.h\.([A-Za-z0-9.-=]+)\.f\.([A-Za-z0-9.-=]+)\.D2\.",
-    re.IGNORECASE,
-)
 desktop_ini_browsing_pattern = re.compile(
     r"([^\.]+)\.([^\.]+)\.?([^\.]*)\.ini\.",
     re.IGNORECASE,

--- a/tests/units/test_tokens.py
+++ b/tests/units/test_tokens.py
@@ -198,12 +198,16 @@ def test_create_token_hit(setup_db, token_type, hit_info):
 @pytest.mark.parametrize(
     "in_url, expected_out",
     [
+        # regular payload of Hello2!
         ("JBSWY3DPGIQQ.G01.yh6wfyh752qi06e35f9b0260f.127.0.0.1", "Hello2!"),
+        # mixed case
         ("JbSwy3DPgiQq.g01.yh6wfyh752qi06e35f9b0260f.127.0.0.1", "Hello2!"),
+        # fails to decode utf-8; gets hexlified
         (
             "GE2QGIWC2NZYFRBEYVKFIJHU4Q.G01.yh6wfyh752qi06e35f9b0260f.127.0.0.1",
             "31350322c2d37382c424c5545424f4e4",
         ),
+        # fails to decode base32; return raw (guaranteed decodable by channel_dns)
         (
             "A---------.G01.yh6wfyh752qi06e35f9b0260f.127.0.0.1",
             "Unrecoverable data: A---------",

--- a/tests/units/test_tokens.py
+++ b/tests/units/test_tokens.py
@@ -198,9 +198,16 @@ def test_create_token_hit(setup_db, token_type, hit_info):
 @pytest.mark.parametrize(
     "in_url, expected_out",
     [
-        ("JBSWY3DPGIQQ.G01.yh6wfyh752qi06e35f9b0260f.127.0.0.1", b"Hello2!"),
-        ("JbSwy3DPgiQq.g01.yh6wfyh752qi06e35f9b0260f.127.0.0.1", b"Hello2!"),
-        ("JBSWY.3DPGI.QQ.G01.yh6wfyh752qi06e35f9b0260f.127.0.0.1", b"Hello2!"),
+        ("JBSWY3DPGIQQ.G01.yh6wfyh752qi06e35f9b0260f.127.0.0.1", "Hello2!"),
+        ("JbSwy3DPgiQq.g01.yh6wfyh752qi06e35f9b0260f.127.0.0.1", "Hello2!"),
+        (
+            "GE2QGIWC2NZYFRBEYVKFIJHU4Q.G01.yh6wfyh752qi06e35f9b0260f.127.0.0.1",
+            "31350322c2d37382c424c5545424f4e4",
+        ),
+        (
+            "A---------.G01.yh6wfyh752qi06e35f9b0260f.127.0.0.1",
+            "Unrecoverable data: A---------",
+        ),
     ],
 )
 def test_generic_data(in_url: str, expected_out: dict[str, str]):


### PR DESCRIPTION
## Proposed changes

This PR fixes the handling of generic data, returning hexlified bytes when the data cannot be decoded as utf-8. Additionally, the webhook notification timeout is dropped to (2, 2).

Documentation updated in [thinkst/canarytokens-docs/PR#44](https://github.com/thinkst/canarytokens-docs/pull/44)

## Types of changes

What types of changes does your code introduce to this repository?
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Documentation Update

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
