### PR TITLE
Use the redis host/port environment variables in frontend and block_user.py

### DIFF
--- a/block_user.py
+++ b/block_user.py
@@ -11,6 +11,9 @@ from canarytokens.queries import (
     unblock_email,
 )
 from canarytokens.redismanager import DB
+from canarytokens.settings import SwitchboardSettings
+
+switchboard_settings = SwitchboardSettings()
 
 parser = argparse.ArgumentParser(
     description="Block emails or domains from creating canarytokens"
@@ -33,8 +36,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-redis_hostname = "localhost" if strtobool(os.getenv("CI", "False")) else "redis"
-DB.set_db_details(hostname=redis_hostname, port=6379)
+DB.set_db_details(hostname=switchboard_settings.REDIS_HOST, port=switchboard_settings.REDIS_PORT)
 
 funcs = {
     "block": {"domain": block_domain, "email": block_email},

--- a/block_user.py
+++ b/block_user.py
@@ -36,7 +36,9 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-DB.set_db_details(hostname=switchboard_settings.REDIS_HOST, port=switchboard_settings.REDIS_PORT)
+DB.set_db_details(
+    hostname=switchboard_settings.REDIS_HOST, port=switchboard_settings.REDIS_PORT
+)
 
 funcs = {
     "block": {"domain": block_domain, "email": block_email},

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -273,8 +273,7 @@ def get_canarydrop_and_authenticate(token: str, auth: str = Security(auth_key)):
 
 @app.on_event("startup")
 def startup_event():
-    redis_hostname = "localhost" if strtobool(os.getenv("CI", "False")) else "redis"
-    DB.set_db_details(hostname=redis_hostname, port=6379)
+    DB.set_db_details(hostname=switchboard_settings.REDIS_HOST, port=switchboard_settings.REDIS_PORT)
     remove_canary_domain()
     remove_canary_domain()
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -273,7 +273,9 @@ def get_canarydrop_and_authenticate(token: str, auth: str = Security(auth_key)):
 
 @app.on_event("startup")
 def startup_event():
-    DB.set_db_details(hostname=switchboard_settings.REDIS_HOST, port=switchboard_settings.REDIS_PORT)
+    DB.set_db_details(
+        hostname=switchboard_settings.REDIS_HOST, port=switchboard_settings.REDIS_PORT
+    )
     remove_canary_domain()
     remove_canary_domain()
 


### PR DESCRIPTION
## Proposed changes

The frontend and block_user.py scripts do not use the `CANARY_REDIS_HOST` environment variable like the switchboard does. 

This change allows both the frontend and block_user.py to use the redis host and port values from set in `CANARY_REDIS_HOST/PORT` (via SwitchboardSettings) so the values are consistent across the app.

## Types of changes

What types of changes does your code introduce to this repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion