### PR TITLE
Standardize card and container shadows

### DIFF
--- a/frontend_vue/src/components/ui/BannerTextCanarytools.vue
+++ b/frontend_vue/src/components/ui/BannerTextCanarytools.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="grid sm:grid-cols-[1fr_5fr] border gap-32 border-grey-200 items-center p-32 bg-white rounded-xl shadow-solid-shadow-grey-sm"
+    class="grid sm:grid-cols-[1fr_5fr] border gap-32 border-grey-200 items-center p-32 bg-white rounded-xl shadow-solid-shadow-grey"
   >
     <div class="justify-center hidden sm:flex">
       <img

--- a/frontend_vue/src/components/ui/CardToken.vue
+++ b/frontend_vue/src/components/ui/CardToken.vue
@@ -1,7 +1,7 @@
 <template>
   <li class="relative flex token-card-wrapper">
     <button
-      class="relative group border flex-1 group flex flex-col px-16 pt-16 pb-24 bg-white rounded-xl top-[0px] shadow-solid-shadow-grey-sm border-grey-200 items-center duration-100 ease-in-out token-card"
+      class="relative group border flex-1 group flex flex-col px-16 pt-16 pb-24 bg-white rounded-xl top-[0px] shadow-solid-shadow-grey border-grey-200 items-center duration-100 ease-in-out token-card"
       @click.stop="handleClickToken"
     >
       <div v-if="isLoading">

--- a/frontend_vue/src/components/ui/CarouselInfoToken.vue
+++ b/frontend_vue/src/components/ui/CarouselInfoToken.vue
@@ -9,7 +9,7 @@
         :id="`${index + 1}__slide`"
         :key="slide"
         tabindex="0"
-        class="flex-[0_0_100%] relative flex items-center my-16 bg-white border rounded-xl shadow-solid-shadow-grey-sm border-grey-200 carousel__slide"
+        class="flex-[0_0_100%] relative flex items-center my-16 bg-white border rounded-xl shadow-solid-shadow-grey border-grey-200 carousel__slide"
       >
         <img
           :src="getCarouselIcon(index)"

--- a/frontend_vue/tailwind.config.js
+++ b/frontend_vue/tailwind.config.js
@@ -38,7 +38,7 @@ export default {
         '700': 'hsl(158, 8%, 26%)',
         '800': 'hsl(160, 8%, 22%)',
         '900': 'hsl(154, 7%, 19%)',
-        '950': 'hsl(168, 10%, 10%)',  
+        '950': 'hsl(168, 10%, 10%)',
       },
       'yellow': {
         '300': 'hsl(36, 100%, 91%)',
@@ -69,8 +69,8 @@ export default {
         'solid-shadow-green-500-sm': `0px 0.25rem 0px 0px  ${theme('colors.green.500')}`,
         'solid-shadow-red': `0px 0.15rem 0px 0px  ${theme('colors.red.DEFAULT')}`,
         'solid-shadow-green-300': `0px 0.15rem 0px 0px  ${theme('colors.green.300')}`,
-        'solid-shadow-grey': `0px 0.15rem 0px 0px  ${theme('colors.grey.300')}`,
-        'solid-shadow-grey-sm': `0px 0.25rem 0px 0px  ${theme('colors.grey.300')}`,
+        'solid-shadow-grey': `0px 0.20rem 0px 0px  ${theme('colors.grey.200')}`,
+        'solid-shadow-grey-sm': `0px 0.25rem 0px 0px  ${theme('colors.grey.200')}`,
         'inner-shadow-grey': `inset 0px 0.25rem 0px 0px  ${theme('colors.grey.50')}`,
       })
     },


### PR DESCRIPTION
## Proposed changes

- This PR aims to standardise the card shadows on the tokens.org
- The change includes using `shadow-solid-shadow-grey` class which now has a slightly lighter grey shadow `theme('colors.grey.200')`
- I've also increased the shadow height slightly from `.15rem` to `.20rem`

## Screenshots
<img width="1509" alt="Screenshot 2024-06-11 at 10 15 55" src="https://github.com/thinkst/canarytokens/assets/145110595/915f8e2b-4282-44ab-80a2-4ee88eece411">
<img width="1509" alt="Screenshot 2024-06-11 at 10 16 04" src="https://github.com/thinkst/canarytokens/assets/145110595/e9bc9686-30f1-4781-914f-86bae5b4b157">
<img width="1509" alt="Screenshot 2024-06-11 at 10 16 23" src="https://github.com/thinkst/canarytokens/assets/145110595/0e670264-502f-4831-a133-c0d3c6a5cf83">

https://github.com/thinkst/canarytokens/assets/145110595/b595afa9-4518-4767-bc61-7c94e9e8dca1

