### PR TITLE
Fix 'How to use' string code support

### DIFF
--- a/frontend_vue/components.d.ts
+++ b/frontend_vue/components.d.ts
@@ -7,24 +7,24 @@ export {}
 
 declare module 'vue' {
   export interface GlobalComponents {
-    BaseButton: (typeof import('./src/components/base/BaseButton.vue'))['default'];
-    BaseCodeSnippet: (typeof import('./src/components/base/BaseCodeSnippet.vue'))['default'];
-    BaseCopyButton: (typeof import('./src/components/base/BaseCopyButton.vue'))['default'];
-    BaseFormSelect: (typeof import('./src/components/base/BaseFormSelect.vue'))['default'];
-    BaseFormTextField: (typeof import('./src/components/base/BaseFormTextField.vue'))['default'];
-    BaseGenerateTokenSettings: (typeof import('./src/components/base/BaseGenerateTokenSettings.vue'))['default'];
-    BaseLink: (typeof import('./src/components/base/BaseLink.vue'))['default'];
-    BaseLinkDocumentation: (typeof import('./src/components/base/BaseLinkDocumentation.vue'))['default'];
-    BaseMessageBox: (typeof import('./src/components/base/BaseMessageBox.vue'))['default'];
-    BaseModal: (typeof import('./src/components/base/BaseModal.vue'))['default'];
-    BaseRadioInput: (typeof import('./src/components/base/BaseRadioInput.vue'))['default'];
-    BaseRefreshButton: (typeof import('./src/components/base/BaseRefreshButton.vue'))['default'];
-    BaseSkeletonLoader: (typeof import('./src/components/base/BaseSkeletonLoader.vue'))['default'];
-    BaseSpinner: (typeof import('./src/components/base/BaseSpinner.vue'))['default'];
-    BaseSwitch: (typeof import('./src/components/base/BaseSwitch.vue'))['default'];
-    BaseTextField: (typeof import('./src/components/base/BaseTextField.vue'))['default'];
-    BaseUploadFile: (typeof import('./src/components/base/BaseUploadFile.vue'))['default'];
-    RouterLink: (typeof import('vue-router'))['RouterLink'];
-    RouterView: (typeof import('vue-router'))['RouterView'];
+    BaseButton: typeof import('./src/components/base/BaseButton.vue')['default']
+    BaseCodeSnippet: typeof import('./src/components/base/BaseCodeSnippet.vue')['default']
+    BaseCopyButton: typeof import('./src/components/base/BaseCopyButton.vue')['default']
+    BaseFormSelect: typeof import('./src/components/base/BaseFormSelect.vue')['default']
+    BaseFormTextField: typeof import('./src/components/base/BaseFormTextField.vue')['default']
+    BaseGenerateTokenSettings: typeof import('./src/components/base/BaseGenerateTokenSettings.vue')['default']
+    BaseLink: typeof import('./src/components/base/BaseLink.vue')['default']
+    BaseLinkDocumentation: typeof import('./src/components/base/BaseLinkDocumentation.vue')['default']
+    BaseMessageBox: typeof import('./src/components/base/BaseMessageBox.vue')['default']
+    BaseModal: typeof import('./src/components/base/BaseModal.vue')['default']
+    BaseRadioInput: typeof import('./src/components/base/BaseRadioInput.vue')['default']
+    BaseRefreshButton: typeof import('./src/components/base/BaseRefreshButton.vue')['default']
+    BaseSkeletonLoader: typeof import('./src/components/base/BaseSkeletonLoader.vue')['default']
+    BaseSpinner: typeof import('./src/components/base/BaseSpinner.vue')['default']
+    BaseSwitch: typeof import('./src/components/base/BaseSwitch.vue')['default']
+    BaseTextField: (typeof import('./src/components/base/BaseTextField.vue'))['default']
+    BaseUploadFile: typeof import('./src/components/base/BaseUploadFile.vue')['default']
+    RouterLink: typeof import('vue-router')['RouterLink']
+    RouterView: typeof import('vue-router')['RouterView']
   }
 }

--- a/frontend_vue/src/components/ModalContentHowToUse.vue
+++ b/frontend_vue/src/components/ModalContentHowToUse.vue
@@ -1,27 +1,30 @@
 <template>
   <ModalContentHowToUseLoader v-if="isLoading" />
-  <div v-else>
+  <template v-else>
     <ul
       v-if="howToUseToken.length > 0"
-      class="flex flex-col gap-16 my-16 ml-16 items-left text-grey-800"
+      class="flex flex-col w-full gap-16 my-16 ml-16 items-left text-grey-800"
     >
       <li
-        v-for="item in howToUseToken"
-        :key="item"
+        v-for="item in parsedHowToUseToken"
+        :key="item.id"
         class="grid justify-start grid-flow-col gap-8 text-left"
       >
-        {{ item }}
+        <component
+          :is="item.component"
+          v-bind="item.props"
+        />
       </li>
     </ul>
     <div v-else>
       At this time, we do not have any suggestions available. Please check back
       soon!
     </div>
