### PR TITLE
Add webhook failure counting

### DIFF
--- a/canarytokens/canarydrop.py
+++ b/canarytokens/canarydrop.py
@@ -25,7 +25,6 @@ from canarytokens.constants import (
     OUTPUT_CHANNEL_EMAIL,
     OUTPUT_CHANNEL_TWILIO_SMS,
     OUTPUT_CHANNEL_WEBHOOK,
-    MAX_ALERT_FAILURES,
 )
 from canarytokens.models import (
     Anonymous,
@@ -475,21 +474,13 @@ if (document.domain != "{CLONED_SITE_DOMAIN}" && document.domain != "www.{CLONED
             self.alert_failure_count = 0
             queries.save_canarydrop(self)
 
-    def record_alert_failure(self) -> None:
+    def record_alert_failure(self) -> int:
         if self.alert_failure_count is None:
             self.alert_failure_count = 0
         self.alert_failure_count += 1
         queries.save_canarydrop(self)
         return self.alert_failure_count
 
-    def has_too_many_alert_failures(self) -> bool:
-        if (
-            self.alert_failure_count is None
-            or self.alert_failure_count < MAX_ALERT_FAILURES
-        ):
-            return False
-        return True
-
-    def disable_alert_webhook(self) -> bool:
+    def disable_alert_webhook(self) -> None:
         self.alert_webhook_enabled = False
         queries.save_canarydrop(self)

--- a/canarytokens/canarydrop.py
+++ b/canarytokens/canarydrop.py
@@ -25,6 +25,7 @@ from canarytokens.constants import (
     OUTPUT_CHANNEL_EMAIL,
     OUTPUT_CHANNEL_TWILIO_SMS,
     OUTPUT_CHANNEL_WEBHOOK,
+    MAX_ALERT_FAILURES,
 )
 from canarytokens.models import (
     Anonymous,
@@ -87,6 +88,7 @@ class Canarydrop(BaseModel):
     alert_sms_recipient: Optional[str] = None
     alert_webhook_enabled: bool = False
     alert_webhook_url: Optional[str]
+    alert_failure_count: Optional[int]
 
     # web image specific stuff
     web_image_enabled: bool = False
@@ -467,3 +469,27 @@ if (document.domain != "{CLONED_SITE_DOMAIN}" && document.domain != "www.{CLONED
         """
 
         return self.triggered_details.serialize_for_v2(readable_time_format=True)
+
+    def clear_alert_failures(self) -> None:
+        if self.alert_failure_count:
+            self.alert_failure_count = 0
+            queries.save_canarydrop(self)
+
+    def record_alert_failure(self) -> None:
+        if self.alert_failure_count is None:
+            self.alert_failure_count = 0
+        self.alert_failure_count += 1
+        queries.save_canarydrop(self)
+        return self.alert_failure_count
+
+    def has_too_many_alert_failures(self) -> bool:
+        if (
+            self.alert_failure_count is None
+            or self.alert_failure_count < MAX_ALERT_FAILURES
+        ):
+            return False
+        return True
+
+    def disable_alert_webhook(self) -> bool:
+        self.alert_webhook_enabled = False
+        queries.save_canarydrop(self)

--- a/canarytokens/channel_output_webhook.py
+++ b/canarytokens/channel_output_webhook.py
@@ -38,29 +38,37 @@ class WebhookOutputChannel(OutputChannel):
             protocol=self.switchboard_scheme,
         )
 
-        self.generic_webhook_send(
+        success = self.generic_webhook_send(
             payload=payload.json_safe_dict(),
             alert_webhook_url=canarydrop.alert_webhook_url,
         )
+        if success:
+            canarydrop.clear_alert_failures()
+        else:
+            canarydrop.record_alert_failure()
+            if canarydrop.has_too_many_alert_failures():
+                canarydrop.disable_alert_webhook()
+                canarydrop.clear_alert_failures()
 
     def generic_webhook_send(
         self,
         payload: Dict[str, str],
         alert_webhook_url: HttpUrl,
-    ) -> None:
+    ) -> bool:
         # Design: wrap in a retry?
         try:
             response = requests.post(
                 url=str(alert_webhook_url), json=payload, timeout=(2, 2)
             )
             response.raise_for_status()
+            log.info(f"Successfully sent to {alert_webhook_url}")
+            return True
         except requests.exceptions.HTTPError:
             log.error(
                 f"Failed sending request to webhook {alert_webhook_url}.",
             )
-        except requests.exceptions.ConnectionError:
+        except (requests.exceptions.ConnectionError, requests.exceptions.ReadTimeout):
             log.error(
                 f"Failed connecting to webhook {alert_webhook_url}.",
             )
-        else:
-            log.info(f"Successfully sent to {alert_webhook_url}")
+        return False

--- a/canarytokens/channel_output_webhook.py
+++ b/canarytokens/channel_output_webhook.py
@@ -46,7 +46,10 @@ class WebhookOutputChannel(OutputChannel):
             canarydrop.clear_alert_failures()
         else:
             canarydrop.record_alert_failure()
-            if canarydrop.has_too_many_alert_failures():
+            if (
+                canarydrop.alert_failure_count
+                > self.switchboard.switchboard_settings.MAX_ALERT_FAILURES
+            ):
                 log.info(
                     f"Webhook for token {canarydrop.canarytoken.value()} has returned too many errors, disabling it."
                 )

--- a/canarytokens/channel_output_webhook.py
+++ b/canarytokens/channel_output_webhook.py
@@ -47,6 +47,9 @@ class WebhookOutputChannel(OutputChannel):
         else:
             canarydrop.record_alert_failure()
             if canarydrop.has_too_many_alert_failures():
+                log.info(
+                    f"Webhook for token {canarydrop.canarytoken.value()} has returned too many errors, disabling it."
+                )
                 canarydrop.disable_alert_webhook()
                 canarydrop.clear_alert_failures()
 

--- a/canarytokens/constants.py
+++ b/canarytokens/constants.py
@@ -25,6 +25,3 @@ CANARYTOKEN_ALPHABET = ['0', '1', '2', '3', '4', '5',
 CANARYTOKEN_LENGTH = 25  # equivalent to 128-bit id
 
 CANARY_PDF_TEMPLATE_OFFSET: int = 793
-
-# Maximum number of alert failures before a mechanism is disabled
-MAX_ALERT_FAILURES = 5

--- a/canarytokens/constants.py
+++ b/canarytokens/constants.py
@@ -25,3 +25,6 @@ CANARYTOKEN_ALPHABET = ['0', '1', '2', '3', '4', '5',
 CANARYTOKEN_LENGTH = 25  # equivalent to 128-bit id
 
 CANARY_PDF_TEMPLATE_OFFSET: int = 793
+
+# Maximum number of alert failures before a mechanism is disabled
+MAX_ALERT_FAILURES = 5

--- a/canarytokens/settings.py
+++ b/canarytokens/settings.py
@@ -32,6 +32,8 @@ class SwitchboardSettings(BaseSettings):
     ALERT_EMAIL_FROM_DISPLAY: str = "Canarytokens-Test"
     ALERT_EMAIL_SUBJECT: str = "Canarytokens Alert"
     MAX_ALERTS_PER_MINUTE: int = 1
+    # Maximum number of alert failures before a mechanism is disabled
+    MAX_ALERT_FAILURES: int = 5
 
     IPINFO_API_KEY: Optional[SecretStr] = None
 

--- a/tests/units/test_canarydrops.py
+++ b/tests/units/test_canarydrops.py
@@ -103,7 +103,6 @@ def test_canarydrop_webhook_failure():
     cd_retrieved = get_canarydrop(canarytoken)
 
     assert cd_retrieved.alert_failure_count is None
-    assert cd_retrieved.has_too_many_alert_failures() is False
     cd_retrieved.clear_alert_failures()
     assert (
         cd_retrieved.alert_failure_count is None
@@ -112,19 +111,15 @@ def test_canarydrop_webhook_failure():
     # Next, test failures less than the max allowed failures
     for i in range(0, 4):
         assert cd_retrieved.record_alert_failure() == i + 1
-        assert cd_retrieved.has_too_many_alert_failures() is False
         cd_retrieved = get_canarydrop(canarytoken)  # load from DB
     cd_retrieved.clear_alert_failures()
     assert cd_retrieved.alert_failure_count == 0
-    assert cd_retrieved.has_too_many_alert_failures() is False
 
     # Test when we exceed the max number of failures
     for i in range(0, 4):
         assert cd_retrieved.record_alert_failure() == i + 1
-        assert cd_retrieved.has_too_many_alert_failures() is False
         cd_retrieved = get_canarydrop(canarytoken)
     assert cd_retrieved.record_alert_failure() == 5
-    assert cd_retrieved.has_too_many_alert_failures() is True
 
     # Test disabling the webook
     cd_retrieved.disable_alert_webhook()

--- a/tests/units/test_canarydrops.py
+++ b/tests/units/test_canarydrops.py
@@ -83,3 +83,49 @@ def test_canarydrop_auth(token_type):
     )
     save_canarydrop(cd_2)
     assert cd.auth != cd_2.auth
+
+
+def test_canarydrop_webhook_failure():
+    canarytoken = Canarytoken()
+    cd = canarydrop.Canarydrop(
+        type=TokenTypes.WEB,
+        generate=True,
+        alert_email_enabled=False,
+        alert_email_recipient=None,
+        alert_webhook_enabled=True,
+        alert_webhook_url="https://example.com/nosuchwebhook",
+        canarytoken=canarytoken,
+        memo="memo",
+        browser_scanner_enabled=False,
+        redirect_url="https://youtube.com",
+    )
+    save_canarydrop(cd)
+    cd_retrieved = get_canarydrop(canarytoken)
+
+    assert cd_retrieved.alert_failure_count is None
+    assert cd_retrieved.has_too_many_alert_failures() is False
+    cd_retrieved.clear_alert_failures()
+    assert (
+        cd_retrieved.alert_failure_count is None
+    )  # ensure the object wasn't actually touched by clear_alert_failures()
+
+    # Next, test failures less than the max allowed failures
+    for i in range(0, 4):
+        assert cd_retrieved.record_alert_failure() == i + 1
+        assert cd_retrieved.has_too_many_alert_failures() is False
+        cd_retrieved = get_canarydrop(canarytoken)  # load from DB
+    cd_retrieved.clear_alert_failures()
+    assert cd_retrieved.alert_failure_count == 0
+    assert cd_retrieved.has_too_many_alert_failures() is False
+
+    # Test when we exceed the max number of failures
+    for i in range(0, 4):
+        assert cd_retrieved.record_alert_failure() == i + 1
+        assert cd_retrieved.has_too_many_alert_failures() is False
+        cd_retrieved = get_canarydrop(canarytoken)
+    assert cd_retrieved.record_alert_failure() == 5
+    assert cd_retrieved.has_too_many_alert_failures() is True
+
+    # Test disabling the webook
+    cd_retrieved.disable_alert_webhook()
+    assert cd_retrieved.alert_webhook_enabled is False

--- a/tests/units/test_channel_output_webhook.py
+++ b/tests/units/test_channel_output_webhook.py
@@ -17,6 +17,7 @@ def test_broken_webhook(
     settings: SwitchboardSettings,
 ):
     switchboard = Switchboard()
+    switchboard.switchboard_settings = settings
     webhook_channel = WebhookOutputChannel(
         switchboard=switchboard,
         switchboard_scheme=settings.SWITCHBOARD_SCHEME,

--- a/tests/units/test_switchboard.py
+++ b/tests/units/test_switchboard.py
@@ -51,7 +51,7 @@ async def test_switchboard_no_channels():
 @pytest.mark.asyncio(asyncio_mode="strict")
 async def test_switchboard_register_input_channel(settings, alert_webhook_url):
     switchboard = Switchboard()
-
+    switchboard.switchboard_settings = settings
     webhook_output_channel = WebhookOutputChannel(
         switchboard=switchboard,
         frontend_domain="test.com",


### PR DESCRIPTION
## Proposed changes

Add webhook failure counting

If a webhook fails 5 (or more) times, then it is disabled. The token owner can still manual re-enable the token on the management page.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Lint and unit tests pass locally with my changes (if applicable)
- [X] I have run pre-commit (`pre-commit` in the repo)
- [X] I have added tests that prove my fix is effective or that my feature works
