### PR TITLE
Fix aws token format on frontend

### DIFF
--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -1315,8 +1315,7 @@ START REPLICA;
           '\naws_secret_access_key = '+ data['aws_secret_access_key']+
           '\noutput = '+ data['output']+
           '\nregion = '+ data['region']);
-          $('#result_aws_keys').css('text-align','left');
-          $('#result_aws_keys').css('width','100%');
+          $('#result_aws_keys').css('text-align','left').css('width','100%');
           $('a.file-download').each(function (i, e){
             e = $(e);
             e.prop('href', 'download?fmt='+e.data('fmt')+'&token='+data['token']+'&auth='+data['auth_token']);

--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -782,7 +782,7 @@ START REPLICA;
                 <h3>Your AWS key token is active!</h3>
                 <div class="artifacts">
                   <p>Copy this credential pair to your clipboard to use as desired:</p>
-                  <pre class="output-area" style="white-space: initial;">
+                  <pre class="output-area">
                     {{ textareacopy('result_aws_keys', 'language-javascript') }}
                   </pre>
                   <div class="form-control">
@@ -1316,11 +1316,15 @@ START REPLICA;
           '\noutput = '+ data['output']+
           '\nregion = '+ data['region']);
           $('#result_aws_keys').css('text-align','left');
+          $('#result_aws_keys').css('width','100%');
           $('a.file-download').each(function (i, e){
             e = $(e);
             e.prop('href', 'download?fmt='+e.data('fmt')+'&token='+data['token']+'&auth='+data['auth_token']);
           });
           hljs.highlightAll();
+          // Trim white spaces from inner HTML
+          let aws_keys_token = document.getElementById("result_aws_keys");
+          aws_keys_token.innerHTML = aws_keys_token.innerHTML.trim()         
         }
 
         var _handleAzureIDResponse = function(data){

--- a/templates/manage_new.html
+++ b/templates/manage_new.html
@@ -160,7 +160,7 @@
             <div class="result aws_keys">
               <h5>Here's your AWS key token:</h5>
               <div class="artifacts">
-                <pre class="output-area" style="white-space: initial;">
+                <pre class="output-area">
                   {{ textareacopy('result_aws_keys') }}
                 </pre>
                 <div class="form-control">
@@ -642,10 +642,14 @@ START REPLICA;
         '\noutput = '+ data['output']+
         '\nregion = '+ data['region']);
         $('#result_aws_keys').css('text-align','left');
+        $('#result_aws_keys').css('width','100%');
         $('a.file-download').each(function (i, e){
           e = $(e);
           e.prop('href', 'download?fmt='+e.data('fmt')+'&token='+data['token']+'&auth='+data['auth']);
         });
+        // Trim white spaces from inner HTML
+        let aws_keys_token = document.getElementById("result_aws_keys");
+        aws_keys_token.innerHTML = aws_keys_token.innerHTML.trim()
       }
       var _handleMySQLResponse = function(data) {
           var cmd = `SET @bb = CONCAT(\"CHANGE MASTER TO MASTER_PASSWORD='my-secret-pw', MASTER_RETRY_COUNT=1, MASTER_PORT=3306, MASTER_HOST='${data['generated_hostname']}', MASTER_USER='${data['token']}\", @@lc_time_names, @@hostname, \"';\");`

--- a/templates/manage_new.html
+++ b/templates/manage_new.html
@@ -641,11 +641,10 @@ START REPLICA;
         '\naws_secret_access_key = '+ data['aws_secret_access_key']+
         '\noutput = '+ data['output']+
         '\nregion = '+ data['region']);
-        $('#result_aws_keys').css('text-align','left');
-        $('#result_aws_keys').css('width','100%');
+        $('#result_aws_keys').css('text-align','left').css('width','100%');
         $('a.file-download').each(function (i, e){
           e = $(e);
-          e.prop('href', 'download?fmt='+e.data('fmt')+'&token='+data['token']+'&auth='+data['auth']);
+          e.prop('href', 'download?fmt='+e.data('fmt')+'&token='+data['canarytoken']+'&auth='+data['auth']);
         });
         // Trim white spaces from inner HTML
         let aws_keys_token = document.getElementById("result_aws_keys");


### PR DESCRIPTION
## Proposed changes

The AWS keys token, displayed on UI has an invalid format. All its new line characters are not displayed.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Tests

1. Ensured the `AWS` token has the correct format, in both the `generate` and `manage` pages. 
<img width="725" alt="Screenshot 2023-10-03 at 15 27 29" src="https://github.com/thinkst/canarytokens/assets/103185449/916a5c16-db79-4bf2-bff0-4aaa7890e460">

2. Ensured the copied `AWS` token has the correct format, in both the `generate` and `manage` pages.
```
[default]
aws_access_key_id = <access key id>
aws_secret_access_key = <secret access key>
output = json
region = <region>
```