-  </div>
+  </template>
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import ModalContentHowToUseLoader from '@/components/ui/ModalContentHowToUseLoader.vue';
 
 const props = defineProps<{
@@ -30,6 +33,18 @@ const props = defineProps<{
 
 const howToUseToken = ref([]);
 const isLoading = ref(true);
+
+const parsedHowToUseToken = computed(() => {
+  return howToUseToken.value.map((item, index) => {
+    return {
+      id: index,
+      component: 'p',
+      props: {
+        innerHTML: item,
+      },
+    };
+  });
+});
 
 const loadHowToUse = async () => {
   const { howToUse } = await import(
@@ -51,5 +66,9 @@ li::before {
   margin-top: 0.1rem;
   background-color: hsl(157, 77%, 45%);
   border: 4px solid hsl(141, 75%, 76%);
+}
+
+p >>> code {
+  @apply bg-grey-100;
 }
 </style>

--- a/frontend_vue/src/components/ModalContentHowToUse.vue
+++ b/frontend_vue/src/components/ModalContentHowToUse.vue
@@ -69,6 +69,6 @@ li::before {
 }
 
 p >>> code {
-  @apply bg-grey-100;
+  @apply bg-grey-100 px-8 py-[2px] rounded-md mt-4;
 }
 </style>

--- a/frontend_vue/src/components/tokens/aws_keys/howToUse.ts
+++ b/frontend_vue/src/components/tokens/aws_keys/howToUse.ts
@@ -1,4 +1,4 @@
 export const howToUse = [
-  'These credentials are often stored in a file called ~/.aws/credentials on linux/OSX systems. Generate a fake credential pair for your senior developers and sysadmins and keep it on their machines. If someone tries to access AWS with the pair you generated for Bob, chances are that Bob`s been compromised.',
+  'These credentials are often stored in a file called <code>~/.aws/credentials</code> on linux/OSX systems. Generate a fake credential pair for your senior developers and sysadmins and keep it on their machines. If someone tries to access AWS with the pair you generated for Bob, chances are that Bob`s been compromised.',
   'Place the credentials in private code repositories. If the token is triggered, it means that someone is accessing that repo without permission',
 ];

--- a/frontend_vue/src/components/tokens/azure_id/howToUse.ts
+++ b/frontend_vue/src/components/tokens/azure_id/howToUse.ts
@@ -1,4 +1,4 @@
 export const howToUse = [
-  'Most systems have a ~/.azure folder (much like the ~/.aws or ~/.ssh). Create a config file with the config details from the token and place it near the certificate (ensuring that the config value has a path to the certificate).',
+  'Most systems have a <code>~/.azure</code> folder (much like the <code>~/.aws</code> or <code>~/.ssh</code>). Create a config file with the config details from the token and place it near the certificate (ensuring that the config value has a path to the certificate).',
   'Place the credentials in private code repositories. If the token is triggered, it means that someone is accessing that repo without permission',
 ];

--- a/frontend_vue/src/components/tokens/dns/howToUse.ts
+++ b/frontend_vue/src/components/tokens/dns/howToUse.ts
@@ -1,6 +1,6 @@
 export const howToUse = [
   'Include in a PTR entry for dark IP space of your internal network. Quick way to determine if someone is walking your internal DNS without configuring DNS logging and monitoring.',
-  'Leave in a .bash_history, or .ssh/config, or ~/servers.txt',
-  'Use as a extremely simple bridge between a detection and notification action. Many possibilities, here`s one that tails a logfile and triggers the token when someone logs in: <pre>tail -f /var/log/auth.log | awk `/Accepted publickey for/ { system("host k5198sfh3cw64rhdpm29oo4ga.canarytokens.com") }`</pre>',
+  'Leave in a <code>.bash_history</code>, or  <code>.ssh/config</code>, or <code>~/servers.txt</code>',
+  'Use as a extremely simple bridge between a detection and notification action. Many possibilities, here`s one that tails a logfile and triggers the token when someone logs in: <code>tail -f /var/log/auth.log | awk `/Accepted publickey for/ { system("host k5198sfh3cw64rhdpm29oo4ga.canarytokens.com") }`</code>',
   'Use as the domain part of an email address.',
 ];

--- a/frontend_vue/src/components/tokens/kubeconfig/howToUse.ts
+++ b/frontend_vue/src/components/tokens/kubeconfig/howToUse.ts
@@ -1,4 +1,4 @@
 export const howToUse = [
-  'Place the file at ~/.kube/config on a host, tempting an attacker to use it.',
+  'Place the file at <code>~/.kube/config</code> on a host, tempting an attacker to use it.',
   'Place the file in private code repositories. If the token is triggered, it means that someone is accessing that repo without permission.',
 ];


### PR DESCRIPTION
## Proposed changes

If < code > is used inside the array of strings for 'How to use', we now show the code formatted differently.

Examples:
<img width="662" alt="Screenshot 2024-05-27 at 17 17 34" src="https://github.com/thinkst/canarytokens/assets/126554007/afa3027c-d69f-4c4e-b51b-ec717f5a90a3">
<img width="704" alt="Screenshot 2024-05-27 at 17 27 37" src="https://github.com/thinkst/canarytokens/assets/126554007/ba3158e6-a0d3-4f82-8eb5-7dfd8a687f5e">
<img width="421" alt="Screenshot 2024-05-27 at 17 27 46" src="https://github.com/thinkst/canarytokens/assets/126554007/f7003309-9741-4925-a49d-01fd76c20854">


Note: I used a work around to not inject html directly. I think it would not be harmful to use v-html, as the html code is hardcoded and fully controlled by us. Anyway, I guess it's good practice to get used to this pattern. 
And I can't stand the IDE crying at me, urgh.