### PR TITLE
Increase max webhook length and add backend length check

### DIFF
--- a/canarytokens/constants.py
+++ b/canarytokens/constants.py
@@ -30,3 +30,5 @@ CANARY_PDF_TEMPLATE_OFFSET: int = 793
 MAILGUN_IGNORE_ERRORS = [
     "to parameter is not a valid address. please check documentation"
 ]
+
+MAX_WEBHOOK_URL_LENGTH = 1024

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -14,7 +14,7 @@ from pydantic import EmailStr, HttpUrl, ValidationError, parse_obj_as
 from twisted.logger import Logger
 
 from canarytokens import canarydrop as cand
-from canarytokens import models, tokens
+from canarytokens import models, tokens, constants
 from canarytokens.exceptions import CanarydropAuthFailure, NoCanarydropFound
 from canarytokens.redismanager import (  # KEY_BITCOIN_ACCOUNT,; KEY_BITCOIN_ACCOUNTS,; KEY_CANARY_NXDOMAINS,; KEY_CANARYTOKEN_ALERT_COUNT,; KEY_CLONEDSITE_TOKEN,; KEY_CLONEDSITE_TOKENS,; KEY_IMGUR_TOKEN,; KEY_IMGUR_TOKENS,; KEY_KUBECONFIG_CERTS,; KEY_KUBECONFIG_HITS,; KEY_KUBECONFIG_SERVEREP,; KEY_LINKEDIN_ACCOUNT,; KEY_LINKEDIN_ACCOUNTS,; KEY_USER_ACCOUNT,
     DB,
@@ -797,11 +797,18 @@ def add_canary_google_api_key(key: str) -> int:
 #     return key
 
 
+class WebhookTooLongError(Exception):
+    pass
+
+
 def validate_webhook(url, token_type: models.TokenTypes):
     """Tests if a webhook is valid by sending a test payload
     Arguments:
     url -- Webhook url
     """
+    if len(url) > constants.MAX_WEBHOOK_URL_LENGTH:
+        raise WebhookTooLongError()
+
     slack = "https://hooks.slack.com"
     googlechat_hook_base_url = "https://chat.googleapis.com"
     discord = "https://discord.com/api/webhooks"

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -147,6 +147,7 @@ from canarytokens.queries import (
     remove_canary_domain,
     save_canarydrop,
     validate_webhook,
+    WebhookTooLongError,
 )
 from canarytokens.redismanager import DB
 from canarytokens.settings import FrontendSettings, SwitchboardSettings
@@ -347,6 +348,8 @@ async def generate(request: Request) -> AnyTokenResponse:  # noqa: C901  # gen i
             validate_webhook(
                 token_request_details.webhook_url, token_request_details.token_type
             )
+        except WebhookTooLongError:
+            return response_error(3, "Webhook URL too long. Use a shorter webhook URL.")
         except requests.exceptions.HTTPError:
             return response_error(
                 3, "Invalid webhook supplied. Confirm you can POST to this URL."

--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -1041,7 +1041,7 @@ START REPLICA;
         if (endpoints.val().length == 0) {
           return endpoints.addClass('error-outline').removeClass('success-outline');
         }
-        if (endpoints.val().length > 255) {
+        if (endpoints.val().length > 1024) {
           return endpoints.addClass('error-outline').removeClass('success-outline');
         }
         endpoints_components = endpoints.val().split(' ');

--- a/tests/units/test_frontend.py
+++ b/tests/units/test_frontend.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 from pydantic import HttpUrl
 
-from canarytokens import canarydrop, models, queries
+from canarytokens import canarydrop, models, queries, constants
 from canarytokens.models import (
     AnyDownloadRequest,
     AnyTokenRequest,
@@ -89,6 +89,18 @@ def test_generate_dns_token(test_client: TestClient) -> None:
     )
     resp = test_client.post("/generate", json=json.loads(dns_request_token.json()))
     assert resp.status_code == 200
+
+
+def test_reject_webhook_too_long(test_client: TestClient) -> None:
+    url_suffix = "a" * constants.MAX_WEBHOOK_URL_LENGTH
+    dns_request_token = models.DNSTokenRequest(
+        token_type=TokenTypes.DNS,
+        email="test@test.com",
+        webhook_url=f"https://slack.com/api/{url_suffix}",
+        memo="test stuff break stuff fix stuff test stuff",
+    )
+    resp = test_client.post("/generate", json=json.loads(dns_request_token.json()))
+    assert resp.status_code == 400
 
 
 def test_generate_log4shell_token(test_client: TestClient) -> None:


### PR DESCRIPTION
## Proposed changes

Increase the maximum allowed length of webhook URLs on the frontend and add backend validation of the webhook URL length as well.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Linked to the relevant github issue or github discussion (https://github.com/thinkst/canarytokens/issues/336)