### PR TITLE
Add information banner to windows folder tokens re: os systems

### DIFF
--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -70,6 +70,14 @@
         class="mt-32"
       ></SettingsToken>
       <BaseMessageBox
+        v-if="manageTokenResponse.canarydrop.canarytoken._value"
+        class="mt-32"
+        :variant="'warning'"
+        :message="`This token only works on Windows 10 systems and lower. It does
+          not work on Windows 11 or higher. This is because a recent group policy update to
+          some versions of Windows defaults to disabling functionality that this token
+          relies on to fire.`" />
+      <BaseMessageBox
         class="mt-32"
         :variant="hasAlerts ? 'danger' : 'info'"
         :text-link="hasAlerts ? 'Check History' : ''"

--- a/frontend_vue/src/components/tokens/windows_dir/ActivatedToken.vue
+++ b/frontend_vue/src/components/tokens/windows_dir/ActivatedToken.vue
@@ -6,6 +6,13 @@
     folder via a network share!
   </p>
   <base-message-box
+    class="mt-32"
+    :variant="'warning'"
+    :message="`This token only works on Windows 10 systems and lower. It does
+      not work on Windows 11 or higher. This is because a recent group policy update to
+      some versions of Windows defaults to disabling functionality that this token
+      relies on to fire.`" />
+  <base-message-box
     class="mt-24"
     variant="info"
     :message="`The alert will include the network domain and username of the browsing user, if present.`"


### PR DESCRIPTION
## Proposed changes
- Add an information banner on Windows Folder tokens to explain which OS the token triggers on

## Screenshots
<img width="1509" alt="Screenshot 2024-06-06 at 13 36 27" src="https://github.com/thinkst/canarytokens/assets/145110595/3eb94b51-25ed-4275-b68f-2ceab528a0a1">
<img width="1509" alt="Screenshot 2024-06-06 at 13 36 11" src="https://github.com/thinkst/canarytokens/assets/145110595/9f641c3b-8430-49e0-ac81-d46ff542ada4">
