### PR TITLE
Fix the form jumping around when we throw input field errors

### DIFF
--- a/frontend_vue/src/components/base/BaseFormTextField.vue
+++ b/frontend_vue/src/components/base/BaseFormTextField.vue
@@ -37,7 +37,7 @@
       @blur="handleChange"
       @input="(e: Event) => validateIfErrorExists(e)"
     />
-    <div class="pr-8 mt-4 ml-16">
+    <div class="h-16 pr-8 mt-4 ml-16">
       <p
         v-show="helperMessage"
         id="helper"


### PR DESCRIPTION
## Proposed changes
- This change aims to add a dedicated space of height 1rem where the error message should appear
- This stops the modal from jumping when error messages are thrown

## Screenshots
<img width="1509" alt="Screenshot 2024-06-11 at 09 46 42" src="https://github.com/thinkst/canarytokens/assets/145110595/cfd13431-74e6-4118-9b2a-3312c4998caa">
<img width="1509" alt="Screenshot 2024-06-11 at 09 46 50" src="https://github.com/thinkst/canarytokens/assets/145110595/6373f96d-156f-4f38-a462-115142ab40b5">

https://github.com/thinkst/canarytokens/assets/145110595/cf972dc1-ce55-4f54-83e4-9d5a12374745

