### PR TITLE
Add data events detection to AWSID infra

### DIFF
--- a/aws-token-infra/awsid.tf
+++ b/aws-token-infra/awsid.tf
@@ -248,6 +248,20 @@ resource "aws_cloudtrail" "canarytoken_logs" {
   s3_key_prefix                 = ""
   cloud_watch_logs_group_arn    = "${aws_cloudwatch_log_group.process_user_api_tokens_logs.arn}:*"
   cloud_watch_logs_role_arn     = aws_iam_role.process_user_api_tokens_logs_cloudtrail.arn
+  event_selector {
+    read_write_type           = "All"
+    include_management_events = true
+
+    data_resource {
+      type   = "AWS::S3::Object"
+      values = ["arn:aws:s3:::"]
+    }
+
+    data_resource {
+      type   = "AWS::Lambda::Function"
+      values = ["arn:aws:lambda"]
+    }
+  }
 }
 
 # ProcessUserAPITokensLogs


### PR DESCRIPTION
## Proposed changes

This change updates the terraform used for the AWSID infra for Canarytokens.org to allow CloudTrail to log data events that involve S3 and Lambda. This was the expected behaviour, but we failed to enable it. 

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] Linked to the relevant github issue or github discussion ([[ https://github.com/thinkst/canarytokens-docker/issues/166 | reported here ]])
