### PR TITLE
Fix cloned site obfuscateToken

### DIFF
--- a/frontend_vue/src/components/base/BaseCodeSnippet.vue
+++ b/frontend_vue/src/components/base/BaseCodeSnippet.vue
@@ -11,7 +11,7 @@
       <button
         v-if="showExpandButton"
         id="show-all-button"
-        class="absolute w-[6rem] top-16 left-16 px-8 z-10 font-semibold text-green-600 bg-white border border-green-200 refresh-token rounded-xl hover:bg-green-50 hover:text-green-500 focus:text-green-500 focus-visible:outline-0 focus:bg-green-100 focus:border-green-200 focus:outline-0"
+        class="absolute w-[6rem] bottom-8 left-[43%] px-8 py-4 z-10 font-semibold text-green-600 bg-white border border-green-200 refresh-token rounded-xl hover:bg-green-50 hover:text-green-500 focus:text-green-500 focus-visible:outline-0 focus:bg-green-100 focus:border-green-200 focus:outline-0"
         @click="handleShowAllSnippet"
       >
         {{ showAllCode ? 'Show less' : 'Show all' }}
@@ -28,6 +28,7 @@
       </div>
       <VCodeBlock
         :id="label"
+        :class="showExpandButton ? 'whitespace-pre-wrap' : ''"
         :code="code"
         highlightjs
         :height="componentHeight"

--- a/frontend_vue/src/components/base/BaseCodeSnippet.vue
+++ b/frontend_vue/src/components/base/BaseCodeSnippet.vue
@@ -11,7 +11,7 @@
       <button
         v-if="showExpandButton"
         id="show-all-button"
-        class="absolute w-[6rem] bottom-8 left-[43%] px-8 py-4 z-10 font-semibold text-green-600 bg-white border border-green-200 refresh-token rounded-xl hover:bg-green-50 hover:text-green-500 focus:text-green-500 focus-visible:outline-0 focus:bg-green-100 focus:border-green-200 focus:outline-0"
+        class="absolute w-[6rem] bottom-8 left-0 right-0 m-auto px-8 py-4 z-10 font-semibold text-green-600 bg-white border border-green-200 refresh-token rounded-xl hover:bg-green-50 hover:text-green-500 focus:text-green-500 focus-visible:outline-0 focus:bg-green-100 focus:border-green-200 focus:outline-0"
         @click="handleShowAllSnippet"
       >
         {{ showAllCode ? 'Show less' : 'Show all' }}

--- a/frontend_vue/src/components/tokens/clonedsite/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/clonedsite/ManageToken.vue
@@ -1,25 +1,19 @@
-<!-- TODO: fix the backend, adjust the frontend afterwards-->
 <template>
-  <!-- <div v-if="!tokenSnippet">Error loading</div>
+  <div v-if="!tokenSnippet">Error loading</div>
   <TokenDisplay
     v-else
     :token-snippet="tokenSnippet"
-  /> -->
-  <BaseMessageBox variant="warning"
-    >The token snippet is not available at the moment. We'll fix this
-    soon.</BaseMessageBox
-  >
+  />
 </template>
 
 <script lang="ts" setup>
-// import { ref } from 'vue';
-// import TokenDisplay from './TokenDisplay.vue';
-// import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
+import { ref } from 'vue';
+import TokenDisplay from './TokenDisplay.vue';
+import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
 
-// const props = defineProps<{
-//   tokenBackendResponse: ManageTokenBackendType;
-// }>();
+const props = defineProps<{
+  tokenBackendResponse: ManageTokenBackendType;
+}>();
 
-// TODO: check how to get the snippet from tokenBackendResponse
-// const tokenSnippet = ref('');
+const tokenSnippet = ref(props.tokenBackendResponse.clonedsite_js);
 </script>

--- a/frontend_vue/src/components/tokens/clonedsite/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/clonedsite/TokenDisplay.vue
@@ -1,38 +1,37 @@
-<!-- TODO: the JavascriptObfuscator package is not working at the moment 
-we need to fix this dependency to show the obfuscated code
--->
 <template>
   <base-code-snippet
     lang="javascript"
     label="Your tokened Javascript"
     :code="codeClonedSite"
+    :show-expand-button="obfuscated_code"
+    :custom-height="'270px'"
   >
   </base-code-snippet>
-  <!-- <base-switch
+  <base-switch
     id="obfuscated_code"
     v-model="obfuscated_code"
     class="mt-16"
     label="Obfuscate this script"
-    helper-message="Show Obfuscated JavaScript"
+    :helper-message="`${obfuscated_code ? 'Hide' : 'Show'} Obfuscated JavaScript`"
     @input.stop="handleEncodingChange()"
