### PR TITLE
Improve robustness in CloudFront Function

### DIFF
--- a/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
+++ b/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
@@ -4,31 +4,51 @@
 
 var token_server = 'https://canarytokens.com';
 
+var matching_ref_response = {
+    statusCode: 200,
+    statusDescription: 'OK',
+    headers: {
+        'content-type': { value: 'image/gif' }
+    },
+    body: "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff"
+    + "\xff\xff\xff\x21\xf9\x04\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00"
+    + "\x01\x00\x01\x00\x00\x02\x02\x4c\x01\x00\x3b"
+};
+
 function handler(event) {
     var uri = event.request.uri.split('/');
     var expected_referrer = '';
+    if (uri.length != 4) { // We have a malformed request, return a 404
+        return {
+            statusCode: 404,
+            statusDescription: 'Not Found'
+        };
+    }
     expected_referrer = String.bytesFrom(uri[2], 'base64url');
     var referer = '';
-    if ('referer' in event.request.headers)
+    var referer_origin = '';
+    if ('referer' in event.request.headers) {
         referer = event.request.headers.referer.value;
+        if (referer.indexOf('//') >= 0) {
+            const pathArray = referer.split( '/' );
+            referer_origin = pathArray[2];
+        } else {
+            referer_origin = referer;
+        }
+    }
 
     if (expected_referrer == '')
         console.log("Empty expected_referrer!");
     if (referer == '')
         console.log("Empty/missing Referer header for: " + expected_referrer);
 
-    if (expected_referrer == '' || referer == '' || referer.indexOf(expected_referrer) >= 0) { // Happy case where the referer matches
-        var response = {
-            statusCode: 200,
-            statusDescription: 'OK',
-            headers: {
-                'content-type': { value: 'image/gif' }
-            },
-            body: "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff"
-            + "\xff\xff\xff\x21\xf9\x04\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00"
-            + "\x01\x00\x01\x00\x00\x02\x02\x4c\x01\x00\x3b"
-        };
-        return response;
+    if (expected_referrer == '' || referer == '' || referer_origin.endsWith(expected_referrer)) { // Happy case where the referer matches   
+        return matching_ref_response;
+    }
+    if (expected_referrer == 'microsoftonline.com' && referer_origin.endsWith('login.microsoft.com')) {
+        // Special case of an MS login token came from login.microsoft.com instead of microsoftonline.com
+        // We still want to treat this as a good login since the referer is a valid MS domain
+        return matching_ref_response;
     }
     // Default case of redirecting to the tokens server
     var response = {

--- a/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
+++ b/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
@@ -2,6 +2,8 @@
 // Expected uri looks like: /TOKEN_ID/escape(btoa(expected_referrer))/imagename.gif
 // Either returns a 1x1 pixel GIF, or forwards it to the token server with the referrer as a GET parameter for reporting
 
+var querystring = require('querystring');
+
 var token_server = 'https://canarytokens.com';
 
 var matching_ref_response = {
@@ -45,7 +47,7 @@ function handler(event) {
     if (expected_referrer == '' || referer == '' || referer_origin.endsWith(expected_referrer)) { // Happy case where the referer matches   
         return matching_ref_response;
     }
-    if (expected_referrer == 'microsoftonline.com' && referer_origin.endsWith('login.microsoft.com')) {
+    if (expected_referrer.endsWith('microsoftonline.com') && referer_origin.endsWith('login.microsoft.com')) {
         // Special case of an MS login token came from login.microsoft.com instead of microsoftonline.com
         // We still want to treat this as a good login since the referer is a valid MS domain
         return matching_ref_response;
@@ -55,7 +57,7 @@ function handler(event) {
         statusCode: 302,
         statusDescription: 'Found',
         headers: {
-            'location': { value: token_server + '/' + uri[1] + '/' + uri[3] + '?r=' + referer }
+            'location': { value: token_server + '/' + uri[1] + '/' + uri[3] + '?' + querystring.stringify({"r": referer}) }
         }
     };
     return response;

--- a/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
+++ b/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
@@ -30,7 +30,7 @@ function handler(event) {
     if ('referer' in event.request.headers) {
         referer = event.request.headers.referer.value;
         if (referer.indexOf('//') >= 0) {
-            const pathArray = referer.split( '/' );
+            var pathArray = referer.split( '/' );
             referer_origin = pathArray[2];
         } else {
             referer_origin = referer;


### PR DESCRIPTION
## Proposed changes

This is an update to the AWS CloudFront Function supporting the CSS token. It addresses the following issues:
- The current implementation results in a 500 error and a FunctionErrorException on non-compliant requests. This PR changes that to return a 404 Not Found, so if, e.g., `/favicon.ico` is requested, it returns 404 rather than 500. This is better HTTP behavior, and will prevent CloudWatch alarms from tripping if someone loads a token URL directly and it requests the favicon.
- Consolidate `login.microsoftonline.com` and `login.microsoft.com` - Both of these domains are valid, but we are currently alerting on valid logins coming from the other domain. If the expected referrer is the Azure portal, this PR will now accept the other domain as expected, and not alert.
- Tighten up origin comparison - The current implementation uses a `indexOf()` check to see if the expected referrer and the actual Referer match, but this would incorrectly *not* alert on a sneaky subdomain, such as login.microsoftonline.com.attackersite.com. This PR changes the processing to compare the referer using an `.endsWith()` so these sneaky subdomains will be alerted on.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

I have a test CF function, and I have tested this for:
- `/favicon.ico` - Returns 404
- token url with blank referer - Returns 200
- token url with referer of both login.microsoft.com and login.microsoftonline.com - Returns 200
- token url with full referer path of https://login.microsoft.com/do_next?saml=true - Returns 200
- token url with referer of asdf.com - Returns 302
- token url with referer of login.microsoftonline.com.attacker.com - Returns 302

Once this is reviewed, I will update the staging version of the function and re-run all these tests before pushing to production.