### PR TITLE
Fix windows folder token conditional

### DIFF
--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -70,14 +70,6 @@
         class="mt-32"
       ></SettingsToken>
       <BaseMessageBox
-        v-if="manageTokenResponse.canarydrop.type === 'windows_dir'"
-        class="mt-32"
-        :variant="'warning'"
-        :message="`This token only works on Windows 10 systems and lower. It does
-          not work on Windows 11 or higher. This is because a recent group policy update to
-          some versions of Windows defaults to disabling functionality that this token
-          relies on to fire.`" />
-      <BaseMessageBox
         class="mt-32"
         :variant="hasAlerts ? 'danger' : 'info'"
         :text-link="hasAlerts ? 'Check History' : ''"

--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -70,7 +70,7 @@
         class="mt-32"
       ></SettingsToken>
       <BaseMessageBox
-        v-if="manageTokenResponse.canarydrop.canarytoken._value"
+        v-if="manageTokenResponse.canarydrop.type === 'windows_dir'"
         class="mt-32"
         :variant="'warning'"
         :message="`This token only works on Windows 10 systems and lower. It does

--- a/frontend_vue/src/components/tokens/windows_dir/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/windows_dir/ManageToken.vue
@@ -4,6 +4,13 @@
     v-else
     :token-data="tokenData"
   />
+  <BaseMessageBox
+    class="mt-32"
+    :variant="'warning'"
+    :message="`This token only works on Windows 10 systems and lower. It does
+      not work on Windows 11 or higher. This is because a recent group policy update to
+      some versions of Windows defaults to disabling functionality that this token
+      relies on to fire.`" />
 </template>
 
 <script lang="ts" setup>

--- a/frontend_vue/src/views/ComponentPreview.vue
+++ b/frontend_vue/src/views/ComponentPreview.vue
@@ -6,6 +6,7 @@
       <SearchBar
         label="Search"
         placeholder="A nice placeholder"
+        value=""
       />
     </div>
   </div>


### PR DESCRIPTION
## Proposed changes
- This diff fix a broken conditional to the new Windows Folder token banner

## Screenshot
**_Showing on Windows Folder token_**
<img width="1509" alt="Screenshot 2024-06-06 at 20 14 29" src="https://github.com/thinkst/canarytokens/assets/145110595/b33afb43-bafa-4021-9c5a-6c48b99f5cc7">

**_Not showing on others_**
<img width="1509" alt="Screenshot 2024-06-06 at 20 13 51" src="https://github.com/thinkst/canarytokens/assets/145110595/e2ded502-1a39-4e06-a2f6-eb913c76b20b">
