### PR TITLE
Return Google Maps API key + canarydrop from new history endpoint

### DIFF
--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -2544,3 +2544,9 @@ class ManageResponse(BaseModel):
     wg_qr_code: Optional[str]
     qr_code: Optional[str]
     force_https: Optional[bool]
+
+
+class HistoryResponse(BaseModel):
+    canarydrop: Dict
+    history: AnyTokenHistory
+    google_api_key: Optional[str]

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -43,7 +43,6 @@ from canarytokens.exceptions import CanarydropAuthFailure
 from canarytokens.models import (
     AnyDownloadRequest,
     AnySettingsRequest,
-    AnyTokenHistory,
     AnyTokenRequest,
     AnyTokenResponse,
     AWSKeyTokenRequest,
@@ -98,6 +97,7 @@ from canarytokens.models import (
     DownloadZipResponse,
     FastRedirectTokenRequest,
     FastRedirectTokenResponse,
+    HistoryResponse,
     KubeconfigTokenRequest,
     KubeconfigTokenResponse,
     Log4ShellTokenRequest,
@@ -780,11 +780,16 @@ async def api_manage_canarytoken(token: str, auth: str) -> ManageResponse:
 @api.get(
     "/history",
     tags=["Canarytokens History"],
-    response_model=AnyTokenHistory,
+    response_model=HistoryResponse,
 )
 async def api_history(token: str, auth: str) -> JSONResponse:
     canarydrop = get_canarydrop_and_authenticate(token=token, auth=auth)
-    return canarydrop.triggered_details
+    response = {
+        "canarydrop": canarydrop,
+        "history": canarydrop.triggered_details,
+        "google_api_key": queries.get_canary_google_api_key(),
+    }
+    return HistoryResponse(**response)
 
 
 @api.post(


### PR DESCRIPTION
## Proposed changes

We forgot to return the Maps API key with the rest of the history data. Currently the Google maps integration doesn't work. This change also returns the canarydrop so we can display the name of the token etc.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...