### PR TITLE
Improve the UX when selecting and deselecting filter categories

### DIFF
--- a/frontend_vue/src/components/ui/FilterButton.vue
+++ b/frontend_vue/src/components/ui/FilterButton.vue
@@ -1,16 +1,11 @@
 <template>
   <button
     class="relative flex flex-col items-center px-16 text-sm leading-relaxed duration-100 border rounded-2xl hover:border-green-500 active:border-green-500 group"
-    :class="selected ? ' border-green-500 ' : 'border-grey-200'"
+    :class="selected ? ' border-green-500 bg-green-100' : 'border-grey-200'"
   >
-    <font-awesome-icon
-      v-if="selected"
-      icon="xmark"
-      class="absolute left-[8px] top-[.25rem] w-2rem text-green-500"
-    ></font-awesome-icon>
     <span
       class="block capitalize group-hover:text-green-500"
-      :class="selected ? 'text-green-500 pl-8' : 'text-grey-300 px-4'"
+      :class="selected ? 'text-green-500 font-semibold' : 'text-grey-300'"
       >{{ category }}</span
     >
   </button>


### PR DESCRIPTION
## Proposed changes
- Improve the UI and UX when a user selects and deselects a filter category
- Since we do not allow filtering by multiple categories, we do not need the X icon on the pill buttons

## Screenshots
<img width="1509" alt="Screenshot 2024-06-11 at 09 28 38" src="https://github.com/thinkst/canarytokens/assets/145110595/395e82c1-0f07-4b1e-9453-3c582fb50f2b">
<img width="1509" alt="Screenshot 2024-06-11 at 09 28 52" src="https://github.com/thinkst/canarytokens/assets/145110595/45a05909-b8d3-4f21-b74f-0e70dc15ba84">
