### PR TITLE
Fix TTL setting on DNS channel

### DIFF
--- a/canarytokens/channel_dns.py
+++ b/canarytokens/channel_dns.py
@@ -158,7 +158,7 @@ class ChannelDNS(InputChannel):
         log.info(f"Building A record: ip = {self.frontend_settings.PUBLIC_IP}")
         ttl = 10
         
-        if any([name.lower().decode() == d for d in self.canary_domains]):
+        if name.lower().decode() in self.canary_domains:
             # This is a resolution of the apex domain, not a token, so we can bump up the TTL
             ttl = 600 # 10 min seems plenty short enough to allow for IP changes without getting overloaded
 

--- a/canarytokens/channel_dns.py
+++ b/canarytokens/channel_dns.py
@@ -118,7 +118,7 @@ class ChannelDNS(InputChannel):
             payload=dns.Record_A(ttl=10, address=self.frontend_settings.PUBLIC_IP),
             type=dns.A,
             auth=True,
-            ttl=10
+            ttl=300
         )
         answers = [answer]
         authority: list[str] = []

--- a/canarytokens/channel_dns.py
+++ b/canarytokens/channel_dns.py
@@ -107,7 +107,7 @@ class ChannelDNS(InputChannel):
         answer = dns.RRHeader(
             name=name,
             payload=dns.Record_NS(
-                ttl=10,
+                ttl=300,
                 name=".".join(["ns1", name.decode()]),
             ),
             type=dns.NS,


### PR DESCRIPTION
## Proposed changes

The canarytokens DNS channel gets a lot of UDP DNS traffic, which makes sense because we set a 0 TTL on A responses for token subdomains to keep them firing instead of getting cached. This PR makes two changes:

1. In the DNS code, we set the TTL to 10s on responses for A queries, but left that out of the RRHeader constructor, so the overall response returns a TTL of 0. While that's fine for token hits, the code implies we meant to set it to 10s (which is fine to prevent massive overloads), so this PR copies the TTL values to the RRHeader used in the individual reply so the spirit of the original code is implemented. We may want to check with the original author (@thinkst-marco) if he meant the TTL to be 0 or 10s.
2. We are our own DNS server, and as such, we respond to queries for the apex domain (e.g., canarytokens.com), whenever any type of token is hit, and since we are returning a TTL of 0 currently, it means every token firing adds DNS traffic which can overwhelm the server, and get sub-par response times/timeouts on a token firing. This PR checks to see if the DNS query is for the apex domain, if so it sets a TTL of 10min, which could probably go even higher unless we're expecting to move the tokens server around a lot. This would allow the other, non-DNS tokens to fire without slamming the server with UDP traffic.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

Probably worth checking that a TTL of 10s on a token A req and 10min for apex domain is a good value.