### PR TITLE
Fix code snippet 

### DIFF
--- a/frontend_vue/src/components/base/BaseCodeSnippet.spec.ts
+++ b/frontend_vue/src/components/base/BaseCodeSnippet.spec.ts
@@ -15,6 +15,35 @@ const tooltip = vi.fn();
 library.add(faRotateRight, faCheck, faCopy);
 
 describe('BaseCodeSnippet', () => {
+  it('renders label when passed', () => {
+    const label = 'Test Label';
+    const wrapper = mount(BaseCodeSnippet, {
+      props: { label },
+    });
+    expect(wrapper.text()).toMatch(label);
+  });
+
+  it('toggles showAllCode when handleShowAllSnippet is called', async () => {
+    const wrapper = mount(BaseCodeSnippet);
+    expect(wrapper.vm.showAllCode).toBe(false);
+    await wrapper.vm.handleShowAllSnippet();
+    expect(wrapper.vm.showAllCode).toBe(true);
+  });
+
+  it('renders expand button when showExpandButton is true', () => {
+    const wrapper = mount(BaseCodeSnippet, {
+      props: { showExpandButton: true },
+    });
+    expect(wrapper.find('button').isVisible()).toBe(true);
+  });
+
+  it('does not render expand button when showExpandButton is false', () => {
+    const wrapper = mount(BaseCodeSnippet, {
+      props: { showExpandButton: false },
+    });
+    expect(wrapper.find('show-all-button').exists()).toBe(false);
+  });
+
   it('emits "refresh-token" event when refresh button is clicked', async () => {
     const code = 'const example = () => { return "Hello World"; }';
     const wrapper = mount(BaseCodeSnippet, {

--- a/frontend_vue/src/components/base/BaseCodeSnippet.spec.ts
+++ b/frontend_vue/src/components/base/BaseCodeSnippet.spec.ts
@@ -17,29 +17,55 @@ library.add(faRotateRight, faCheck, faCopy);
 describe('BaseCodeSnippet', () => {
   it('renders label when passed', () => {
     const label = 'Test Label';
+    const code = 'const example = () => { return "Hello World"; }';
     const wrapper = mount(BaseCodeSnippet, {
-      props: { label },
+      props: {
+        code: code,
+        lang: 'javascript',
+        showExpandButton: false,
+      },
+      global: {
+        stubs: { BaseCopyButton, BaseRefreshButton, FontAwesomeIcon },
+      },
+      directives: {
+        tooltip,
+      },
     });
     expect(wrapper.text()).toMatch(label);
   });
 
-  it('toggles showAllCode when handleShowAllSnippet is called', async () => {
-    const wrapper = mount(BaseCodeSnippet);
-    expect(wrapper.vm.showAllCode).toBe(false);
-    await wrapper.vm.handleShowAllSnippet();
-    expect(wrapper.vm.showAllCode).toBe(true);
-  });
-
   it('renders expand button when showExpandButton is true', () => {
+    const code = 'const example = () => { return "Hello World"; }';
     const wrapper = mount(BaseCodeSnippet, {
-      props: { showExpandButton: true },
+      props: {
+        code: code,
+        lang: 'javascript',
+        showExpandButton: false,
+      },
+      global: {
+        stubs: { BaseCopyButton, BaseRefreshButton, FontAwesomeIcon },
+      },
+      directives: {
+        tooltip,
+      },
     });
     expect(wrapper.find('button').isVisible()).toBe(true);
   });
 
   it('does not render expand button when showExpandButton is false', () => {
+    const code = 'const example = () => { return "Hello World"; }';
     const wrapper = mount(BaseCodeSnippet, {
-      props: { showExpandButton: false },
+      props: {
+        code: code,
+        lang: 'javascript',
+        showExpandButton: false,
+      },
+      global: {
+        stubs: { BaseCopyButton, BaseRefreshButton, FontAwesomeIcon },
+      },
+      directives: {
+        tooltip,
+      },
     });
     expect(wrapper.find('show-all-button').exists()).toBe(false);
   });

--- a/frontend_vue/src/components/base/BaseCodeSnippet.vue
+++ b/frontend_vue/src/components/base/BaseCodeSnippet.vue
@@ -10,6 +10,7 @@
     <div class="relative bg-white border rounded-lg border-grey-100">
       <button
         v-if="showExpandButton"
+        id="show-all-button"
         class="absolute w-[6rem] top-16 left-16 px-8 z-10 font-semibold text-green-600 bg-white border border-green-200 refresh-token rounded-xl hover:bg-green-50 hover:text-green-500 focus:text-green-500 focus-visible:outline-0 focus:bg-green-100 focus:border-green-200 focus:outline-0"
         @click="handleShowAllSnippet"
       >

--- a/frontend_vue/src/components/base/BaseCodeSnippet.vue
+++ b/frontend_vue/src/components/base/BaseCodeSnippet.vue
@@ -8,55 +8,73 @@
     >
 
     <div class="relative bg-white border rounded-lg border-grey-100">
+      <button
+        v-if="showExpandButton"
+        class="absolute w-[6rem] top-16 left-16 px-8 z-10 font-semibold text-green-600 bg-white border border-green-200 refresh-token rounded-xl hover:bg-green-50 hover:text-green-500 focus:text-green-500 focus-visible:outline-0 focus:bg-green-100 focus:border-green-200 focus:outline-0"
+        @click="handleShowAllSnippet"
+      >
+        {{ showAllCode ? 'Show less' : 'Show all' }}
+      </button>
       <div class="absolute top-[.8rem] right-[1rem] z-10 flex gap-8">
         <BaseRefreshButton
           v-if="hasRefresh"
           @refresh-token="handleRefreshToken"
         />
-        <BaseCopyButton :content="code" />
+        <BaseCopyButton
+          :content="code"
+          class="ring-white ring-4"
+        />
       </div>
       <VCodeBlock
         :id="label"
         :code="code"
         highlightjs
+        :height="componentHeight"
         :lang="lang"
         theme="github"
-        :height="multiline ? customHeight : '3.5rem'"
         :copy-button="false"
-        :class="[
-          { 'pr-[3rem]': !multiline && hasRefresh },
-          { 'pr-[2rem]': !multiline && !hasRefresh },
-        ]"
       />
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from 'vue';
 import VCodeBlock from '@wdns/vue-code-block';
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     code: string;
     lang: string;
-    multiline?: boolean;
     hasRefresh?: boolean;
     hasCopy?: boolean;
+    showExpandButton?: boolean;
     customHeight?: string;
     label?: string | null;
   }>(),
   {
-    multiline: false,
     hasRefresh: false,
     hasCopy: true,
-    customHeight: '250px',
+    customHeight: null,
     label: null,
   }
 );
 
 const emits = defineEmits(['refresh-token']);
+const showAllCode = ref(false);
+
+const componentHeight = computed(() => {
+  if (props.customHeight && !props.showExpandButton) {
+    return props.customHeight;
+  }
+  return showAllCode.value ? 'auto' : props.customHeight;
+});
 
 function handleRefreshToken() {
   emits('refresh-token');
+}
+
+function handleShowAllSnippet() {
+  showAllCode.value = !showAllCode.value;
 }
 </script>

--- a/frontend_vue/src/components/base/BaseCodeSnippet.vue
+++ b/frontend_vue/src/components/base/BaseCodeSnippet.vue
@@ -56,8 +56,9 @@ const props = withDefaults(
   {
     hasRefresh: false,
     hasCopy: true,
-    customHeight: null,
+    customHeight: 'auto',
     label: null,
+    showExpandButton: false,
   }
 );
 

--- a/frontend_vue/src/components/tokens/aws_keys/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/aws_keys/TokenDisplay.vue
@@ -3,8 +3,6 @@
     lang="javascript"
     label="AWS token"
     :code="AWSKeyCode"
-    multiline
-    custom-height="10rem"
   ></base-code-snippet>
 </template>
 

--- a/frontend_vue/src/components/tokens/azure_id/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/azure_id/TokenDisplay.vue
@@ -3,8 +3,6 @@
     lang="json"
     label="JSON config"
     :code="CertificateTokenCode"
-    multiline
-    custom-height="13rem"
   ></base-code-snippet>
   <base-button
     class="mt-16"

--- a/frontend_vue/src/components/tokens/clonedsite/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/clonedsite/TokenDisplay.vue
@@ -5,8 +5,6 @@ we need to fix this dependency to show the obfuscated code
   <base-code-snippet
     lang="javascript"
     label="Your tokened Javascript"
-    multiline
-    custom-height="8rem"
     :code="codeClonedSite"
   >
   </base-code-snippet>

--- a/frontend_vue/src/components/tokens/cmd/ActivatedToken.vue
+++ b/frontend_vue/src/components/tokens/cmd/ActivatedToken.vue
@@ -21,8 +21,6 @@
     class="mt-16"
     lang="bash"
     :code="recommendedReg"
-    custom-height="5rem"
-    multiline
   ></BaseCodeSnippet>
 </template>
 

--- a/frontend_vue/src/components/tokens/cssclonedsite/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/cssclonedsite/TokenDisplay.vue
@@ -3,8 +3,6 @@
     lang="css"
     label="CSS token"
     :code="tokenSnippet"
-    multiline
-    custom-height="8rem"
   ></base-code-snippet>
 </template>
 

--- a/frontend_vue/src/components/tokens/my_sql/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/my_sql/TokenDisplay.vue
@@ -3,8 +3,6 @@
   <base-code-snippet
     lang="sql"
     label="Your MYSQL code"
-    multiline
-    custom-height="5rem"
     :code="codeMYSQL"
   ></base-code-snippet>
   <p class="mt-32">

--- a/frontend_vue/src/components/tokens/sql_server/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/sql_server/TokenDisplay.vue
@@ -3,8 +3,8 @@
     lang="sql"
     label="Microsoft Server SQL token"
     :code="snippetCode"
-    multiline
     custom-height="10rem"
+    show-expand-button
   ></base-code-snippet>
 </template>
 

--- a/frontend_vue/src/components/tokens/wireguard/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/wireguard/TokenDisplay.vue
@@ -11,8 +11,6 @@
     lang="bash"
     label="WireGuard VPN config"
     :code="codeSnippet"
-    multiline
-    custom-height="10rem"
   ></base-code-snippet>
 </template>
 


### PR DESCRIPTION
## Proposed changes

There is a bit of shuffling on the props for the BaseSnippet component
- removes multiline prop
- adds a 'show expand button' prop, in case the snippet is too long and we want to enclose it in a custom-height component
- add height 'auto' to all Code snippets, when no custom height is specified

There's a small difference now with the copy button: on single line code, I removed the padding right from the input.
This image shows the difference.
Users can see the code flowing behind the copy button.
I think it's not that ugly after all and allows us to eliminate the multiline prop.
 However, I added an outline to the button, to give it some room.

<img width="604" alt="Screenshot 2024-05-15 at 16 23 30" src="https://github.com/thinkst/canarytokens/assets/126554007/d596b8c2-1de0-4b8b-96f0-c31fcadcc1e4">
<img width="613" alt="Screenshot 2024-05-15 at 16 42 20" src="https://github.com/thinkst/canarytokens/assets/126554007/dd6ee6ab-de1e-42a2-969a-babe9c09c331">

'Show all' and 'Show less' buttons
<img width="769" alt="Screenshot 2024-05-15 at 16 24 04" src="https://github.com/thinkst/canarytokens/assets/126554007/f134004d-a322-4d7a-af6d-0fdbbbc0d200">
<img width="785" alt="Screenshot 2024-05-15 at 16 24 14" src="https://github.com/thinkst/canarytokens/assets/126554007/1c4078ed-6b1f-4b58-8ac2-25ca9827e510">

Other code snippets with auto height

<img width="684" alt="Screenshot 2024-05-15 at 16 23 10" src="https://github.com/thinkst/canarytokens/assets/126554007/6badb548-427b-4abd-bfee-eba65475d0d4">
<img width="515" alt="Screenshot 2024-05-15 at 16 23 24" src="https://github.com/thinkst/canarytokens/assets/126554007/c209cd07-e4f3-4e7b-a371-64f4c9a84233">

---------------
Note of this code delivery: I couldn't access the height of the code node inside VCodeBlock. 
I would have liked to show the expand button automatically if custom height < code height.
I'm not sure what's going on exactly in the VCodeBlock, but we need this button in only a few cases (just one so far) so I'd rather spend my life on something else 🥲