### PR TITLE
Add memo field on /manage

### DIFF
--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -59,6 +59,9 @@
         </div>
       </template>
     </Suspense>
+    <MemoDisplay class="mt-32">{{
+      manageTokenResponse.canarydrop.memo
+    }}</MemoDisplay>
     <SettingsToken
       :token-backend-response="manageTokenResponse"
       class="mt-32"
@@ -87,6 +90,7 @@ import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
 import getImageUrl from '@/utils/getImageUrl';
 import { TOKENS_TYPE } from './constants';
 import BannerDeviceCanarytools from '@/components/ui/BannerDeviceCanarytools.vue';
+import MemoDisplay from '@/components/ui/MemoDisplay.vue';
 
 const route = useRoute();
 const router = useRouter();

--- a/frontend_vue/src/components/ui/MemoDisplay.vue
+++ b/frontend_vue/src/components/ui/MemoDisplay.vue
@@ -1,0 +1,16 @@
+<template>
+  <div>
+    <h3 class="inline-block mb-8 text-grey-500">Your Memo for this token</h3>
+    <div
+      class="flex flex-row items-center self-start flex-grow gap-16 py-8 w-full bg-grey-100 rounded-xl min-h-[3rem] text-grey"
+    >
+      <font-awesome-icon
+        icon="quote-left"
+        class="pl-16 text-2xl text-grey-300"
+      />
+      <p class="py-8 text-pretty">
+        <slot />
+      </p>
+    </div>
+  </div>
+</template>

--- a/frontend_vue/src/main.ts
+++ b/frontend_vue/src/main.ts
@@ -27,6 +27,7 @@ import {
   faMagnifyingGlass,
   faFileExcel,
   faFile,
+  faQuoteLeft,
 } from '@fortawesome/free-solid-svg-icons';
 import { createVfm } from 'vue-final-modal';
 import { vTooltip } from 'floating-vue';
@@ -62,7 +63,8 @@ library.add(
   faGear,
   faMagnifyingGlass,
   faFileExcel,
-  faFile
+  faFile,
+  faQuoteLeft
 );
 
 const vfm = createVfm();


### PR DESCRIPTION
## Proposed changes

Add memo field on /manage, to remind user about the memo associated to their token

<img width="457" alt="Screenshot 2024-05-27 at 15 59 50" src="https://github.com/thinkst/canarytokens/assets/126554007/9f518482-8aba-43f9-a924-d125f11f701a">
<img width="1020" alt="Screenshot 2024-05-27 at 15 59 56" src="https://github.com/thinkst/canarytokens/assets/126554007/76e64f4e-d5e8-4a76-a597-df2b4deb1162">
