### PR TITLE
Allow cross-origin requests for custom image web bug Canarytoken

### DIFF
--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -657,7 +657,6 @@ class Canarytoken(object):
     def _get_response_for_web_image(
         canarydrop: canarydrop.Canarydrop, request: Request
     ):
-
         if request.getHeader("Accept") and "text/html" in request.getHeader("Accept"):
             if canarydrop.browser_scanner_enabled:
                 # set response mimetype

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -657,6 +657,7 @@ class Canarytoken(object):
     def _get_response_for_web_image(
         canarydrop: canarydrop.Canarydrop, request: Request
     ):
+
         if request.getHeader("Accept") and "text/html" in request.getHeader("Accept"):
             if canarydrop.browser_scanner_enabled:
                 # set response mimetype
@@ -687,6 +688,10 @@ class Canarytoken(object):
 
                 # render template
                 return template.render(**fortune_template_params).encode()
+
+        # If a browser makes cross-origin requests for this img that aren't "simple" it will reject
+        # the image response without this Canarytokens server permitting all cross-origin requests
+        request.setHeader("Access-Control-Allow-Origin", "*")
 
         if canarydrop.web_image_enabled and canarydrop.web_image_path.exists():
             # set response mimetype


### PR DESCRIPTION
## Proposed changes

If a browser makes cross-origin requests for this img that aren't "simple" it will reject the image response without this Canarytokens server permitting all cross-origin requests. (Although alerts are still triggered as expected.) Here, we selectively permit cross-origin requests just for the image response.

Fixes #222

## Types of changes

What types of changes does your code introduce to this repository?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
