### PR TITLE
fix scroll on modal

### DIFF
--- a/frontend_vue/src/components/base/BaseModal.vue
+++ b/frontend_vue/src/components/base/BaseModal.vue
@@ -1,54 +1,65 @@
+<!-- eslint-disable vuejs-accessibility/no-static-element-interactions -->
+<!-- eslint-disable vuejs-accessibility/click-events-have-key-events -->
 <template>
   <!-- @vue-expect-error content-transition ts error -->
   <VueFinalModal
-    class="flex items-center justify-center modal h-[100svh] overflow-scroll"
     overlay-class="blur-bg"
-    content-class="bg-grey-50 rounded-xl text-grey-800 md:w-[60vw] mx-16 "
+    conten-class="absolute inset-[0px]"
     overlay-transition="vfm-fade"
     :content-transition="modalCustomTransition"
-    esc-to-close
     @update:model-value="(val) => emit('update:modelValue', val)"
   >
-    <!-- header -->
-    <div class="relative pt-32 pb-16 bg-white rounded-t-lg header">
-      <button
-        v-if="hasBackButton"
-        type="button"
-        class="absolute top-[40px] left-[30px]"
-        @click="emit('handleBackButton', false)"
-      >
-        <font-awesome-icon
-          icon="angle-left"
-          class="w-6 h-6 hover:text-grey-400"
-        />
-      </button>
-      <h1 class="text-2xl font-semibold text-center">
-        {{ title }}
-      </h1>
-      <button
-        type="button"
-        class="absolute top-[20px] right-[30px]"
-        @click="emit('update:modelValue', false)"
-      >
-        <font-awesome-icon
-          icon="xmark"
-          class="w-6 h-6 hover:text-grey-400"
-        />
-      </button>
-    </div>
-
-    <!-- content -->
     <div
-      class="flex flex-col items-center justify-center px-32 py-16 rounded-b-lg bg-grey-50 text-grey-800"
+      class="absolute inset-[0px] h-full overflow-auto"
+      @click.self="() => emit('update:modelValue', false)"
     >
-      <slot></slot>
-    </div>
+      <div class="md:w-[60vw] my-16 mx-auto bg-white rounded-lg max-w-[90vw]">
+        <!-- header -->
+        <div class="relative pt-32 pb-16 bg-white rounded-t-lg header">
+          <button
+            v-if="hasBackButton"
+            type="button"
+            class="absolute top-[40px] left-[30px]"
+            @click="emit('handleBackButton', false)"
+          >
+            <font-awesome-icon
+              icon="angle-left"
+              class="w-6 h-6 hover:text-grey-400"
+              aria-hidden="true"
+            />
+            <span class="fa-sr-only">Back</span>
+          </button>
+          <h1 class="text-2xl font-semibold text-center">
+            {{ title }}
+          </h1>
+          <button
+            type="button"
+            class="absolute top-[20px] right-[30px]"
+            @click="emit('update:modelValue', false)"
+          >
+            <font-awesome-icon
+              icon="xmark"
+              class="w-6 h-6 hover:text-grey-400"
+              aria-hidden="true"
+            />
+            <span class="fa-sr-only">Close</span>
+          </button>
+        </div>
 
-    <!-- footer -->
-    <div
-      class="flex items-center justify-center gap-8 py-24 mt-16 text-center bg-white rounded-b-lg"
-    >
-      <slot name="footer"></slot>
+        <!-- content -->
+        <div
+          class="flex flex-col items-center justify-center px-32 py-16 bg-grey-50 text-grey-800"
+        >
+          <slot></slot>
+        </div>
+
+        <!-- footer -->
+        <div
+          class="flex items-center justify-center gap-8 py-24 bg-white rounded-b-lg mb-16text-center"
+        >
+          <slot name="footer"></slot>
+        </div>
+      </div>
     </div>
   </VueFinalModal>
 </template>


### PR DESCRIPTION
## Proposed changes

Fix the scroll on Modals when the content exceeds the page view
https://github.com/thinkst/canarytokens/assets/126554007/a32564f8-b9ba-4833-8ae8-51b2c2aacd0b

Note: there are some comments at the beginning of the files for disabling a11y errors.
ESLint is crying because of the click event on the outer div in the modal. 
This click event allows users to exit the modal by clicking the background.
The background is not a button or semantically meaningful element for screen-readers.
The issue should be minimal, as I added a proper label for the close button on top right


