### PR TITLE
Include token & auth in Entra redirect state

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -586,11 +586,14 @@ async def azure_css_landing(
     """
     info = ""
     if admin_consent == "True":
-        tenant_id = tenant
-        if css := state:
-            css = b64decode(unquote(state)).decode()
-        if css is not None and tenant_id is not None:
-            (success, info) = install_azure_css(tenant_id, css)
+        css = None
+        token = None
+        token_auth = None
+
+        css, token, token_auth = b64decode(unquote(state)).decode().split(":")
+
+        if css is not None and tenant is not None:
+            (success, info) = install_azure_css(tenant, css)
             info += " We have uninstalled our application from you tenant, revoking all of our permissions."
     else:
         info = "Installation failed due to lack of sufficient granted permissions."

--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -1508,7 +1508,10 @@ START REPLICA;
         }
         var _handleEntraClonedWebsiteResponse = function(data) {
           $('#result_entra_cloned_website').append(data['css']);
-          state = escape(btoa(data['css']));
+          const encodedCss = btoa(data['css']);
+          const encodedData = btoa(`${encodedCss}:${data['token']}:${data['auth_token']}`);
+          state = encodeURIComponent(encodedData);
+
           redirect = window.location.origin + '/azure_css_landing';
           loc = "https://login.microsoftonline.com/common/adminconsent?client_id=" + data['client_id'] + "&state=" + state + "&redirect_uri=" + redirect;
           $('#azure_popup').attr('onclick', 'window.open("' + loc + '"); return false;')


### PR DESCRIPTION
## Proposed changes

This includes the Entra token + token auth in the `state` param we include in the Microsoft auth redirect requests. The reason for this is that in the upcoming UI refresh we want these redirects to drop the user on the token's manage page. Currently users are redirected to an arbitrary "all done" or "error" page. If they land on the error page and want to retry they have to great a new token, which is a weird flow. The new UI refresh manage page will allow folks to reinitiate the automated flow for the same token. 

Functionally this won't change anything on master but since we've been landing API changes to master and rebasing the UI refresh branch I figured we'd do the same here. The changes on the UI refresh will be a little clearer / easy to read.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...