### PR TITLE
Discord webhook support

### DIFF
--- a/canarytokens/channel.py
+++ b/canarytokens/channel.py
@@ -94,28 +94,33 @@ def format_as_googlechat_canaryalert(
         cardsV2=[GoogleChatCardV2(cardId="unique-card-id", card=card)]
     )
 
+
 def format_as_discord_canaryalert(
-        details: TokenAlertDetails
+    details: TokenAlertDetails,
 ) -> TokenAlertDetailsDiscord:
     embeds = DiscordEmbeds(
-        author = DiscordAuthorField(
-            icon_url = "https://s3-eu-west-1.amazonaws.com/email-images.canary.tools/canary-logo-round.png",
+        author=DiscordAuthorField(
+            icon_url="https://s3-eu-west-1.amazonaws.com/email-images.canary.tools/canary-logo-round.png",
         ),
-        url = details.manage_url,
-        timestamp = details.time.strftime("%Y-%m-%dT%H:%M:%S"),
+        url=details.manage_url,
+        timestamp=details.time.strftime("%Y-%m-%dT%H:%M:%S"),
     )
+
     embeds.add_fields(
         fields_info=DiscordDetails(
-            canarytoken=details.canarytoken,
+            canarytoken=details.token,
             token_reminder=details.memo,
-            src_data=details.src_data,
-            additional_data=details.additional_data,
+            src_data=details.src_data if details.src_data else None,
         ).get_discord_data(),
     )
-    
-    return TokenAlertDetailsDiscord(
-        embeds = [embeds]
-    )
+
+    if details.additional_data:
+        embeds.add_fields(
+            fields_info=details.additional_data,
+        )
+
+    return TokenAlertDetailsDiscord(embeds=[embeds])
+
 
 class Channel(object):
     CHANNEL = "Base"

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1940,6 +1940,65 @@ class GoogleChatCardV2(BaseModel):
     card: GoogleChatCard
 
 
+class DiscordFieldEntry(BaseModel):
+    name: str = ""
+    value: str = ""
+    inline: bool = False
+
+class DiscordDetails(BaseModel):
+    canarytoken: Canarytoken
+    token_reminder: Memo
+    src_data: Optional[dict]
+    additional_data: Optional[dict[str, any]]
+
+    def get_discord_data(self) -> Dict[str, str]:
+        data = json_safe_dict(self)
+        data["Canarytoken"] = data.pop("canarytoken", "")
+        data["Token Reminder"] = data.pop("token_reminder", "")
+        if data['src_data']:
+            data['Source Data'] = data.pop('src_data', "")
+        if data['additional_data']:
+            data['Additional Data'] = data.pop('additional_data')
+        return data
+
+class DiscordAuthorField(BaseModel):
+    name: str = "Canary Alerts"
+    icon_url: str
+
+class DiscordEmbeds(BaseModel):
+    author: DiscordAuthorField
+    color: int = 3724415 # Magic colour number. Trust the process
+    title: str = "Canarytoken Triggered"
+    url: HttpUrl
+    timestamp: datetime
+    fields: List[DiscordFieldEntry] = []
+
+    def add_fields(self, fields_info: Optional[Dict[str, str]] = {}) -> None:
+        for label, text in fields_info.items():
+            if not label or not text:
+                continue
+            message_text = (
+                json.dumps(text) if isinstance(text, dict) else "{}".format(text)
+            )
+            self.fields.append(
+                DiscordFieldEntry(
+                    name = label,
+                    value = text,
+                    inline = len(max(text.split('\n')>40))
+                )
+            )
+
+    @validator("time", pre=True)
+    def validate_time(cls, value):
+        if isinstance(value, str):
+            return datetime.strptime(value, "%Y-%m-%d %H:%M:%S (UTC)")
+        return value
+    
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.strftime("%Y-%m-%d %H:%M:%S (UTC)"),
+        }
+
 class TokenAlertDetailsGoogleChat(BaseModel):
     cardsV2: List[GoogleChatCardV2]
 
@@ -1955,6 +2014,13 @@ class TokenAlertDetailsSlack(BaseModel):
     def json_safe_dict(self) -> Dict[str, str]:
         return json_safe_dict(self)
 
+class TokenAlertDetailsDiscord(BaseModel):
+    """Details that are sent to Discord webhooks"""
+
+    embeds: List[DiscordEmbeds]
+
+    def json_safe_dict(self) -> Dict[str, str]:
+        return json_safe_dict(self)
 
 class TokenAlertDetailGeneric(TokenAlertDetails):
     ...

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1945,31 +1945,34 @@ class DiscordFieldEntry(BaseModel):
     value: str = ""
     inline: bool = False
 
+
 class DiscordDetails(BaseModel):
     canarytoken: Canarytoken
     token_reminder: Memo
-    src_data: Optional[dict]
-    additional_data: Optional[dict[str, any]]
+    src_data: Optional[dict[str, Any]]
+    additional_data: Optional[dict[str, Any]]
 
     def get_discord_data(self) -> Dict[str, str]:
         data = json_safe_dict(self)
         data["Canarytoken"] = data.pop("canarytoken", "")
         data["Token Reminder"] = data.pop("token_reminder", "")
-        if data['src_data']:
-            data['Source Data'] = data.pop('src_data', "")
-        if data['additional_data']:
-            data['Additional Data'] = data.pop('additional_data')
+        if "src_data" in data:
+            data["Source Data"] = data.pop("src_data", "")
+        if "additional_data" in data:
+            data["Additional Data"] = data.pop("additional_data")
         return data
+
 
 class DiscordAuthorField(BaseModel):
     name: str = "Canary Alerts"
     icon_url: str
 
