### PR TITLE
Add a new Azure Entra ID token redirect page

### DIFF
--- a/frontend_vue/src/components/base/BaseMessageBox.vue
+++ b/frontend_vue/src/components/base/BaseMessageBox.vue
@@ -52,6 +52,7 @@ import type { NotificationBoxVariantType } from './types';
 enum VariantEnum {
   DANGER = 'danger',
   WARNING = 'warning',
+  SUCCESS = 'success',
   INFO = 'info',
 }
 
@@ -67,9 +68,11 @@ defineEmits(['click']);
 const boxClasses = computed(() => {
   switch (props.variant) {
     case VariantEnum.DANGER:
-      return 'bg-red-100 text-red-500 bg-red-100';
+      return 'bg-red-100 text-red-500';
     case VariantEnum.WARNING:
       return 'text-yellow-700 bg-yellow-300';
+    case VariantEnum.SUCCESS:
+      return 'text-green-800 bg-green-200';
     case VariantEnum.INFO:
       return 'text-blue-700 bg-blue-300';
     default:
@@ -83,6 +86,8 @@ const iconClass = computed(() => {
       return 'fill-yellow';
     case VariantEnum.DANGER:
       return 'fill-red';
+    case VariantEnum.SUCCESS:
+      return 'fill-green-700';
     case VariantEnum.INFO:
       return 'fill-blue';
     default:

--- a/frontend_vue/src/components/base/types.ts
+++ b/frontend_vue/src/components/base/types.ts
@@ -1,6 +1,7 @@
 export interface BaseStateVariantInterface {
   danger: string;
   warning: string;
+  success: string;
   info: string;
 }
 

--- a/frontend_vue/src/components/constants.ts
+++ b/frontend_vue/src/components/constants.ts
@@ -1,11 +1,11 @@
-/* 
+/*
 TOKENS_TYPE defines a set of token types that are used in various parts of the application.
 !! These token types should match the token_type values coming from the Backend
 
-When you add a new token inside @/components/tokens, 
+When you add a new token inside @/components/tokens,
 name the new folder as the token_type
 
-TODO: if possible, we might add a eslint rule 
+TODO: if possible, we might add a eslint rule
 to check if a folder name matches a TOKENS_TYPE type
 */
 
@@ -93,3 +93,17 @@ export const TOKEN_CATEGORY = {
   DATABASE: 'database',
   OTHER: 'Other',
 };
+
+export const ENTRA_ID_FEEDBACK_TYPES = {
+  ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY: "has_custom_css_already",
+  ENTRA_STATUS_ERROR: "error",
+  ENTRA_STATUS_SUCCESS: "success",
+  ENTRA_STATUS_NO_ADMIN_CONSENT: "no_admin_consent",
+}
+
+export const ENTRA_ID_FEEDBACK_MESSAGES = {
+  ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY: "  Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quos vel illum aliquid inventore et perspiciatis. Similique illum nisi, quidem pariatur quod iusto reprehenderit voluptates ipsam ut, deserunt, voluptate enim voluptatem?",
+  ENTRA_STATUS_ERROR: "Installation failed: your tenant already has a conflicting custom CSS, please manually add the CSS to your portal branding. We have uninstalled our application from you tenant, revoking all of our permissions.",
+  ENTRA_STATUS_SUCCESS: "  Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quos vel illum aliquid inventore et perspiciatis. Similique illum nisi, quidem pariatur quod iusto reprehenderit voluptates ipsam ut, deserunt, voluptate enim voluptatem?",
+  ENTRA_STATUS_NO_ADMIN_CONSENT: "  Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quos vel illum aliquid inventore et perspiciatis. Similique illum nisi, quidem pariatur quod iusto reprehenderit voluptates ipsam ut, deserunt, voluptate enim voluptatem?",
+}

--- a/frontend_vue/src/components/constants.ts
+++ b/frontend_vue/src/components/constants.ts
@@ -102,8 +102,8 @@ export const ENTRA_ID_FEEDBACK_TYPES = {
 }
 
 export const ENTRA_ID_FEEDBACK_MESSAGES = {
-  ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY: "  Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quos vel illum aliquid inventore et perspiciatis. Similique illum nisi, quidem pariatur quod iusto reprehenderit voluptates ipsam ut, deserunt, voluptate enim voluptatem?",
-  ENTRA_STATUS_ERROR: "Installation failed: your tenant already has a conflicting custom CSS, please manually add the CSS to your portal branding. We have uninstalled our application from you tenant, revoking all of our permissions.",
-  ENTRA_STATUS_SUCCESS: "  Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quos vel illum aliquid inventore et perspiciatis. Similique illum nisi, quidem pariatur quod iusto reprehenderit voluptates ipsam ut, deserunt, voluptate enim voluptatem?",
-  ENTRA_STATUS_NO_ADMIN_CONSENT: "  Lorem ipsum dolor sit amet consectetur, adipisicing elit. Quos vel illum aliquid inventore et perspiciatis. Similique illum nisi, quidem pariatur quod iusto reprehenderit voluptates ipsam ut, deserunt, voluptate enim voluptatem?",
+  ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY: "Installation failed: your tenant already has a conflicting custom CSS, please manually add the CSS to your portal branding. We have uninstalled our application from your tenant, revoking all of our permissions.",
+  ENTRA_STATUS_ERROR: "Installation failed: Unable to automatically install the CSS, please manually add the CSS to your portal branding. We have uninstalled our application from you tenant, revoking all of our permissions.",
+  ENTRA_STATUS_SUCCESS: "Successfully installed the CSS into your Azure tenant. Please wait for a few minutes for the changes to propagate; no further action is needed. We have uninstalled our application from your tenant, revoking all of our permissions.",
+  ENTRA_STATUS_NO_ADMIN_CONSENT: "Installation failed due to lack of sufficient granted permissions. We have uninstalled our application from your tenant, revoking all of our permissions.",
 }

--- a/frontend_vue/src/router/index.ts
+++ b/frontend_vue/src/router/index.ts
@@ -58,6 +58,14 @@ const router = createRouter({
       },
     },
     {
+      path: '/entra/:result',
+      name: 'entra-id',
+      component: () => import('../views/EntraIDResultView.vue'),
+      meta: {
+        title: 'Azure Entra ID',
+      },
+    },
+    {
       path: '/error',
       name: 'error',
       component: () => import('../views/ErrorView.vue'),

--- a/frontend_vue/src/views/EntraIDResultView.vue
+++ b/frontend_vue/src/views/EntraIDResultView.vue
@@ -30,15 +30,20 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
-import { useRoute } from 'vue-router';
+import { ref, computed, onMounted} from 'vue';
+import { useRoute, useRouter } from 'vue-router';
 import AppLayoutOneColumn from '@/layout/AppLayoutOneColumn.vue';
 import BannerDeviceCanarytools from '@/components/ui/BannerDeviceCanarytools.vue';
 import { ENTRA_ID_FEEDBACK_TYPES, ENTRA_ID_FEEDBACK_MESSAGES } from '@/components/constants'
 import getImageUrl from '@/utils/getImageUrl';
 
 const route = useRoute();
+const router = useRouter();
 const logoURL = ref('token_icons/azure_id_config.png');
+
+onMounted(async () => {
+  if (!Object.values(ENTRA_ID_FEEDBACK_TYPES).includes(route.params.result)) router.push({ name: 'error' });
+});
 
 const alertsMessage = computed(() => {
   if (route.params.result === ENTRA_ID_FEEDBACK_TYPES.ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY) return ENTRA_ID_FEEDBACK_MESSAGES.ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY

--- a/frontend_vue/src/views/EntraIDResultView.vue
+++ b/frontend_vue/src/views/EntraIDResultView.vue
@@ -1,0 +1,62 @@
+<template>
+  <AppLayoutOneColumn>
+  <div class="flex flex-col items-center gap-8 mb-24"
+    >
+      <img
+        :src="getImageUrl(logoURL)"
+        class="h-[4rem]"
+        aria-hidden="true"
+        :alt="` Azure Entra ID login logo`"
+      />
+      <h2 class="text-xl text-center text-grey-800">
+        Automatic Setup Process Complete
+      </h2>
+    </div>
+    <div class="flex flex-col justify-center p-16 md:p-32 md:mx-32 rounded-xl bg-grey-50 md:max-w-[50vw] w-full">
+      <BaseMessageBox
+        class="mb-16"
+        :message="alertsMessage"
+        :variant="variant"
+        @click="console.log('danger!')"
+      />
+      <BaseButton
+        class="m-auto"
+        variant="secondary"
+        @click="closeWindow()"
+        >Close Window</BaseButton>
+      <BannerDeviceCanarytools class="my-8" />
+    </div>
+  </AppLayoutOneColumn>
+</template>
+
+<script setup>
+import { ref, computed } from 'vue';
+import { useRoute } from 'vue-router';
+import AppLayoutOneColumn from '@/layout/AppLayoutOneColumn.vue';
+import BannerDeviceCanarytools from '@/components/ui/BannerDeviceCanarytools.vue';
+import { ENTRA_ID_FEEDBACK_TYPES, ENTRA_ID_FEEDBACK_MESSAGES } from '@/components/constants'
+import getImageUrl from '@/utils/getImageUrl';
+
+const route = useRoute();
+const logoURL = ref('token_icons/azure_id_config.png');
+
+const alertsMessage = computed(() => {
+  if (route.params.result === ENTRA_ID_FEEDBACK_TYPES.ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY) return ENTRA_ID_FEEDBACK_MESSAGES.ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY
+  if (route.params.result === ENTRA_ID_FEEDBACK_TYPES.ENTRA_STATUS_ERROR) return ENTRA_ID_FEEDBACK_MESSAGES.ENTRA_STATUS_ERROR
+  if (route.params.result === ENTRA_ID_FEEDBACK_TYPES.ENTRA_STATUS_NO_ADMIN_CONSENT) return ENTRA_ID_FEEDBACK_MESSAGES.ENTRA_STATUS_NO_ADMIN_CONSENT
+  return ENTRA_ID_FEEDBACK_MESSAGES.ENTRA_STATUS_SUCCESS;
+});
+
+const variant = computed(() => {
+  if (route.params.result === ENTRA_ID_FEEDBACK_TYPES.ENTRA_STATUS_ERROR) return 'danger'
+  if (route.params.result === ENTRA_ID_FEEDBACK_TYPES.ENTRA_STATUS_NO_ADMIN_CONSENT) return 'warning'
+  if (route.params.result === ENTRA_ID_FEEDBACK_TYPES.ENTRA_STATUS_SUCCESS) return 'success'
+  return 'info'
+});
+
+const closeWindow = () => {
+  window.close()
+}
+</script>
+
+<style></style>

--- a/frontend_vue/src/views/EntraIDResultView.vue
+++ b/frontend_vue/src/views/EntraIDResultView.vue
@@ -17,7 +17,6 @@
         class="mb-16"
         :message="alertsMessage"
         :variant="variant"
-        @click="console.log('danger!')"
       />
       <BaseButton
         class="m-auto"


### PR DESCRIPTION
## Proposed changes
- Add a new redirect page for Azure Entra ID tokens
- It should handle the following route names:
```
  export const ENTRA_ID_FEEDBACK_TYPES = {
    ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY: "has_custom_css_already",
    ENTRA_STATUS_ERROR: "error",
    ENTRA_STATUS_SUCCESS: "success",
    ENTRA_STATUS_NO_ADMIN_CONSENT: "no_admin_consent",
  }
```

## Screenshots
_ENTRA_STATUS_NO_ADMIN_CONSENT_
<img width="1509" alt="Screenshot 2024-05-31 at 07 23 00" src="https://github.com/thinkst/canarytokens/assets/145110595/b59c5829-ee30-4028-92c2-3f2ec0572f70">

_ENTRA_STATUS_HAS_CUSTOM_CSS_ALREADY_
<img width="1509" alt="Screenshot 2024-05-31 at 07 23 16" src="https://github.com/thinkst/canarytokens/assets/145110595/72683bb4-9bed-4354-9298-caa4b952676f">

_ENTRA_STATUS_SUCCESS_
<img width="1509" alt="Screenshot 2024-05-31 at 07 23 24" src="https://github.com/thinkst/canarytokens/assets/145110595/eb86aba2-92b5-43e7-9021-6cf42e0b37ac">

_ENTRA_STATUS_ERROR_
<img width="1509" alt="Screenshot 2024-05-31 at 07 23 33" src="https://github.com/thinkst/canarytokens/assets/145110595/7049ea26-c6b0-47d5-b82e-c4711f49cedb">
