### PR TITLE
Settings manage page

### DIFF
--- a/frontend_vue/components.d.ts
+++ b/frontend_vue/components.d.ts
@@ -17,7 +17,6 @@ declare module 'vue' {
     BaseModal: typeof import('./src/components/base/BaseModal.vue')['default']
     BaseRefreshButton: typeof import('./src/components/base/BaseRefreshButton.vue')['default']
     BaseSwitch: typeof import('./src/components/base/BaseSwitch.vue')['default']
-    BaseTextField: typeof import('src/components/base/BaseTextField.vue')['default']
     BaseUploadFile: typeof import('./src/components/base/BaseUploadFile.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']

--- a/frontend_vue/src/api/main.ts
+++ b/frontend_vue/src/api/main.ts
@@ -1,8 +1,15 @@
 import axios from 'axios';
 
-type ManageTokenType = {
-  auth: string | string[];
-  token: string | string[];
+type TokenAuthType = {
+  auth: string;
+  token: string;
+};
+
+type DownloadTokenType = {
+  fmt: string;
+  auth: string;
+  token: string;
+  encoded: boolean;
 };
 
 export type EnableSettingsOptionType =
@@ -28,7 +35,7 @@ export function generateToken(form: any) {
     .catch((error) => error.response);
 }
 
-export function manageToken(params: ManageTokenType) {
+export function manageToken(params: TokenAuthType) {
   const url = '/api/manage';
   return axios
     .get(url, { params })
@@ -36,7 +43,7 @@ export function manageToken(params: ManageTokenType) {
     .catch((error) => error.response);
 }
 
-export function downloadToken(params: ManageTokenType) {
+export function downloadToken(params: DownloadTokenType) {
   const url = '/api/download';
   console.log(params);
   return axios

--- a/frontend_vue/src/api/main.ts
+++ b/frontend_vue/src/api/main.ts
@@ -1,8 +1,23 @@
 import axios from 'axios';
 
-type manageTokenType = {
+type ManageTokenType = {
   auth: string | string[];
   token: string | string[];
+};
+
+export type EnableSettingsOptionType =
+  | 'email_enable'
+  | 'web_image_enable'
+  | 'webhook_enable'
+  | 'browser_scanner_enable';
+
+type ValueSettingsOptionType = 'off' | 'on';
+
+export type SettingsTokenType = {
+  value: ValueSettingsOptionType;
+  token: string;
+  auth: string;
+  setting: EnableSettingsOptionType;
 };
 
 export function generateToken(form: any) {
@@ -13,7 +28,7 @@ export function generateToken(form: any) {
     .catch((error) => error.response);
 }
 
-export function manageToken(params: manageTokenType) {
+export function manageToken(params: ManageTokenType) {
   const url = '/api/manage';
   return axios
     .get(url, { params })
@@ -21,11 +36,19 @@ export function manageToken(params: manageTokenType) {
     .catch((error) => error.response);
 }
 
-export function downloadToken(params: manageTokenType) {
+export function downloadToken(params: ManageTokenType) {
   const url = '/api/download';
   console.log(params);
   return axios
     .get(url, { params })
+    .then((response) => response)
+    .catch((error) => error.response);
+}
+
+export function settingsToken(params: SettingsTokenType) {
+  const url = '/api/settings';
+  return axios
+    .post(url, params)
     .then((response) => response)
     .catch((error) => error.response);
 }

--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -65,8 +65,8 @@ async function fetchTokenData() {
   isLoading.value = true;
 
   const params = {
-    auth: route.params.auth,
-    token: route.params.token,
+    auth: route.params.auth as string,
+    token: route.params.token as string,
   };
 
   manageToken(params)

--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -73,7 +73,6 @@ async function fetchTokenData() {
       isLoading.value = false;
       manageTokenResponse.value = res.data as ManageTokenBackendType;
       tokenLogoUrl.value = `token_icons/${tokenServices[manageTokenResponse.value.canarydrop.type].icon}`;
-      console.log(manageTokenResponse.value, 'manageTokenResponse.value');
 
       loadComponent();
     })

--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -28,7 +28,7 @@
   </div>
   <div
     v-if="manageTokenResponse"
-    class="flex flex-col justify-center gap-32 p-16 md:p-32 md:mx-32 rounded-xl bg-grey-50 md:max-w-[50vw] w-full"
+    class="flex flex-col justify-center p-16 md:p-32 md:mx-32 rounded-xl bg-grey-50 md:max-w-[50vw] w-full"
   >
     <component
       :is="dynamicComponent"
@@ -36,6 +36,7 @@
     />
     <SettingsToken
       :tocken-backend-response="manageTokenResponse"
+      class="mt-32"
     ></SettingsToken>
   </div>
 </template>

--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -1,5 +1,19 @@
 <template>
   <div
+    v-if="manageTokenResponse"
+    class="flex flex-col items-center gap-8 mb-24"
+  >
+    <img
+      :src="getImageUrl(tokenLogoUrl)"
+      class="h-[4rem]"
+      aria-hidden="true"
+      :alt="`${tokenServices[manageTokenResponse.canarydrop.type].label} logo`"
+    />
+    <h2 class="text-xl text-center text-grey-800">
+      {{ tokenServices[manageTokenResponse.canarydrop.type].label }}
+    </h2>
+  </div>
+  <div
     v-if="isLoading"
     class="loading"
   >
@@ -12,11 +26,17 @@
   >
     {{ error }}
   </div>
-  <div v-if="manageTokenResponse">
+  <div
+    v-if="manageTokenResponse"
+    class="flex flex-col justify-center gap-32 p-16 md:p-32 md:mx-32 rounded-xl bg-grey-50 md:max-w-[50vw] w-full"
+  >
     <component
       :is="dynamicComponent"
       :tocken-backend-response="manageTokenResponse"
     />
+    <SettingsToken
+      :tocken-backend-response="manageTokenResponse"
+    ></SettingsToken>
   </div>
 </template>
 
@@ -24,12 +44,17 @@
 import { defineAsyncComponent, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { manageToken } from '@/api/main.ts';
+import SettingsToken from './SettingsToken.vue';
+import { tokenServices } from '@/utils/tokenServices';
+import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
+import getImageUrl from '@/utils/getImageUrl';
 
 const route = useRoute();
 
 const isLoading = ref(false);
 const error = ref(null);
 const manageTokenResponse = ref();
+const tokenLogoUrl = ref();
 
 const dynamicComponent = ref({
   props: {},
@@ -46,7 +71,9 @@ async function fetchTokenData() {
   manageToken(params)
     .then((res) => {
       isLoading.value = false;
-      manageTokenResponse.value = res.data;
+      manageTokenResponse.value = res.data as ManageTokenBackendType;
+      tokenLogoUrl.value = `token_icons/${tokenServices[manageTokenResponse.value.canarydrop.type].icon}`;
+      console.log(manageTokenResponse.value, 'manageTokenResponse.value');
 
       loadComponent();
     })
@@ -66,10 +93,6 @@ async function loadComponent() {
         `@/components/tokens/${manageTokenResponse.value?.canarydrop.type}/ManageToken.vue`
       )
   );
-  // dynamicComponent.value.props = {
-  //   tockenBackendResponse: token,
-  //   tokenSnippetData: tokenSnippetData.value,
-  // };
 }
 
 loadComponent();

--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -32,10 +32,10 @@
   >
     <component
       :is="dynamicComponent"
-      :tocken-backend-response="manageTokenResponse"
+      :token-backend-response="manageTokenResponse"
     />
     <SettingsToken
-      :tocken-backend-response="manageTokenResponse"
+      :token-backend-response="manageTokenResponse"
       class="mt-32"
     ></SettingsToken>
   </div>

--- a/frontend_vue/src/components/SettingsToken.vue
+++ b/frontend_vue/src/components/SettingsToken.vue
@@ -6,7 +6,7 @@
       v-model="enabledEmailAlert"
       label="Email alerts"
       :helper-message="tockenBackendResponse.canarydrop.alert_email_recipient"
-      @change="
+      @change.stop="
         handleChangeSetting(
           ENABLE_SETTINGS_TYPE.EMAIL as EnableSettingsOptionType,
           enabledEmailAlert
@@ -18,7 +18,7 @@
       id="webhook-alert"
       v-model="enabledWebhookAlert"
       label="Webhook reporting"
-      @change="
+      @change.stop="
         handleChangeSetting(
           ENABLE_SETTINGS_TYPE.WEB_HOOK as EnableSettingsOptionType,
           enabledWebhookAlert
@@ -31,7 +31,7 @@
       v-model="enabledBrowserScan"
       label="Browser scanner"
       helper-message="Runs Javascript fingerprinting when the token is browsed"
-      @change="
+      @change.stop="
         handleChangeSetting(
           ENABLE_SETTINGS_TYPE.BROWSER_SCANNER as EnableSettingsOptionType,
           enabledBrowserScan
@@ -41,10 +41,10 @@
     <BaseSwitch
       v-if="hasCustomImage"
       id="custom-image"
-      v-model="enabledBrowserScan"
+      v-model="enabledCustomImage"
       label="Custom web image"
       helper-message="Serve your alternative image"
-      @change="
+      @change.stop="
         handleChangeSetting(
           ENABLE_SETTINGS_TYPE.WEB_IMAGE as EnableSettingsOptionType,
           enabledCustomImage
@@ -120,8 +120,8 @@ function handleChangeSetting(
 ) {
   const params = {
     value: convertBooleanToValue(isSettingTypeEnabled),
-    token: '5fqcg2ps930ddbs4hqq1dis1l',
-    auth: 'ec884fe3b540e9caa1991c9be4e70a81',
+    token: props.tockenBackendResponse.canarydrop.canarytoken._value,
+    auth: props.tockenBackendResponse.canarydrop.auth,
     setting: settingType,
   };
 
@@ -131,7 +131,7 @@ function handleChangeSetting(
       console.log(err, 'error!');
     })
     .finally(() => {
-      console.log(params.setting, 'setting updated!');
+      console.log('setting updated!');
     });
 }
 </script>

--- a/frontend_vue/src/components/SettingsToken.vue
+++ b/frontend_vue/src/components/SettingsToken.vue
@@ -5,7 +5,7 @@
       id="email-alert"
       v-model="enabledEmailAlert"
       label="Email alerts"
-      :helper-message="tockenBackendResponse.canarydrop.alert_email_recipient"
+      :helper-message="tokenBackendResponse.canarydrop.alert_email_recipient"
       @change.stop="
         handleChangeSetting(
           ENABLE_SETTINGS_TYPE.EMAIL as EnableSettingsOptionType,
@@ -62,25 +62,25 @@ import type { SettingsTokenType, EnableSettingsOptionType } from '@/api/main';
 import { ENABLE_SETTINGS_TYPE, TOKENS_TYPE } from '@/components/constants';
 
 const props = defineProps<{
-  tockenBackendResponse: ManageTokenBackendType;
+  tokenBackendResponse: ManageTokenBackendType;
 }>();
 
 function isSupportBrowserScan() {
   return (
-    props.tockenBackendResponse.canarydrop.type === TOKENS_TYPE.WEB_BUG ||
-    props.tockenBackendResponse.canarydrop.type === TOKENS_TYPE.WEB_IMAGE
+    props.tokenBackendResponse.canarydrop.type === TOKENS_TYPE.WEB_BUG ||
+    props.tokenBackendResponse.canarydrop.type === TOKENS_TYPE.WEB_IMAGE
   );
 }
 
 function isSupportCustomImage() {
-  return props.tockenBackendResponse.canarydrop.type === TOKENS_TYPE.WEB_IMAGE;
+  return props.tokenBackendResponse.canarydrop.type === TOKENS_TYPE.WEB_IMAGE;
 }
 
 const hasEmailAlert = ref(
-  props.tockenBackendResponse.canarydrop.alert_email_recipient
+  props.tokenBackendResponse.canarydrop.alert_email_recipient
 );
 const hasWebhookAlert = ref(
-  props.tockenBackendResponse.canarydrop.alert_webhook_url
+  props.tokenBackendResponse.canarydrop.alert_webhook_url
 );
 const hasBrowserScan = ref(isSupportBrowserScan());
 const hasCustomImage = ref(isSupportCustomImage());
@@ -93,19 +93,19 @@ const enabledCustomImage = ref(false);
 onMounted(() => {
   enabledEmailAlert.value =
     (hasEmailAlert.value &&
-      props.tockenBackendResponse.canarydrop?.alert_email_enabled) ||
+      props.tokenBackendResponse.canarydrop?.alert_email_enabled) ||
     false;
   enabledWebhookAlert.value =
     (hasWebhookAlert.value &&
-      props.tockenBackendResponse.canarydrop?.alert_webhook_enabled) ||
+      props.tokenBackendResponse.canarydrop?.alert_webhook_enabled) ||
     false;
   enabledBrowserScan.value =
     (hasBrowserScan.value &&
-      props.tockenBackendResponse.canarydrop?.browser_scanner_enabled) ||
+      props.tokenBackendResponse.canarydrop?.browser_scanner_enabled) ||
     false;
   enabledCustomImage.value =
     (hasCustomImage.value &&
-      props.tockenBackendResponse.canarydrop?.web_image_enabled) ||
+      props.tokenBackendResponse.canarydrop?.web_image_enabled) ||
     false;
 });
 
@@ -120,8 +120,8 @@ function handleChangeSetting(
 ) {
   const params = {
     value: convertBooleanToValue(isSettingTypeEnabled),
-    token: props.tockenBackendResponse.canarydrop.canarytoken._value,
-    auth: props.tockenBackendResponse.canarydrop.auth,
+    token: props.tokenBackendResponse.canarydrop.canarytoken._value,
+    auth: props.tokenBackendResponse.canarydrop.auth,
     setting: settingType,
   };
 

--- a/frontend_vue/src/components/base/BaseSwitch.spec.ts
+++ b/frontend_vue/src/components/base/BaseSwitch.spec.ts
@@ -58,4 +58,34 @@ describe('BaseSwitch.vue', () => {
     const checkbox = wrapper.find('input[type="checkbox"]');
     expect(checkbox.attributes('disabled')).toBeDefined();
   });
+
+  it('displays error message when hasError is true', () => {
+    const label = 'Test Label';
+    const id = 'test-id';
+    const errorMessage = 'Error message';
+
+    const wrapper = mount(BaseSwitch, {
+      props: {
+        errorMessage,
+        label,
+        id,
+      },
+    });
+    expect(wrapper.text()).toContain(errorMessage);
+  });
+
+  it('displays helper message', () => {
+    const label = 'Test Label';
+    const id = 'test-id';
+    const helperMessage = 'Helper message';
+
+    const wrapper = mount(BaseSwitch, {
+      props: {
+        helperMessage,
+        label,
+        id,
+      },
+    });
+    expect(wrapper.text()).toContain(helperMessage);
+  });
 });

--- a/frontend_vue/src/components/base/BaseSwitch.vue
+++ b/frontend_vue/src/components/base/BaseSwitch.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vuejs-accessibility/label-has-for -->
 <template>
-  <div class="flex flex-col-reverse justify-between">
+  <div class="flex flex-col justify-between">
     <input
       v-bind="$attrs"
       :id="id"
@@ -11,7 +11,27 @@
       :checked="model"
       :aria-checked="model"
     />
-    <label :for="id">{{ label }}</label>
+    <label
+      :for="id"
+      :class="helperMessage && 'multiline'"
+      >{{ label }}</label
+    >
+    <div>
+      <p
+        v-show="helperMessage"
+        id="helper"
+        class="text-xs leading-4 text-grey-500 pr-[3rem]"
+      >
+        {{ helperMessage }}
+      </p>
+      <p
+        v-show="errorMessage"
+        id="error"
+        class="text-xs leading-4 text-red"
+      >
+        {{ errorMessage }}
+      </p>
+    </div>
   </div>
 </template>
 
@@ -19,6 +39,8 @@
 defineProps<{
   id: string;
   label: string;
+  helperMessage?: string | null;
+  errorMessage?: string;
 }>();
 
 const model = defineModel<boolean>();
@@ -49,6 +71,14 @@ label::before {
   background-color: hsl(0, 0%, 91%);
   border-radius: 1em;
   transition: background-color 200ms ease-in-out;
+}
+
+label.multiline::before {
+  top: 0.5rem;
+}
+
+label.multiline::after {
+  top: 0.75rem;
 }
 
 /* toggle ball */

--- a/frontend_vue/src/components/base/__snapshots__/BaseSwitch.spec.ts.snap
+++ b/frontend_vue/src/components/base/__snapshots__/BaseSwitch.spec.ts.snap
@@ -1,3 +1,10 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`BaseSwitch.vue > renders correctly 1`] = `"<div data-v-2a6ccf4b="" class="flex flex-col-reverse justify-between"><input data-v-2a6ccf4b="" id="test-id" type="checkbox" role="switch" class="toggle" aria-checked="false"><label data-v-2a6ccf4b="" for="test-id">Test Label</label></div>"`;
+exports[`BaseSwitch.vue > renders correctly 1`] = `
+"<div data-v-2a6ccf4b="" class="flex flex-col justify-between"><input data-v-2a6ccf4b="" id="test-id" type="checkbox" role="switch" class="toggle" aria-checked="false"><label data-v-2a6ccf4b="" for="test-id" class="">Test Label</label>
+  <div data-v-2a6ccf4b="">
+    <p data-v-2a6ccf4b="" id="helper" class="text-xs leading-4 text-grey-500 pr-[3rem]" style="display: none;"></p>
+    <p data-v-2a6ccf4b="" id="error" class="text-xs leading-4 text-red" style="display: none;"></p>
+  </div>
+</div>"
+`;

--- a/frontend_vue/src/components/constants.ts
+++ b/frontend_vue/src/components/constants.ts
@@ -16,4 +16,12 @@ export const TOKENS_TYPE = {
   CLONED_WEBSITE: 'clonedsite',
   QRCODE: 'qr_code',
   MYSQL: 'my_sql',
+  WEB_IMAGE: 'web_image',
+};
+
+export const ENABLE_SETTINGS_TYPE = {
+  EMAIL: 'email_enable',
+  WEB_HOOK: 'webhook_enable',
+  BROWSER_SCANNER: 'browser_scanner_enable',
+  WEB_IMAGE: 'web_image_enable',
 };

--- a/frontend_vue/src/components/constants.ts
+++ b/frontend_vue/src/components/constants.ts
@@ -19,6 +19,10 @@ export const TOKENS_TYPE = {
   WEB_IMAGE: 'web_image',
 };
 
+/*
+ENABLE_SETTINGS_TYPE values are coming from the backend
+*/
+
 export const ENABLE_SETTINGS_TYPE = {
   EMAIL: 'email_enable',
   WEB_HOOK: 'webhook_enable',

--- a/frontend_vue/src/components/icons/InfoIcon.vue
+++ b/frontend_vue/src/components/icons/InfoIcon.vue
@@ -18,4 +18,4 @@
   </svg>
 </template>
 
-<script lang="ts"></script>
+<script lang="ts" setup></script>

--- a/frontend_vue/src/components/tokens/dns/ActivatedToken.vue
+++ b/frontend_vue/src/components/tokens/dns/ActivatedToken.vue
@@ -15,10 +15,10 @@
 <script setup lang="ts">
 import { ref } from 'vue';
 import TokenDisplay from './TokenDisplay.vue';
-import type { NullableNewTokenBackendType } from '@/components/tokens/types';
+import type { NewTokenBackendType } from '@/components/tokens/types';
 
 const props = defineProps<{
-  tokenData: NullableNewTokenBackendType;
+  tokenData: NewTokenBackendType;
 }>();
 
 const tokenUrl = ref(props.tokenData.token_url);

--- a/frontend_vue/src/components/tokens/dns/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/dns/ManageToken.vue
@@ -1,5 +1,4 @@
 <template>
-  Your Token
   <div v-if="!tokenUrl">Error loading</div>
   <TokenDisplay
     v-else

--- a/frontend_vue/src/components/tokens/dns/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/dns/ManageToken.vue
@@ -12,8 +12,8 @@ import TokenDisplay from './TokenDisplay.vue';
 import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
 
 const props = defineProps<{
-  tockenBackendResponse: ManageTokenBackendType;
+  tokenBackendResponse: ManageTokenBackendType;
 }>();
 
-const tokenUrl = ref(props.tockenBackendResponse.canarydrop?.generated_url);
+const tokenUrl = ref(props.tokenBackendResponse.canarydrop?.generated_url);
 </script>

--- a/frontend_vue/src/components/tokens/my_sql/ActivatedToken.vue
+++ b/frontend_vue/src/components/tokens/my_sql/ActivatedToken.vue
@@ -24,8 +24,8 @@ const props = defineProps<{
 }>();
 
 const tokenSnippetData = ref({
-  code: props.tokenData.usage,
-  token: props.tokenData.token,
-  auth: props.tokenData.auth_token,
+  code: props.tokenData.usage || '',
+  token: props.tokenData.token || '',
+  auth: props.tokenData.auth_token || '',
 });
 </script>

--- a/frontend_vue/src/components/tokens/my_sql/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/my_sql/ManageToken.vue
@@ -1,8 +1,8 @@
 <template>
-  <div v-if="!tockenData">Error loading</div>
+  <div v-if="!tokenData">Error loading</div>
   <TokenDisplay
     v-else
-    :token-data="tockenData"
+    :token-data="tokenData"
   />
 </template>
 
@@ -13,12 +13,12 @@ import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
 import generateManagedToken from '@/components/tokens/my_sql/generateManagedToken';
 
 const props = defineProps<{
-  tockenBackendResponse: ManageTokenBackendType;
+  tokenBackendResponse: ManageTokenBackendType;
 }>();
 
-const tockenData = ref({
-  code: generateManagedToken(props.tockenBackendResponse),
-  token: props.tockenBackendResponse?.canarydrop?.canarytoken?._value,
-  auth: props.tockenBackendResponse.canarydrop?.auth as string,
+const tokenData = ref({
+  code: generateManagedToken(props.tokenBackendResponse),
+  token: props.tokenBackendResponse?.canarydrop?.canarytoken?._value,
+  auth: props.tokenBackendResponse.canarydrop?.auth as string,
 });
 </script>

--- a/frontend_vue/src/components/tokens/my_sql/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/my_sql/ManageToken.vue
@@ -1,5 +1,4 @@
 <template>
-  Your Token
   <div v-if="!tockenData">Error loading</div>
   <TokenDisplay
     v-else
@@ -20,6 +19,6 @@ const props = defineProps<{
 const tockenData = ref({
   code: generateManagedToken(props.tockenBackendResponse),
   token: props.tockenBackendResponse?.canarydrop?.canarytoken?._value,
-  auth: props.tockenBackendResponse.canarydrop?.auth,
+  auth: props.tockenBackendResponse.canarydrop?.auth as string,
 });
 </script>

--- a/frontend_vue/src/components/tokens/my_sql/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/my_sql/TokenDisplay.vue
@@ -41,8 +41,8 @@ const encoded = ref(false);
 function handleDownloadDumpFile() {
   const params = {
     fmt: 'my_sql',
-    auth: props.tokenData.auth,
-    token: props.tokenData.token,
+    auth: props.tokenData?.auth,
+    token: props.tokenData?.token,
     encoded: encoded.value,
   };
   downloadToken(params)

--- a/frontend_vue/src/components/tokens/my_sql/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/my_sql/TokenDisplay.vue
@@ -18,8 +18,8 @@
     v-model="encoded"
     class="mt-16"
     label="Encode Snippet"
+    helper-message="Encode snippet to make it harder to spot"
   ></base-switch>
-  <p class="text-sm">Encode snippet to make it harder to spot</p>
 </template>
 
 <script setup lang="ts">

--- a/frontend_vue/src/components/tokens/my_sql/generateManagedToken.ts
+++ b/frontend_vue/src/components/tokens/my_sql/generateManagedToken.ts
@@ -1,9 +1,9 @@
 // when Managing an existing MySQL token
 // we generate it on the frontend
 // by using 'auth code' and 'generated_hostname'
-import type { ManageTokenType } from '@/components/types.ts';
+import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
 
-export default function generateManagedToken(data: ManageTokenType) {
+export default function generateManagedToken(data: ManageTokenBackendType) {
   const hostname = data.canarydrop.generated_hostname;
   const token = data.canarydrop.canarytoken._value;
   const code = `SET @bb = CONCAT(\"CHANGE MASTER TO MASTER_PASSWORD='my-secret-pw', MASTER_RETRY_COUNT=1, MASTER_PORT=3306, MASTER_HOST='${hostname}', MASTER_USER='${token}\", @@lc_time_names, @@hostname, \"';\");`;

--- a/frontend_vue/src/components/tokens/qr_code/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/qr_code/ManageToken.vue
@@ -1,5 +1,5 @@
 <template>
-  <TokenDisplay :token-png="props.tockenBackendResponse.qr_code" />
+  <TokenDisplay :token-png="props.tokenBackendResponse.qr_code" />
 </template>
 
 <script lang="ts" setup>
@@ -7,6 +7,6 @@ import TokenDisplay from './TokenDisplay.vue';
 import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
 
 const props = defineProps<{
-  tockenBackendResponse: ManageTokenBackendType;
+  tokenBackendResponse: ManageTokenBackendType;
 }>();
 </script>

--- a/frontend_vue/src/components/tokens/qr_code/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/qr_code/ManageToken.vue
@@ -1,5 +1,4 @@
 <template>
-  Your Token
   <TokenDisplay :token-png="props.tockenBackendResponse.qr_code" />
 </template>
 

--- a/frontend_vue/src/components/tokens/types.ts
+++ b/frontend_vue/src/components/tokens/types.ts
@@ -74,7 +74,7 @@ export type NullableCanaryDropType = {
   [K in keyof CanaryDropType]: K extends 'canarytoken'
     ? CanaryTokenType
     : K extends 'auth'
-      ? string
+      ? string | boolean
       : CanaryDropType[K] | null;
 };
 

--- a/frontend_vue/src/components/tokens/web/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/web/ManageToken.vue
@@ -1,5 +1,4 @@
 <template>
-  Your Token
   <div v-if="!tokenUrl">Error loading</div>
   <TokenDisplay
     v-else

--- a/frontend_vue/src/components/tokens/web/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/web/ManageToken.vue
@@ -12,8 +12,8 @@ import TokenDisplay from './TokenDisplay.vue';
 import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
 
 const props = defineProps<{
-  tockenBackendResponse: ManageTokenBackendType;
+  tokenBackendResponse: ManageTokenBackendType;
 }>();
 
-const tokenUrl = ref(props.tockenBackendResponse.canarydrop?.generated_url);
+const tokenUrl = ref(props.tokenBackendResponse.canarydrop?.generated_url);
 </script>

--- a/frontend_vue/src/layout/AppLayout.vue
+++ b/frontend_vue/src/layout/AppLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <main class="flex items-center justify-center main-height bg-grey-50">
     <div
-      class="max-w-[70svw] m-24 md:mx-[10svw] bg-white rounded-lg shadow-lg shadow-grey-200/40 min-h-[50vh] p-24 flex-auto"
+      class="max-w-[90svw] md:max-w-[70svw] m-24 md:mx-[10svw] bg-white rounded-lg shadow-lg shadow-grey-200/40 min-h-[50vh] p-24 flex-auto"
     >
       <h1 class="text-grey-800">{{ title }}</h1>
       <slot></slot>

--- a/frontend_vue/src/layout/AppLayoutOneColumn.vue
+++ b/frontend_vue/src/layout/AppLayoutOneColumn.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="flex flex-col items-center">
     <slot></slot>
   </div>
 </template>


### PR DESCRIPTION
## Proposed changes

Add Setting manager for an existing token.
The following settings are available:
<img width="595" alt="Screenshot 2024-04-09 at 11 19 51" src="https://github.com/thinkst/canarytokens/assets/126554007/41615c24-e3c6-4fd9-ac39-2674c0145dc2">

The logic for showing email alerts and browser alert, is coming from the backend
Browser scan is available only for Web-bug and Web-image tokens
Custom image is available only for Web-image

<img width="1012" alt="Screenshot 2024-04-09 at 11 25 11" src="https://github.com/thinkst/canarytokens/assets/126554007/32af467c-abea-411e-8e14-46fc91125106">
<img width="318" alt="Screenshot 2024-04-09 at 11 25 18" src="https://github.com/thinkst/canarytokens/assets/126554007/7d3cf9c0-1f2a-4f71-b5cd-61319a8683c4">
