### PR TITLE
Fix incorrect PSModulePath in test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,4 +162,4 @@ jobs:
           copy .\frontend\frontend.env.dist .\frontend\frontend.env
           copy .\switchboard\switchboard.env.dist .\switchboard\switchboard.env
           cd tests
-          poetry run pytest .\integration\test_custom_binary.py --runv3 -v
+          $env:PSModulePath = ''; poetry run pytest .\integration\test_custom_binary.py --runv3 -v


### PR DESCRIPTION
## Proposed changes

Fix Windows tests failing because of powershell import error.

After the Windows Github Action runner image was updated and powershell is now on 7.4, the Windows tests were failing due to a powershell import error. The error only happens when importing from python (doesn't happen when importing the powershell security module directly in the workflow file).

The problem was the same as the problem mentioned in [this](https://github.com/PowerShell/PowerShell/issues/18681) issue. The [same fix](https://github.com/PowerShell/PowerShell/issues/18530#issuecomment-1325691850) was applied here and now the Windows tests are passing again.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion