### PR TITLE
Fix header, Card Token, Carousel info, add Icons to Settings 

### DIFF
--- a/frontend_vue/src/components/base/BaseGenerateTokenSettings.vue
+++ b/frontend_vue/src/components/base/BaseGenerateTokenSettings.vue
@@ -2,7 +2,14 @@
   <div
     class="relative border flex-1 group flex flex-col px-16 sm:px-24 pt-16 pb-24 bg-white rounded-xl top-[0px] shadow-solid-shadow-grey border-grey-200"
   >
-    <h3 class="mb-16 text-sm font-semibold text-left text-grey-400">
+    <h3
+      class="flex flex-row gap-8 mb-16 text-sm font-semibold text-left text-grey-400"
+    >
+      <font-awesome-icon
+        :icon="icon"
+        class="pt-4 text-grey-300"
+        aria-hidden="true"
+      ></font-awesome-icon>
       {{ settingType }} Settings
     </h3>
     <slot></slot>
@@ -10,7 +17,25 @@
 </template>
 
 <script setup lang="ts">
-defineProps<{
-  settingType: 'Canarytoken' | 'Notifications';
+import { computed } from 'vue';
+
+enum settingTypeEnum {
+  Canarytoken = 'Canarytoken',
+  Notifications = 'Notifications',
+}
+
+const props = defineProps<{
+  settingType: settingTypeEnum.Canarytoken | settingTypeEnum.Notifications;
 }>();
+
+const icon = computed(() => {
+  switch (props.settingType) {
+    case settingTypeEnum.Canarytoken:
+      return 'gear';
+    case settingTypeEnum.Notifications:
+      return 'bell';
+    default:
+      return 'gear';
+  }
+});
 </script>

--- a/frontend_vue/src/components/ui/AppNavbar.vue
+++ b/frontend_vue/src/components/ui/AppNavbar.vue
@@ -1,34 +1,36 @@
 <template>
-  <div class="z-50 flex justify-between gap-24">
-    <AppLogo class="px-32 py-24" />
-    <nav
-      role="navigation"
-      class="items-center justify-end hidden w-full pr-32 md:flex"
-    >
-      <ul
-        class="flex items-end pt-8 text-sm uppercase gap-x-24 lg:gap-x-32 font-regular"
+  <div class="z-50 flex justify-between w-full gap-24 sm:justify-center">
+    <div class="flex flex-row lg:w-[80vw] sm:w-full">
+      <AppLogo class="px-32 py-24" />
+      <nav
+        role="navigation"
+        class="items-center justify-end hidden w-full pr-32 md:flex"
       >
-        <li
-          v-for="item in menuItems"
-          :key="item.name"
+        <ul
+          class="flex items-end pt-8 text-sm uppercase gap-x-24 lg:gap-x-32 font-regular"
         >
-          <RouterLink
-            :to="item.path"
-            class="text-grey-400 hover:text-green desktop-link"
+          <li
+            v-for="item in menuItems"
+            :key="item.name"
           >
-            {{ item.name }}
-          </RouterLink>
-        </li>
-        <li class="cursor-pointer text-grey-400 hover:text-green">
-          <a href="#">
-            <font-awesome-icon
-              icon="link"
-              class="w-[0.8rem] pr-8"
-            />Documentation
-          </a>
-        </li>
-      </ul>
-    </nav>
+            <RouterLink
+              :to="item.path"
+              class="text-grey-400 hover:text-green desktop-link"
+            >
+              {{ item.name }}
+            </RouterLink>
+          </li>
+          <li class="cursor-pointer text-grey-400 hover:text-green">
+            <a href="#">
+              <font-awesome-icon
+                icon="link"
+                class="w-[0.8rem] pr-8"
+              />Documentation
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
     <AppNavbarMenuMobile
       :menu-items="menuItems"
       class="w-full"

--- a/frontend_vue/src/components/ui/CardToken.vue
+++ b/frontend_vue/src/components/ui/CardToken.vue
@@ -1,7 +1,7 @@
 <template>
   <li class="relative flex">
     <button
-      class="relative border flex-1 group flex flex-col px-24 py-32 bg-white rounded-xl top-[0px] shadow-solid-shadow-grey-sm border-grey-200 items-center duration-100 ease-in-out token-card"
+      class="relative border flex-1 group flex flex-col px-16 pt-16 pb-24 bg-white rounded-xl top-[0px] shadow-solid-shadow-grey-sm border-grey-200 items-center duration-100 ease-in-out token-card"
       @click.stop="handleClickToken"
     >
       <div v-if="isLoading">
@@ -17,10 +17,14 @@
         aria-hidden="true"
         :alt="`${title} logo`"
       />
-      <span class="py-16 font-semibold leading-5 text-center text-grey-800">
+      <span
+        class="flex-grow py-16 font-semibold leading-5 text-center text-grey-800"
+      >
         {{ title }}
       </span>
-      <span class="text-sm leading-5 text-center text-grey-400 text-pretty">
+      <span
+        class="flex-grow text-sm leading-5 text-center text-grey-400 text-pretty"
+      >
         {{ description }}
       </span>
       <span

--- a/frontend_vue/src/components/ui/CarouselInfoToken.vue
+++ b/frontend_vue/src/components/ui/CarouselInfoToken.vue
@@ -72,7 +72,7 @@ function calculateActiveSlide(sliderView: Element) {
     ? sliderView.getBoundingClientRect().width
     : 0;
 
-  // Hack: adding 1px to sliderView.scrollLeft fix issue on slideIndex calculation
+  // Hack: adding 10px to sliderView.scrollLeft fix issue on slideIndex calculation
   const scrollPosition = sliderView?.scrollLeft + 10 || 0;
   const slideIndex = Math.floor(scrollPosition / singleSlideWidth);
 

--- a/frontend_vue/src/components/ui/CarouselInfoToken.vue
+++ b/frontend_vue/src/components/ui/CarouselInfoToken.vue
@@ -5,7 +5,9 @@
       :link="tokenServices[props.selectedToken].documentationLink"
     />
   </h3>
-  <div class="relative w-full h-[12svh] md:w-[90%] lg:w-[70%] carousel">
+  <div
+    class="relative w-full sm:h-[100px] h-[110px] md:w-[90%] lg:w-[70%] carousel"
+  >
     <ul class="flex flex-row mx-8 carousel__slides-container">
       <li
         v-for="(slide, index) in slideContent"
@@ -18,7 +20,7 @@
           :src="getImageUrl(`icons/carousel_${index + 1}.png`)"
           alt="icon"
           aria-hidden="true"
-          class="h-[5rem] -translate-y-8"
+          class="h-[6rem] sm:h-[5rem] -translate-y-8 sm:ml-16 ml-8"
         />
         <span class="carousel__slide__snapper"></span>
         <p class="px-16 text-sm text-left text-grey-400 text-pretty">
@@ -71,7 +73,7 @@ function calculateActiveSlide(sliderView: Element) {
     : 0;
 
   // Hack: adding 1px to sliderView.scrollLeft fix issue on slideIndex calculation
-  const scrollPosition = sliderView?.scrollLeft + 1 || 0;
+  const scrollPosition = sliderView?.scrollLeft + 10 || 0;
   const slideIndex = Math.floor(scrollPosition / singleSlideWidth);
 
   currentSlide.value = slideIndex + 1;

--- a/frontend_vue/src/main.ts
+++ b/frontend_vue/src/main.ts
@@ -22,6 +22,8 @@ import {
   faChevronUp,
   faPlus,
   faMinus,
+  faBell,
+  faGear,
 } from '@fortawesome/free-solid-svg-icons';
 import { createVfm } from 'vue-final-modal';
 import { vTooltip } from 'floating-vue';
@@ -52,7 +54,9 @@ library.add(
   faArrowDown,
   faChevronUp,
   faPlus,
-  faMinus
+  faMinus,
+  faBell,
+  faGear
 );
 
 const vfm = createVfm();


### PR DESCRIPTION
## Proposed changes

Add max width to navbar for large screens ( keep the size for smaller screen )
<img width="989" alt="Screenshot 2024-05-14 at 15 24 41" src="https://github.com/thinkst/canarytokens/assets/126554007/d0f3256f-ba7a-4050-b91e-53be891ae0f2">
<img width="989" alt="Screenshot 2024-05-14 at 16 48 55" src="https://github.com/thinkst/canarytokens/assets/126554007/2e465f97-519c-4e4a-9c58-843dcaeaa7c6">

Fix Card token size by reducing paddings + fix alignments
<img width="907" alt="Screenshot 2024-05-14 at 16 49 46" src="https://github.com/thinkst/canarytokens/assets/126554007/887c0efe-5021-4b54-90a7-300a4310d49c">
<img width="877" alt="Screenshot 2024-05-14 at 16 49 29" src="https://github.com/thinkst/canarytokens/assets/126554007/bdc91e4c-8154-480d-936b-ad3e3929ac73">

Fix Carousel padding/margins
<img width="1183" alt="Screenshot 2024-05-14 at 16 50 52" src="https://github.com/thinkst/canarytokens/assets/126554007/a17c4fe6-b63a-486e-9ad2-9a0dbd4f4308">
<img width="702" alt="Screenshot 2024-05-14 at 16 50 27" src="https://github.com/thinkst/canarytokens/assets/126554007/ede0cc2e-7de1-4aa7-8031-0c98116c45dc">

Add icons to Settings
<img width="630" alt="Screenshot 2024-05-14 at 16 51 37" src="https://github.com/thinkst/canarytokens/assets/126554007/2cd861c0-6471-4623-9269-dbc2b17a390e">
<img width="386" alt="Screenshot 2024-05-14 at 16 51 50" src="https://github.com/thinkst/canarytokens/assets/126554007/94f04537-808f-45bb-9768-05656b3c2839">
