### PR TITLE
Add URL validation on webhook_url field

### DIFF
--- a/frontend_vue/src/utils/formValidators.ts
+++ b/frontend_vue/src/utils/formValidators.ts
@@ -5,6 +5,7 @@ import { isValidFileType, validFileExtensions } from './utils';
 type FieldsType = {
   email: string | undefined;
   memo: string;
+  webhook_url: string | undefined;
 };
 
 type ValidateSchemaType = {
@@ -15,6 +16,7 @@ type ValidateSchemaType = {
 
 const validationMessages = {
   validEmail: 'It must be a valid email',
+  validURL: 'It must be a valid URL',
   provideMemo: 'Memo is a required field',
   maxLengthMemo: 'Memo cannot be longer than 1000 characters',
   provideEmail: 'Provide a valid email',
@@ -28,6 +30,8 @@ const validationNotificationSettings = {
     .required(validationMessages.provideMemo)
     .max(1000, validationMessages.maxLengthMemo)
     .test('empty-check', validationMessages.provideMemo, val => val.trim().length !== 0),
+  webhook_url: Yup.string()
+        .url(validationMessages.validURL),
 };
 
 export const formValidators: ValidateSchemaType = {


### PR DESCRIPTION
## What does this PR do?
- It adds a URL validation rule on the webhook field to ensure we catch incorrect input before submission
- The input remains un-required

## Screenshots
<img width="1509" alt="Screenshot 2024-06-04 at 15 25 47" src="https://github.com/thinkst/canarytokens/assets/145110595/39324db5-d796-4885-9e0e-f18e3b975e98">
<img width="1509" alt="Screenshot 2024-06-04 at 15 26 00" src="https://github.com/thinkst/canarytokens/assets/145110595/170fe491-22fe-4d52-bd69-48d04ad30e4e">

