### PR TITLE
Disable API docs by default

### DIFF
--- a/canarytokens/settings.py
+++ b/canarytokens/settings.py
@@ -88,6 +88,9 @@ class FrontendSettings(BaseSettings):
     STATIC_FILES_APPLICATION_SUB_PATH: str = "/resources"
     STATIC_FILES_APPLICATION_INTERNAL_NAME: str = "resources"
 
+    # if None the API docs won't load. Loads at /API_HASH/{your_url}. Must start with a /
+    API_REDOC_URL: Optional[str]
+
     # upload settings
     MAX_UPLOAD_SIZE: int = 1024 * 1024 * 1
     WEB_IMAGE_UPLOAD_PATH: str = "/uploads"

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -210,6 +210,8 @@ api = FastAPI(
     version=canarytokens.__version__,
     openapi_prefix=ROOT_API_ENDPOINT,
     openapi_tags=tags_metadata,
+    docs_url=None,  # should be None on prod
+    redoc_url=frontend_settings.API_REDOC_URL,  # should default to None on prod
 )
 
 app.mount(ROOT_API_ENDPOINT, api)


### PR DESCRIPTION
By default we were serving the API documentation. We shouldn't do this by default incase folks get the impression we are supported this as an external API. We aren't.

## Proposed changes

Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

If it fixes a bug be sure to link to that issue.
If it resolves a feature request, be sure to link to that discussion.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...