### PR TITLE
Add loading state on create token button

### DIFF
--- a/frontend_vue/src/components/ModalContentHowToUse.vue
+++ b/frontend_vue/src/components/ModalContentHowToUse.vue
@@ -68,7 +68,7 @@ li::before {
   border: 4px solid hsl(141, 75%, 76%);
 }
 
-p >>> code {
+p :deep(code) {
   @apply bg-grey-100 px-8 py-[2px] rounded-md mt-4;
   overflow-wrap: anywhere;
 }

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -11,6 +11,7 @@
         :trigger-submit="triggerSubmit"
         @token-generated="(formValues) => handleGenerateToken(formValues)"
         @invalid-submit="handleInvalidSubmit"
+        @is-loading="isLoading = $event"
       />
       <template #fallback>
         <ModalContentGenerateTokenLoader />
@@ -39,34 +40,42 @@
 
     <!-- footer -->
     <template #footer>
-      <template v-if="modalType === ModalType.AddToken">
-        <BaseButton
-          variant="primary"
-          :loading="isLoadngSubmit"
-          @click.stop="handleAddToken"
-          >Create Token</BaseButton
-        >
+      <template v-if="isLoading">
+        <BaseSkeletonLoader
+          type="rectangle"
+          class="w-[130px] h-[40px]"
+        />
       </template>
+      <template v-else>
+        <template v-if="modalType === ModalType.AddToken">
+          <BaseButton
+            variant="primary"
+            :loading="isLoadngSubmit"
+            @click.stop="handleAddToken"
+            >Create Token</BaseButton
+          >
+        </template>
 
-      <template v-if="modalType === ModalType.NewToken">
-        <BaseButton
-          variant="secondary"
-          @click="handleHowToUse"
-          >How to use</BaseButton
-        >
-        <BaseButton
-          variant="secondary"
-          @click="handleManageToken"
-          >Manage Token</BaseButton
-        >
-      </template>
+        <template v-if="modalType === ModalType.NewToken">
+          <BaseButton
+            variant="secondary"
+            @click="handleHowToUse"
+            >How to use</BaseButton
+          >
+          <BaseButton
+            variant="secondary"
+            @click="handleManageToken"
+            >Manage Token</BaseButton
+          >
+        </template>
 
-      <template v-if="modalType === ModalType.HowToUse">
-        <BaseButton
-          variant="secondary"
-          @click="handleManageToken()"
-          >Manage Token</BaseButton
-        >
+        <template v-if="modalType === ModalType.HowToUse">
+          <BaseButton
+            variant="secondary"
+            @click="handleManageToken()"
+            >Manage Token</BaseButton
+          >
+        </template>
       </template>
     </template>
     <!-- banner ADV -->
@@ -113,6 +122,7 @@ const isSuspenseError = ref(false);
 const isGenerateTokenError = ref(false);
 const errorMessage = ref('');
 const isLoadngSubmit = ref(false);
+const isLoading = ref(false);
 
 const props = defineProps<{
   selectedToken: string;


### PR DESCRIPTION
## Proposed changes

Add loading state on 'Create Token' button, when the Add New token components are still loading

<img width="1029" alt="Screenshot 2024-06-04 at 12 07 14" src="https://github.com/thinkst/canarytokens/assets/126554007/1b5bc15c-6ff7-47f5-a8e3-82522b9c32c2">


NOTE: I didn't add the same loading state on the 'How to use' and 'Manage token' buttons in the next modal, as clicking on those buttons would still work even if the modal content is loading.