-  ></base-switch> -->
+  ></base-switch>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue';
-// import type { Ref } from 'vue';
-// import obfuscateToken from './obfuscateToken';
+import type { Ref } from 'vue';
+import obfuscateToken from './obfuscateToken';
 
 const props = defineProps<{
   tokenSnippet: string;
 }>();
 
 const codeClonedSite = ref(props.tokenSnippet);
-// const obfuscated_code: Ref<boolean> = ref(false);
+const obfuscated_code: Ref<boolean> = ref(false);
 
-// function handleEncodingChange() {
-//   obfuscated_code.value = !obfuscated_code.value;
-//   if (obfuscated_code.value === true)
-//     codeClonedSite.value = obfuscateToken(props.tokenSnippet);
-// }
+function handleEncodingChange() {
+  obfuscated_code.value = !obfuscated_code.value;
+  if (obfuscated_code.value === true) codeClonedSite.value = obfuscateToken(props.tokenSnippet);
+  else codeClonedSite.value = props.tokenSnippet
+}
 </script>

--- a/frontend_vue/src/components/tokens/clonedsite/obfuscateToken.ts
+++ b/frontend_vue/src/components/tokens/clonedsite/obfuscateToken.ts
@@ -1,29 +1,29 @@
-// import JavascriptObfuscator from 'javascript-obfuscator';
-// export default function obfuscateToken(jsCode: string) {
-//   const modifyScriptJs = (scriptJs, cb) => {
-//     let innerJs = scriptJs.replace(/^<script>/, '');
-//     innerJs = innerJs.replace(/<\/script>$/, '');
-//     const newInnerJs = cb(innerJs);
-//     // Break up script tag strings otherwise Vue build breaks
-//     /* eslint-disable-next-line prefer-template,no-useless-concat */
-//     return '<scri' + 'pt>' + newInnerJs + '</scri' + 'pt>';
-//   };
+import JavascriptObfuscator from 'javascript-obfuscator';
+export default function obfuscateToken(jsCode: string) {
+  const modifyScriptJs = (scriptJs, cb) => {
+    let innerJs = scriptJs.replace(/^<script>/, '');
+    innerJs = innerJs.replace(/<\/script>$/, '');
+    const newInnerJs = cb(innerJs);
+    // Break up script tag strings otherwise Vue build breaks
+    /* eslint-disable-next-line prefer-template,no-useless-concat */
+    return '<scri' + 'pt>' + newInnerJs + '</scri' + 'pt>';
+  };
 
-//   const obfuscatedToken = modifyScriptJs(jsCode, (scriptJs) =>
-//     JavascriptObfuscator.obfuscate(scriptJs, {
-//       compact: true,
-//       simplify: true,
-//       stringArray: true,
-//       stringArrayRotate: true,
-//       stringArrayShuffle: true,
-//       stringArrayCallsTransform: true,
-//       stringArrayThreshold: 1,
-//       stringArrayIndexShift: true,
-//       stringArrayEncoding: ['base64'],
-//       splitStrings: true,
-//       splitStringsChunkLength: 4,
-//     }).getObfuscatedCode()
-//   );
+  const obfuscatedToken = modifyScriptJs(jsCode, (scriptJs) =>
+    JavascriptObfuscator.obfuscate(scriptJs, {
+      compact: true,
+      simplify: true,
+      stringArray: true,
+      stringArrayRotate: true,
+      stringArrayShuffle: true,
+      stringArrayCallsTransform: true,
+      stringArrayThreshold: 1,
+      stringArrayIndexShift: true,
+      stringArrayEncoding: ['base64'],
+      splitStrings: true,
+      splitStringsChunkLength: 4,
+    }).getObfuscatedCode()
+  );
 
-//   return obfuscatedToken;
-// }
+  return obfuscatedToken;
+}

--- a/frontend_vue/src/components/tokens/types.ts
+++ b/frontend_vue/src/components/tokens/types.ts
@@ -91,6 +91,7 @@ export type ManageTokenBackendType = {
   wg_qr_code: string;
   qr_code: string;
   force_https: boolean;
+  clonedsite_js: string;
 };
 
 export type NewTokenBackendType = {


### PR DESCRIPTION
## What does this PR do?
- This PR restored script obfuscation on the Cloned Site token - both inside the modal and on the manage page

## How to test
1. Create a Cloned Website token
2. Click on the `Obfuscate this script` checklist
3. Test on the `Manage Token` page too

## Demo

https://github.com/thinkst/canarytokens/assets/145110595/4b6cba1d-2fff-406c-b51a-2266c521cdbd

