### PR TITLE
Remove build id from index

### DIFF
--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -849,10 +849,12 @@ START REPLICA;
         <a href="http://canary.tools/why" target="_blank" class="banner"></a>
         <p>Read Our <a href="https://docs.canarytokens.org/guide/" target="_blank">Canarytokens Documentation</a></p>
         <p>By Using This Service, You Agree to Our <a href="/legal">Terms of Use.</a></p>
-        <p id="mainsite" class="hidden">This <a href="https://canarytokens.org/">Canarytokens</a> installation is unaffiliated with Thinkst Canary.</p>
-        {% if build_id %}
-        <p>Build ID: {{ build_id }}</p>
-        {%endif%}
+        <div id="mainsite" class="hidden">
+          <p>This <a href="https://canarytokens.org/">Canarytokens</a> installation is unaffiliated with Thinkst Canary.</p>
+          {% if build_id %}
+          <p>Build ID: {{ build_id }}</p>
+          {%endif%}
+        </div>
       </footer>
 
     </div> <!-- /container -->


### PR DESCRIPTION
We don't need this on the production site.

Will still show up for dev builds and other public deploys.