### PR TITLE
Fix Code snipper content overlap on Copy/refresh button

### DIFF
--- a/frontend_vue/src/components/base/BaseCodeSnippet.vue
+++ b/frontend_vue/src/components/base/BaseCodeSnippet.vue
@@ -28,7 +28,11 @@
       </div>
       <VCodeBlock
         :id="label"
-        :class="showExpandButton ? 'whitespace-pre-wrap' : ''"
+        :class="[
+          showExpandButton ? 'whitespace-pre-wrap' : '',
+          isSingleLine && hasCopy && !hasRefresh ? 'pr-[2rem]' : '',
+          isSingleLine && hasCopy && hasRefresh ? 'pr-[3rem]' : '',
+        ]"
         :code="code"
         highlightjs
         :height="componentHeight"
@@ -53,6 +57,7 @@ const props = withDefaults(
     showExpandButton?: boolean;
     customHeight?: string;
     label?: string | null;
+    isSingleLine?: boolean;
   }>(),
   {
     hasRefresh: false,
@@ -60,6 +65,7 @@ const props = withDefaults(
     customHeight: 'auto',
     label: null,
     showExpandButton: false,
+    isSingleLine: false,
   }
 );
 

--- a/frontend_vue/src/components/tokens/dns/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/dns/TokenDisplay.vue
@@ -2,6 +2,7 @@
   <base-code-snippet
     lang="php"
     label="URL token"
+    is-single-line
     :code="tokenUrl"
   ></base-code-snippet>
 </template>

--- a/frontend_vue/src/components/tokens/fast_redirect/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/fast_redirect/TokenDisplay.vue
@@ -2,6 +2,7 @@
   <base-code-snippet
     lang="javascript"
     label="URL token"
+    is-single-line
     :code="tokenUrl"
   ></base-code-snippet>
 </template>

--- a/frontend_vue/src/components/tokens/slow_redirect/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/slow_redirect/TokenDisplay.vue
@@ -2,6 +2,7 @@
   <base-code-snippet
     lang="javascript"
     label="URL token"
+    is-single-line
     :code="tokenUrl"
   ></base-code-snippet>
 </template>

--- a/frontend_vue/src/components/tokens/web/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/web/TokenDisplay.vue
@@ -2,6 +2,7 @@
   <base-code-snippet
     lang="javascript"
     label="URL token"
+    is-single-line
     :code="tokenUrl"
   ></base-code-snippet>
 </template>

--- a/frontend_vue/src/components/tokens/web_image/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/web_image/TokenDisplay.vue
@@ -2,6 +2,7 @@
   <base-code-snippet
     lang="javascript"
     label="URL token"
+    is-single-line
     :code="tokenUrl"
   ></base-code-snippet>
 </template>

--- a/frontend_vue/src/views/ComponentPreview.vue
+++ b/frontend_vue/src/views/ComponentPreview.vue
@@ -1,4 +1,14 @@
 <template>
+  <div>
+    <hr class="my-24" />
+    <h1>Search bar</h1>
+    <div class="flex flex-col gap-16 mt-24 mb-32">
+      <SearchBar
+        label="Search"
+        placeholder="A nice placeholder"
+      />
+    </div>
+  </div>
   <div class="flex flex-col w-[200px] gap-16">
     <h1>Buttons</h1>
     <base-button>Primary</base-button>
@@ -185,7 +195,16 @@
       <h1 class="pb-16">Code Snippet</h1>
 
       <BaseCodeSnippet
+        is-single-line
+        class="mb-16"
+        label="Single line"
+        lang="javascript"
+        code="http://canarytokens.com/traffic/ttg75cc1ah5ae4f24o6767csk/post.jsp"
+      />
+
+      <BaseCodeSnippet
         has-refresh
+        is-single-line
         class="mb-16"
         label="Single line"
         lang="javascript"
@@ -273,16 +292,6 @@
         class="w-[200px]"
         type="text"
       />
-    </div>
-    <div>
-      <hr class="my-24" />
-      <h1>Search bar</h1>
-      <div class="flex flex-col gap-16 mt-24 mb-32">
-        <SearchBar
-          label="Search"
-          placeholder="A nice placeholder"
-        />
-      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Proposed changes

The code was going under the Copy button and the refresh button.
By adding the prop to define if a component is one line, a padding is added and the problem is solved.

------

Note: I don't like much this solution, forcing users to add a prop just for fixing the UI is something I'd avoid.
Unfortunately, it seems there's no other way I can track the height of the Vcode block.

Maybe it's possible, but I couldn't find a way. If somebody feels like fiddling with it, you're the most welcome