### PR TITLE
Test displaying Github sha on honeypdfs

### DIFF
--- a/frontend_vue/src/components/ui/AppFooter.vue
+++ b/frontend_vue/src/components/ui/AppFooter.vue
@@ -28,10 +28,13 @@
           >Our Terms of Use.</RouterLink
         >
       </p>
+      <p v-if="BUILD_ID">Build ID: {{ BUILD_ID }}</p>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { RouterLink } from 'vue-router';
+
+const BUILD_ID = import.meta.env.VITE_GITHUB_SHA;
 </script>

--- a/frontend_vue/src/components/ui/AppFooter.vue
+++ b/frontend_vue/src/components/ui/AppFooter.vue
@@ -28,7 +28,10 @@
           >Our Terms of Use.</RouterLink
         >
       </p>
-      <p v-if="BUILD_ID">Build ID: {{ BUILD_ID }}</p>
+      <div v-if="BUILD_ID">
+        <p>Build ID: {{ BUILD_ID }}</p>
+        <p>(This will be one commit behind the frontend Dist build if you made frontend changes)</p>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
## Proposed changes
- Add a display for the current Github commit id on newtokens.org dev site

## Screenshots
_On honeypdfs.net_
<img width="1509" alt="Screenshot 2024-06-07 at 17 17 12" src="https://github.com/thinkst/canarytokens/assets/145110595/9af82dbe-bace-4ce0-81c0-de6f39a13625">


_Locally and on master - no commit id_
<img width="1509" alt="Screenshot 2024-06-07 at 15 44 49" src="https://github.com/thinkst/canarytokens/assets/145110595/f43b89ae-c83f-45de-93e4-a75a3594703e">

