### PR TITLE
Allow /manage and /history endpoints in UI refresh to be loaded directly

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -198,7 +198,9 @@ app = FastAPI(
 vue_index = Jinja2Templates(directory="../frontend_vue/dist/")
 
 
-@app.get("/components")
+@app.get("/newuiwhodis/components")
+@app.get("/newuiwhodis/manage/{rest_of_path:path}")
+@app.get("/newuiwhodis/history/{rest_of_path:path}")
 def index(request: Request):
     return vue_index.TemplateResponse("index.html", {"request": request})
 


### PR DESCRIPTION
Since the new UI app is a Vue single-page app we need to load the app first which then handles the routing.

This diff makes sure when we hit these endpoints we load the app.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...