### PR TITLE
Add information banner to windows folder tokens re: os systems

### DIFF
--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -481,6 +481,12 @@
                 <div class="advice">
                   <p>Unzip this file in a folder, and get notified when someone browses the folder in Windows Explorer. It will even trigger if someone is browsing the folder via a network share!</p>
                   <p>The alert will include the network domain and username of the browsing user, if present.<p>
+                  <div class="alert alert-warning" role="alert" style="text-align: center;">
+                    This token only works on Windows 10 systems and lower. It does
+                    not work on Windows 11 or higher. This is because a recent group policy update to
+                    some versions of Windows defaults to disabling functionality that this token
+                    relies on to fire.
+                  </div>
                   <p><h5>Ideas for use:</h5>
                     <ul>
                       <li>Unzip the file on a juicely named Windows network share.</li>

--- a/templates/manage_new.html
+++ b/templates/manage_new.html
@@ -228,6 +228,7 @@
                   <a class="btn btn-large btn-success file-download" data-fmt="zip">Download your Zip file</a>
                 </div>
               </div>
+              <br>
               <div class="alert alert-warning" role="alert" style="text-align: center;">
                 This token only works on Windows 10 systems and lower. It does
                 not work on Windows 11 or higher. This is because a recent group policy update to

--- a/templates/manage_new.html
+++ b/templates/manage_new.html
@@ -228,6 +228,12 @@
                   <a class="btn btn-large btn-success file-download" data-fmt="zip">Download your Zip file</a>
                 </div>
               </div>
+              <div class="alert alert-warning" role="alert" style="text-align: center;">
+                This token only works on Windows 10 systems and lower. It does
+                not work on Windows 11 or higher. This is because a recent group policy update to
+                some versions of Windows defaults to disabling functionality that this token
+                relies on to fire.
+              </div>
             </div>
             <!-- <div class="result signed_exe">
               <h3>Here's  your Signed Executable token:</h3>


### PR DESCRIPTION
## Proposed changes
- Add an information banner on the old tokens.org
- Banner informs users that the Windows Folder token is only usable on Windows 10 and lower

## Screenshots
<img width="1509" alt="Screenshot 2024-06-06 at 13 53 30" src="https://github.com/thinkst/canarytokens/assets/145110595/75634522-1809-40e0-8ffb-d506fab6752c">
<img width="1509" alt="Screenshot 2024-06-06 at 14 00 14" src="https://github.com/thinkst/canarytokens/assets/145110595/fd160445-5e40-443a-951d-03dfcb9ffe51">
