### PR TITLE
Fix alignment modal back button

### DIFF
--- a/frontend_vue/src/components/ModalContentHowToUse.vue
+++ b/frontend_vue/src/components/ModalContentHowToUse.vue
@@ -70,5 +70,6 @@ li::before {
 
 p >>> code {
   @apply bg-grey-100 px-8 py-[2px] rounded-md mt-4;
+  overflow-wrap: anywhere;
 }
 </style>

--- a/frontend_vue/src/components/base/BaseModal.vue
+++ b/frontend_vue/src/components/base/BaseModal.vue
@@ -21,7 +21,7 @@
           <button
             v-if="hasBackButton"
             type="button"
-            class="absolute top-[40px] left-[30px]"
+            class="absolute top-[1.8rem] left-24"
             @click="emit('handleBackButton', false)"
           >
             <font-awesome-icon


### PR DESCRIPTION
## Proposed changes

Fix position for the back button on modal's Header
<img width="323" alt="Screenshot 2024-05-29 at 13 43 25" src="https://github.com/thinkst/canarytokens/assets/126554007/c0da2130-7569-4319-835a-f87a13ac8f4e">
<img width="760" alt="Screenshot 2024-05-29 at 13 26 11" src="https://github.com/thinkst/canarytokens/assets/126554007/6538c8bc-57b2-4aaa-849c-f382933c203b">

minor fix: code blocks are overflowing when too long on 'How to use'. One line rule fix the issue  overflow-wrap: anywhere;
Currently the rule is not available on tailwind