### PR TITLE
Prevent indexing of history and download pages

### DIFF
--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -2308,6 +2308,7 @@ class TokenDownloadResponse(Response):
         headers = {
             "Content-Type": __pydantic_self__.contenttype,
             "Content-Disposition": f"attachment; filename={file_name}",
+            "X-Robots-Tag": "noindex",
         }
 
         super().__init__(content=content, headers=headers)

--- a/templates/history.html
+++ b/templates/history.html
@@ -12,6 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">
     <meta name="author" content="">
+    <meta name="robots" content="noindex">
     <link rel="shortcut icon" href="/resources/favicon.ico">
     <link rel="stylesheet" type="text/css" href="/resources/famfamfam-flags.css" >
 


### PR DESCRIPTION
## Proposed changes

Prevent search engines from indexing the history and download pages using [noindex](https://developers.google.com/search/docs/crawling-indexing/block-indexing) instead of `robots.txt` since that's the currently recommended approach.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion