### PR TITLE
Fix sensitive command token notifications

### DIFF
--- a/canarytokens/channel_dns.py
+++ b/canarytokens/channel_dns.py
@@ -31,7 +31,9 @@ def handle_query_name(query_name: Name) -> Tuple[Canarydrop, Dict[str, str]]:
     # DESIGN: If lookups are unique per type we should use that for this lookup.
     #         V2
     src_data = Canarytoken.look_for_source_data(query_name=query_name_decoded)
-    log.info(f"Recovered: {[o for o in src_data.items()]} for {query_name_decoded}")
+    log.info(
+        f"Recovered: {repr([o for o in src_data.items()])} for {query_name_decoded}"
+    )
     return canarydrop, src_data
 
 

--- a/canarytokens/channel_dns.py
+++ b/canarytokens/channel_dns.py
@@ -219,7 +219,8 @@ class ChannelDNS(InputChannel):
         # if canarydrop._drop['type'] == 'my_sql':
         #     d = deferLater(...)
         if (
-            canarydrop.type in [TokenTypes.LOG4SHELL, TokenTypes.WINDOWS_DIR]
+            canarydrop.type
+            in [TokenTypes.LOG4SHELL, TokenTypes.WINDOWS_DIR, TokenTypes.CMD]
             and src_data == {}
         ):
             return defer.succeed(self._do_dynamic_response(name=query.name.name))

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -260,7 +260,7 @@ class Canarytoken(object):
     @staticmethod
     def _grab_http_general_info(request: Request):
         """"""
-        useragent = request.getHeader("User-Agent") or "No useragent specified"
+        useragent = request.getHeader("User-Agent") or "(no user-agent specified)"
         src_ip = request.getHeader("x-real-ip") or request.client.host
         # DESIGN/TODO: this makes a call to third party ensure we happy with fails here
         #              and have default.
@@ -379,24 +379,24 @@ class Canarytoken(object):
 
         additional_info = {
             "Azure ID Log Data": {
-                "Date": [json_data.get("time", "Not Available")],
+                "Date": [json_data.get("time", "(not available)")],
                 "Authentication": [auth_details],
             },
             "Microsoft Azure": {
-                "Resource": [json_data.get("resource", "Not Available")],
-                "App ID": [json_data.get("app_id", "Not Available")],
-                "Cert ID": [json_data.get("cert_id", "Not Available")],
+                "Resource": [json_data.get("resource", "(not available)")],
+                "App ID": [json_data.get("app_id", "(not available)")],
+                "Cert ID": [json_data.get("cert_id", "(not available)")],
             },
             "Location": {
-                "city": [location_details.get("city", "Not Available")],
-                "state": [location_details.get("state", "Not Available")],
+                "city": [location_details.get("city", "(not available)")],
+                "state": [location_details.get("state", "(not available)")],
                 "countryOrRegion": [
-                    location_details.get("countryOrRegion", "Not Available")
+                    location_details.get("countryOrRegion", "(not available)")
                 ],
             },
             "Coordinates": {
-                "latitude": [geo_details.get("latitude", "Not Available")],
-                "longitude": [geo_details.get("longitude", "Not Available")],
+                "latitude": [geo_details.get("latitude", "(not available)")],
+                "longitude": [geo_details.get("longitude", "(not available)")],
             },
         }
         hit_info = {

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -221,8 +221,8 @@ class Canarytoken(object):
         computer_name = matches.group(1).lower()
         user_name = matches.group(2).lower()
         data = {}
-        data["cmd_computer_name"] = "Not Obtained"
-        data["cmd_user_name"] = "Not Obtained"
+        data["cmd_computer_name"] = "(not obtained)"
+        data["cmd_user_name"] = "(not obtained)"
         if user_name and user_name != "u":
             data["cmd_user_name"] = user_name[1:]
         if computer_name and computer_name != "c":
@@ -251,7 +251,7 @@ class Canarytoken(object):
 
         # TODO: refactor (make nice) and make 'x' a variable eg: _l4j_hostname_marker.
         if len(computer_name) <= 1 or not computer_name.startswith("x"):
-            computer_name = "Not Obtained"
+            computer_name = "(not obtained)"
         else:
             computer_name = computer_name[1:]
         data["src_data"] = {"log4_shell_computer_name": computer_name}

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -218,15 +218,15 @@ class Canarytoken(object):
     @staticmethod
     def _cmd_process(matches: Match[AnyStr]) -> dict[str, dict[str, AnyStr]]:
         """"""
-        computer_name = matches.group(1)
-        user_name = matches.group(2)
+        computer_name = matches.group(1).lower()
+        user_name = matches.group(2).lower()
         data = {}
         data["cmd_computer_name"] = "Not Obtained"
         data["cmd_user_name"] = "Not Obtained"
         if user_name and user_name != "u":
-            data["cmd_user_name"] = user_name[1:].lower()
+            data["cmd_user_name"] = user_name[1:]
         if computer_name and computer_name != "c":
-            data["cmd_computer_name"] = computer_name[1:].lower()
+            data["cmd_computer_name"] = computer_name[1:]
         return {"src_data": data}
 
     @staticmethod

--- a/templates/emails/notification.html
+++ b/templates/emails/notification.html
@@ -149,7 +149,7 @@
                                         <td style="border: 1px solid #cccccc; padding: 5px;"><code>{{ BasicDetails['cmd_process'] | e}}</code></td>
                                       </tr>
                       {% endif %}
-                      {% if BasicDetails['cmd_process'] %}
+                      {% if BasicDetails['cmd_computer_name'] %}
                                       <tr>
                                         <td class="label" style="background: #eeeeee; font-weight: bold; _border: none; width: 180px; border: 1px solid #cccccc; padding: 5px;">Executed on</td>
                                         <td style="border: 1px solid #cccccc; padding: 5px;"><code>{{ BasicDetails['cmd_computer_name'] | e}}</code></td>

--- a/tests/units/test_tokens.py
+++ b/tests/units/test_tokens.py
@@ -51,7 +51,7 @@ def test_windows_dir_pattern(
     "query, computer_name, should_match,",
     [
         ("xbrokenpc.L4J.sometoken.com", "brokenpc", True),
-        ("ns1.L4J.sometoken.com", "Not Obtained", True),
+        ("ns1.L4J.sometoken.com", "(not obtained)", True),
         ("xbrokenpc.L4.sometoken.com", "brokenpc", False),
     ],
 )
@@ -68,7 +68,7 @@ def test_log4_shell_pattern(query, computer_name, should_match):
     "query, cmd_computer_name,cmd_user_name,should_match,",
     [
         ("cbrokenpc.UN.ubrokenuser.CMD.sometoken.com", "brokenpc", "brokenuser", True),
-        ("c.UN.ubrokenuser.CMD.sometoken.com", "Not Obtained", "brokenuser", True),
+        ("c.UN.ubrokenuser.CMD.sometoken.com", "(not obtained)", "brokenuser", True),
         # ("xbrokenpc.L4.sometoken.com", "brokenpc", False),
     ],
 )


### PR DESCRIPTION
## Proposed changes

This PR fixes two issues noted in #280:
1. Sometimes emails were coming through with no details. This is because of partial DNS queries where the token subdomain was queried without any further details shortly before the full query. As with the zip and l4j tokens, we will now skip on these preliminary requests to alert only on the full ones.
2. An empty computer name was not being rendered as "Not Obtained" due to 0x20 encoding; this has now been fixed.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] Linked to the relevant github issue or github discussion