### PR TITLE
Fix required fields on slow and fast redirect tokens

### DIFF
--- a/frontend_vue/src/components/tokens/cmd/GenerateTokenForm.vue
+++ b/frontend_vue/src/components/tokens/cmd/GenerateTokenForm.vue
@@ -7,6 +7,7 @@
       label="Name of the process to monitor"
       helper-message="Add a .exe extension, e.g klist.exe"
       full-width
+      required
     />
   </BaseGenerateTokenSettings>
   <GenerateTokenSettingsNotifications

--- a/frontend_vue/src/components/tokens/fast_redirect/GenerateTokenForm.vue
+++ b/frontend_vue/src/components/tokens/fast_redirect/GenerateTokenForm.vue
@@ -3,9 +3,10 @@
     <BaseFormTextField
       id="redirect_url"
       type="text"
-      placeholder="Redirect Url"
+      placeholder="Redirect URL"
       label="Redirect URL"
       full-width
+      required
     />
   </BaseGenerateTokenSettings>
   <GenerateTokenSettingsNotifications

--- a/frontend_vue/src/components/tokens/slow_redirect/GenerateTokenForm.vue
+++ b/frontend_vue/src/components/tokens/slow_redirect/GenerateTokenForm.vue
@@ -3,9 +3,10 @@
     <BaseFormTextField
       id="redirect_url"
       type="text"
-      placeholder="Redirect Url"
+      placeholder="Redirect URL"
       label="Redirect URL"
       full-width
+      required
     />
   </BaseGenerateTokenSettings>
   <GenerateTokenSettingsNotifications

--- a/frontend_vue/src/utils/formValidators.ts
+++ b/frontend_vue/src/utils/formValidators.ts
@@ -150,7 +150,7 @@ export const formValidators: ValidateSchemaType = {
   [TOKENS_TYPE.CLONED_WEBSITE]: {
     schema: Yup.object().shape({
       ...validationNotificationSettings,
-      clonedsite: Yup.string().required(),
+      clonedsite: Yup.string().required('Domain is required'),
     }),
   },
   [TOKENS_TYPE.CSS_CLONED_SITE]: {


### PR DESCRIPTION
## Proposed changes

- Add missing *required tags on Create token forms
- Fix `Url` to `URL`
- Better `domain is required` error message for cloned site token

## Screenshots
<img width="1509" alt="Screenshot 2024-06-05 at 08 52 43" src="https://github.com/thinkst/canarytokens/assets/145110595/5b58a303-6b28-441d-bd07-b35f004bb62c">
<img width="1509" alt="Screenshot 2024-06-05 at 08 52 29" src="https://github.com/thinkst/canarytokens/assets/145110595/7013c665-acd5-45e7-ac60-478d2a5dd18d">
<img width="1509" alt="Screenshot 2024-06-05 at 08 52 18" src="https://github.com/thinkst/canarytokens/assets/145110595/aa45bfa0-c534-42ff-973c-520ba6dea42f">
