### PR TITLE
Add upload file size validation for signed exe and web image tokens

### DIFF
--- a/frontend_vue/src/components/constants.ts
+++ b/frontend_vue/src/components/constants.ts
@@ -109,3 +109,5 @@ export const ENTRA_ID_FEEDBACK_MESSAGES = {
   ENTRA_STATUS_SUCCESS: "Successfully installed the CSS into your Azure tenant. Please wait for a few minutes for the changes to propagate; no further action is needed. We have uninstalled our application from your tenant, revoking all of our permissions.",
   ENTRA_STATUS_NO_ADMIN_CONSENT: "Installation failed due to lack of sufficient granted permissions. We have uninstalled our application from your tenant, revoking all of our permissions.",
 }
+
+export const MAX_UPLOAD_SIZE = 1024 * 1024 * 1;

--- a/frontend_vue/src/utils/formValidators.ts
+++ b/frontend_vue/src/utils/formValidators.ts
@@ -1,5 +1,5 @@
 import * as Yup from 'yup';
-import { TOKENS_TYPE } from '@/components/constants.ts';
+import { TOKENS_TYPE, MAX_UPLOAD_SIZE } from '@/components/constants.ts';
 import { isValidFileType, validFileExtensions } from './utils';
 
 type FieldsType = {
@@ -100,6 +100,11 @@ export const formValidators: ValidateSchemaType = {
               value && value.name.toLowerCase(),
               validFileExtensions.image
             ) as boolean
+        )
+        .test(
+          'fileTooLarge',
+          'Image size must be below 1MB',
+          (value) => value.size < MAX_UPLOAD_SIZE
         ),
     }),
   },
@@ -128,6 +133,11 @@ export const formValidators: ValidateSchemaType = {
               value && value.name.toLowerCase(),
               validFileExtensions.exe
             ) as boolean
+        )
+        .test(
+          'fileTooLarge',
+          'File size must be below 1MB',
+          (value) => value.size < MAX_UPLOAD_SIZE
         ),
     }),
   },


### PR DESCRIPTION
## Proposed changes
- This change adds a validation rule for file upload inputs to catch excess file size on the UI
- The `MAX UPLOAD SIZE` is `1MB` as stated in the backend

## Screenshots
<img width="1509" alt="Screenshot 2024-06-05 at 09 28 06" src="https://github.com/thinkst/canarytokens/assets/145110595/65860685-40ba-44c3-99be-38513285ae07">
<img width="1509" alt="Screenshot 2024-06-05 at 09 28 55" src="https://github.com/thinkst/canarytokens/assets/145110595/2381d0a1-4bcc-4416-b2f6-4a863d236ccc">
