### PR TITLE
Skip email tests if API keys not present in env files

### DIFF
--- a/canarytokens/settings.py
+++ b/canarytokens/settings.py
@@ -39,12 +39,12 @@ class SwitchboardSettings(BaseSettings):
 
     IPINFO_API_KEY: Optional[SecretStr] = None
 
-    MAILGUN_API_KEY: Optional[SecretStr] = SecretStr("NoSendgridAPIKeyFound")
+    MAILGUN_API_KEY: Optional[SecretStr] = None
     MAILGUN_BASE_URL: Optional[HttpUrl] = HttpUrl(
         "https://api.mailgun.net", scheme="https"
     )
     MAILGUN_DOMAIN_NAME: Optional[str]
-    SENDGRID_API_KEY: Optional[SecretStr] = SecretStr("NoSendgridAPIKeyFound")
+    SENDGRID_API_KEY: Optional[SecretStr] = None
     SENDGRID_SANDBOX_MODE: bool = True
 
     SENTRY_DSN: Optional[HttpUrl] = None

--- a/tests/units/test_channel_output_email.py
+++ b/tests/units/test_channel_output_email.py
@@ -142,6 +142,8 @@ def test_sendgrid_send(
     email: str,
     expected_result_type: EmailResponseStatuses,
 ):
+    if not settings.SENDGRID_API_KEY:
+        pytest.skip("No SendGrid API key found; skipping...")
     details = _get_send_token_details()
 
     result, message_id = sendgrid_send(
@@ -177,7 +179,8 @@ def test_mailgun_send(
     email: str,
     expected_result_type: EmailResponseStatuses,
 ):
-
+    if not settings.MAILGUN_API_KEY:
+        pytest.skip("No Mailgun API key found; skipping...")
     details = _get_send_token_details()
     result, message_id = mailgun_send(
         email_content_html=EmailOutputChannel.format_report_html(
@@ -203,6 +206,11 @@ def _do_send_alert(
     switchboard_settings: SwitchboardSettings,
     email: str,
 ) -> Canarydrop:
+    if (
+        not switchboard_settings.SENDGRID_API_KEY
+        and not switchboard_settings.MAILGUN_API_KEY
+    ):
+        pytest.skip("No email provider API key found; skipping...")
     email_channel = EmailOutputChannel(
         frontend_settings=frontend_settings,
         switchboard_settings=switchboard_settings,


### PR DESCRIPTION
## Proposed changes

Running unit tests currently requires having an env file with API keys in it. This PR skips those tests unless the API keys are present, simplifying dev onboarding

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)