### PR TITLE
Fix AWS alert history page not rendering when missing fields

### DIFF
--- a/templates/history.html
+++ b/templates/history.html
@@ -354,6 +354,7 @@
                   Yes
                 </td>
               </tr>
+              {% if canarydrop['triggered_list'][item]['additional_info']['AWS Key Log Data'].get('last_used', False) %}
               <tr class="info_row">
                 <td>
                   Key Last Used
@@ -362,6 +363,7 @@
                   {{ canarydrop['triggered_list'][item]['additional_info']['AWS Key Log Data']['last_used'][0]|e }}
                 </td>
               </tr>
+              {% endif %}
         {% endif %}
       {% endif %}
       {% if canarydrop['triggered_list'][item]['additional_info'][info].__class__.__name__ != 'str' %}


### PR DESCRIPTION
It seems there are cases where the 'last_used' key can be missing from the triggered list.

This makes sure the entire history page doesn't break because of it.