### PR TITLE
Add `/api/delete` endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - "master"
       - "dev"
+      - "Feature_branch_New_UI"
 
   workflow_dispatch:
     inputs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - "master"
       - "dev"
-      - "Feature_branch_New_UI"
 
   workflow_dispatch:
     inputs:

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -2529,6 +2529,10 @@ class SettingsResponse(BaseModel):
     message: Literal["success", "failure"]
 
 
+class DeleteResponse(BaseModel):
+    message: Literal["success", "failure"]
+
+
 class ManageTokenSettingsRequest(BaseModel):
     token: str
     auth: str

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -133,24 +133,12 @@ def add_canary_nxdomain(domain: str) -> int:
     return DB.get_db().sadd(KEY_CANARY_NXDOMAINS, domain)
 
 
-def remove_set_member(key: str, member: str) -> None:
-    """
-    Removes `member` from the set at `key`,
-    and deletes the key if the set is empty afterwards.
-    """
-    current_set = DB.get_db().smembers(key)
-    DB.get_db().srem(key, member)
-    current_set.remove(member)
-    if current_set == set():
-        DB.get_db().delete(key)
-
-
 def add_email_token_idx(email: str, canarytoken: str) -> int:
     return DB.get_db().sadd(KEY_EMAIL_IDX + email, canarytoken)
 
 
 def remove_email_token_idx(email: str, canarytoken: str) -> None:
-    remove_set_member(KEY_EMAIL_IDX + email, canarytoken)
+    DB.get_db().srem(KEY_EMAIL_IDX + email, canarytoken)
 
 
 def add_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> int:
@@ -158,7 +146,7 @@ def add_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> int:
 
 
 def remove_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> None:
-    remove_set_member(KEY_WEBHOOK_IDX + webhook, canarytoken)
+    DB.get_db().srem(KEY_WEBHOOK_IDX + webhook, canarytoken)
 
 
 def add_auth_token_idx(auth: str, token: str) -> int:
@@ -166,7 +154,7 @@ def add_auth_token_idx(auth: str, token: str) -> int:
 
 
 def remove_auth_token_idx(auth: str, token: str) -> None:
-    remove_set_member(KEY_AUTH_IDX + auth, token)
+    DB.get_db().srem(KEY_AUTH_IDX + auth, token)
 
 
 def delete_email_tokens(email_address):

--- a/tests/units/test_frontend.py
+++ b/tests/units/test_frontend.py
@@ -75,6 +75,8 @@ def test_get_generate_page(test_client: TestClient) -> None:
 
 
 def test_redirect_base_to_generate(test_client: TestClient) -> None:
+    if FrontendSettings().NEW_UI:
+        pytest.skip("New UI does not redirect to /generate")
     response = test_client.get("/")
     assert response.status_code == 200
     assert response.url.path == "/generate"
@@ -534,8 +536,7 @@ def test_history_page(
         ).dict(),
     )
     assert resp.status_code == 200
-    # TODO: Make this a stricter test
-    assert cd.canarytoken.value() in resp.content.decode()
+    # now that it's a Vue app we can't test further here
 
 
 @pytest.mark.parametrize(
@@ -558,6 +559,8 @@ def test_authorised_page_access(
         endpoint (str): endpoint to attempt to access.
         verb (str): HTTP verb for endpoint.
     """
+    if FrontendSettings().NEW_UI:
+        pytest.skip("New UI redirects these to index.html")
     resp = test_client.post(
         "/generate",
         data=DNSTokenRequest(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -33,6 +33,7 @@ from canarytokens.models import (
     CustomImageTokenRequest,
     CustomImageTokenResponse,
     DNSTokenResponse,
+    DownloadFmtTypes,
     DownloadGetRequestModel,
     DownloadIncidentListJsonRequest,
     GeoIPBogonInfo,
@@ -50,6 +51,7 @@ from canarytokens.models import (
     WindowsDirectoryTokenResponse,
 )
 from canarytokens.tokens import Canarytoken
+from frontend.app import ROOT_API_ENDPOINT
 
 log = Logger("test_utils")
 
@@ -292,7 +294,7 @@ def get_token_history(
     ],
     version: Union[V2, V3],
     expected_len: int = 1,
-    fmt="incidentlist_json",
+    fmt: DownloadFmtTypes = DownloadFmtTypes.INCIDENTLISTJSON,
 ) -> Dict[str, str]:
     token_history_request = DownloadIncidentListJsonRequest(
         token=token_info.token,
@@ -484,6 +486,38 @@ def create_token(token_request: TokenRequest, version: Union[V2, V3]):
         isinstance(version, V2) and data["Error"] == 3
     ):  # webhook failed not the servers fault
         raise CanaryTokenCreationError("Webhook failed to validate")  # pragma: no cover
+
+    return data
+
+
+@retry_on_failure(
+    retry_when_raised=(requests.exceptions.HTTPError, CanaryTokenCreationError)
+)
+def delete_token(token: str, auth: str, version: Union[V2, V3]):
+    delete_url = f"{version.server_url}{ROOT_API_ENDPOINT}/delete"
+    data = {"token": token, "auth": auth}
+    timeout = request_timeout
+    if not isinstance(version, V3):
+        raise ValueError(f"Version not supported: {version}")
+
+    resp = session.post(
+        url=delete_url,
+        timeout=timeout,
+        json=data,
+        headers={"Connection": "close"},
+    )
+    # TODO / DESIGN: The webhook receiver sometimes chokes due to ngrok rate limit 429 error.
+    #                retry for now. +1 for a webhook receiver as a docker service.
+    if resp.status_code == 429:  # webhook failed not the servers fault
+        raise CanaryTokenCreationError("Webhook failed to validate")  # pragma: no cover
+    if resp.status_code >= 400:
+        log.error(
+            f"Token deletion error: \n\t{token=}\n\t{resp.status_code=}; {resp.json()=}"
+        )
+    resp.raise_for_status()
+    data = resp.json()
+    resp.close()
+    session.close()
 
     return data
 


### PR DESCRIPTION
## Proposed changes
Since we will be adding a delete button to the /manage page for tokens in #471, we need an API endpoint to trigger the deletion. 

Changes in this PR:
- [x] Add a `delete_drop()` function to `queries`
- [x] Clean up related queries code (we weren't deleting keys properly)
- [x] Add the endpoint
- [x] Fix existing broken tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works

Tests passing: https://github.com/thinkst/canarytokens/actions/runs/9500954486