+
 class DiscordEmbeds(BaseModel):
     author: DiscordAuthorField
-    color: int = 3724415 # Magic colour number. Trust the process
+    color: int = 3724415  # Magic colour number. Trust the process
     title: str = "Canarytoken Triggered"
-    url: HttpUrl
+    url: Optional[HttpUrl]
     timestamp: datetime
     fields: List[DiscordFieldEntry] = []
 
@@ -1982,22 +1985,23 @@ class DiscordEmbeds(BaseModel):
             )
             self.fields.append(
                 DiscordFieldEntry(
-                    name = label,
-                    value = text,
-                    inline = len(max(text.split('\n')>40))
+                    name=label,
+                    value=message_text,
+                    inline=len(max(message_text.split("\n"))) < 40,
                 )
             )
 
-    @validator("time", pre=True)
-    def validate_time(cls, value):
+    @validator("timestamp", pre=True)
+    def validate_timestamp(cls, value):
         if isinstance(value, str):
-            return datetime.strptime(value, "%Y-%m-%d %H:%M:%S (UTC)")
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
         return value
-    
+
     class Config:
         json_encoders = {
-            datetime: lambda v: v.strftime("%Y-%m-%d %H:%M:%S (UTC)"),
+            datetime: lambda v: v.strftime("%Y-%m-%dT%H:%M:%S"),
         }
+
 
 class TokenAlertDetailsGoogleChat(BaseModel):
     cardsV2: List[GoogleChatCardV2]
@@ -2014,6 +2018,7 @@ class TokenAlertDetailsSlack(BaseModel):
     def json_safe_dict(self) -> Dict[str, str]:
         return json_safe_dict(self)
 
+
 class TokenAlertDetailsDiscord(BaseModel):
     """Details that are sent to Discord webhooks"""
 
@@ -2021,6 +2026,7 @@ class TokenAlertDetailsDiscord(BaseModel):
 
     def json_safe_dict(self) -> Dict[str, str]:
         return json_safe_dict(self)
+
 
 class TokenAlertDetailGeneric(TokenAlertDetails):
     ...

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1950,7 +1950,6 @@ class DiscordDetails(BaseModel):
     canarytoken: Canarytoken
     token_reminder: Memo
     src_data: Optional[dict[str, Any]]
-    additional_data: Optional[dict[str, Any]]
 
     def get_discord_data(self) -> Dict[str, str]:
         data = json_safe_dict(self)
@@ -1958,8 +1957,6 @@ class DiscordDetails(BaseModel):
         data["Token Reminder"] = data.pop("token_reminder", "")
         if "src_data" in data:
             data["Source Data"] = data.pop("src_data", "")
-        if "additional_data" in data:
-            data["Additional Data"] = data.pop("additional_data")
         return data
 
 

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -841,17 +841,16 @@ def validate_webhook(url, token_type: models.TokenTypes):
             cardsV2=[models.GoogleChatCardV2(cardId="unique-card-id", card=card)]
         )
     elif url.startswith(discord):
-        #construct discord alert card
+        # construct discord alert card
         embeds = models.DiscordEmbeds(
             author=models.DiscordAuthorField(
-                icon_url="https://s3-eu-west-1.amazonaws.com/email-images.canary.tools/canary-logo-round.png",
+                icon_url="https://s3-eu-west-1.amazonaws.com/email-images.canary.tools/canary-logo-round.png"
             ),
-            title="Validating new canarytokens webhook"
+            title="Validating new canarytokens webhook",
             fields=[],
+            timestamp=datetime.datetime.now(),
         )
-        payload = models.TokenAlertDetailsDiscord(
-            embeds=[embeds]
-        )
+        payload = models.TokenAlertDetailsDiscord(embeds=[embeds])
 
     else:
         payload = models.TokenAlertDetails(

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -804,10 +804,12 @@ def validate_webhook(url, token_type: models.TokenTypes):
     """
     slack = "https://hooks.slack.com"
     googlechat_hook_base_url = "https://chat.googleapis.com"
+    discord = "https://discord.com/api/webhooks"
     payload: Union[
         models.TokenAlertDetails,
         models.TokenAlertDetailsSlack,
         models.TokenAlertDetailsGoogleChat,
+        models.TokenAlertDetailsDiscord,
     ]
     if url.startswith(slack):
         payload = models.TokenAlertDetailsSlack(
@@ -838,6 +840,19 @@ def validate_webhook(url, token_type: models.TokenTypes):
         payload = models.TokenAlertDetailsGoogleChat(
             cardsV2=[models.GoogleChatCardV2(cardId="unique-card-id", card=card)]
         )
+    elif url.startswith(discord):
+        #construct discord alert card
+        embeds = models.DiscordEmbeds(
+            author=models.DiscordAuthorField(
+                icon_url="https://s3-eu-west-1.amazonaws.com/email-images.canary.tools/canary-logo-round.png",
+            ),
+            title="Validating new canarytokens webhook"
+            fields=[],
+        )
+        payload = models.TokenAlertDetailsDiscord(
+            embeds=[embeds]
+        )
+
     else:
         payload = models.TokenAlertDetails(
             manage_url=HttpUrl(


### PR DESCRIPTION
## Proposed changes
This adds support for Discord webhook calls, creating properly formatted messages with token details.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate) -- None needed
- [x] Linked to the relevant github issue or github discussion

## Further comments
This change is made in response to [a matching feature request](https://github.com/thinkst/canarytokens/issues/314). The result is a simple, direct implementation of the discord webhook structure, with the relevant details from the token output.

Sample output:
<img width="598" alt="image" src="https://github.com/thinkst/canarytokens/assets/88440843/8adb9329-5dd3-4fef-8663-50281b77c436">