### PR TITLE
Add spacing on footer on emails

### DIFF
--- a/templates/emails/notification.html
+++ b/templates/emails/notification.html
@@ -245,7 +245,7 @@
                   <td class="footer" style="font-size: 12px; text-align: center; padding-top: 10px; color: #666666; min-width: 315px; max-width: 660px; padding-bottom: 10px;" width="100%">
                     <table class="left" width="100%">
                       <tr>
-                        <td>Powered by:<a href="https://canary.tools">Thinkst Canary</a>
+                        <td>Powered by: <a href="https://canary.tools">Thinkst Canary</a>
                       </tr>
                     </table>
                   </td>


### PR DESCRIPTION
## Proposed changes

Adds a minor spacing here between the powered by and the url


<img width="467" alt="Captura de ecrã 2024-02-20, às 21 55 46" src="https://github.com/thinkst/canarytokens/assets/29093946/9686c5d7-4072-40db-ab1b-b48e9a696fe5">
