### PR TITLE
Revise 'How to use' modal 

### DIFF
--- a/frontend_vue/src/components/ModalContentHowToUse.vue
+++ b/frontend_vue/src/components/ModalContentHowToUse.vue
@@ -1,12 +1,9 @@
 <template>
   <ModalContentHowToUseLoader v-if="isLoading" />
   <template v-else>
-    <div class="flex flex-col w-full xl:w-[80%] sm:mt-40 px-8">
-      <HowDoesItWorkSteps
-        :selected-token="props.selectedToken"
-        class="px-16 py-40 bg-white border border-grey-200 rounded-2xl"
-      />
-      <h2 class="px-16 mt-40 text-left text-grey-800">
+    <div class="flex flex-col w-full md:w-[100%] xl:w-[80%] sm:mt-40 px-8">
+      <HowDoesItWorkSteps :selected-token="props.selectedToken" />
+      <h2 class="px-16 mt-40 text-center text-grey-800">
         Ideas for
         <span class="font-semibold"
           >{{ tokenServices[$props.selectedToken].label }} token</span
@@ -15,12 +12,12 @@
       </h2>
       <ul
         v-if="howToUseToken.length > 0"
-        class="flex flex-col w-full gap-16 px-16 my-16 items-left text-grey-800 border-grey-200 rounded-xl"
+        class="flex flex-col w-full gap-16 my-16 items-left text-grey-800"
       >
         <li
           v-for="item in parsedHowToUseToken"
           :key="item.id"
-          class="grid justify-start grid-flow-col gap-8 text-left text-grey-500"
+          class="grid justify-start grid-flow-col gap-8 px-16 py-8 text-left bg-white border rounded-xl border-grey-200 text-grey-500"
         >
           <component
             :is="item.component"
@@ -76,7 +73,7 @@ onMounted(loadHowToUse);
 li::before {
   font-family: 'Font Awesome 6 Free';
   content: '\f0e7';
-  @apply text-grey-300;
+  @apply text-green-500;
 }
 
 p :deep(code) {

--- a/frontend_vue/src/components/ModalContentHowToUse.vue
+++ b/frontend_vue/src/components/ModalContentHowToUse.vue
@@ -1,9 +1,12 @@
 <template>
   <ModalContentHowToUseLoader v-if="isLoading" />
   <template v-else>
-    <div class="flex flex-col w-full md:w-[100%] lg:w-[80%] sm:mt-40 px-8">
-      <HowDoesItWorkSteps :selected-token="props.selectedToken" />
-      <h2 class="mt-40 text-center text-grey-800">
+    <div class="flex flex-col w-full xl:w-[80%] sm:mt-40 px-8">
+      <HowDoesItWorkSteps
+        :selected-token="props.selectedToken"
+        class="px-16 py-40 bg-white border border-grey-200 rounded-2xl"
+      />
+      <h2 class="px-16 mt-40 text-left text-grey-800">
         Ideas for
         <span class="font-semibold"
           >{{ tokenServices[$props.selectedToken].label }} token</span
@@ -12,12 +15,12 @@
       </h2>
       <ul
         v-if="howToUseToken.length > 0"
-        class="flex flex-col w-full gap-16 p-16 my-16 bg-white border items-left text-grey-800 border-grey-200 rounded-xl"
+        class="flex flex-col w-full gap-16 px-16 my-16 items-left text-grey-800 border-grey-200 rounded-xl"
       >
         <li
           v-for="item in parsedHowToUseToken"
           :key="item.id"
-          class="grid justify-start grid-flow-col gap-8 px-16 py-8 text-left text-grey-500"
+          class="grid justify-start grid-flow-col gap-8 text-left text-grey-500"
         >
           <component
             :is="item.component"
@@ -73,7 +76,7 @@ onMounted(loadHowToUse);
 li::before {
   font-family: 'Font Awesome 6 Free';
   content: '\f0e7';
-  @apply text-green-500;
+  @apply text-grey-300;
 }
 
 p :deep(code) {

--- a/frontend_vue/src/components/ModalContentHowToUse.vue
+++ b/frontend_vue/src/components/ModalContentHowToUse.vue
@@ -3,14 +3,21 @@
   <template v-else>
     <div class="flex flex-col w-full md:w-[100%] lg:w-[80%] sm:mt-40 px-8">
       <HowDoesItWorkSteps :selected-token="props.selectedToken" />
+      <h2 class="mt-40 text-center text-grey-800">
+        Ideas for
+        <span class="font-semibold"
+          >{{ tokenServices[$props.selectedToken].label }} token</span
+        >
+        use :
+      </h2>
       <ul
         v-if="howToUseToken.length > 0"
-        class="flex flex-col w-full gap-16 my-16 mt-40 items-left text-grey-800"
+        class="flex flex-col w-full gap-16 p-16 my-16 bg-white border items-left text-grey-800 border-grey-200 rounded-xl"
       >
         <li
           v-for="item in parsedHowToUseToken"
           :key="item.id"
-          class="grid justify-start grid-flow-col gap-8 px-16 py-8 text-left bg-white border rounded-xl border-grey-200 text-grey-500"
+          class="grid justify-start grid-flow-col gap-8 px-16 py-8 text-left text-grey-500"
         >
           <component
             :is="item.component"
@@ -30,6 +37,7 @@
 import { ref, onMounted, computed } from 'vue';
 import ModalContentHowToUseLoader from '@/components/ui/ModalContentHowToUseLoader.vue';
 import HowDoesItWorkSteps from '@/components/ui/HowDoesItWorkSteps.vue';
+import { tokenServices } from '@/utils/tokenServices';
 
 const props = defineProps<{
   selectedToken: string;

--- a/frontend_vue/src/components/tokens/aws_keys/howToUse.ts
+++ b/frontend_vue/src/components/tokens/aws_keys/howToUse.ts
@@ -1,4 +1,4 @@
 export const howToUse = [
-  'These credentials are often stored in a file called <code>~/.aws/credentials</code> on linux/OSX systems. Generate a fake credential pair for your senior developers and sysadmins and keep it on their machines. If someone tries to access AWS with the pair you generated for Bob, chances are that Bob`s been compromised.',
-  'Place the credentials in private code repositories. If the token is triggered, it means that someone is accessing that repo without permission',
+  'The provided AWS credentials are often stored in a file called <code>~/.aws/credentials</code> on linux/OSX systems. Generate a fake credential pair for your senior developers and sysadmins and keep it on their machines. If someone tries to access AWS with the pair you generated for Bob, chances are that Bob`s been compromised.',
+  'Place the provided credentials in private code repositories. If the token is triggered, it means that someone is accessing that repo without permission',
 ];

--- a/frontend_vue/src/components/tokens/azure_id_config/howToUse.ts
+++ b/frontend_vue/src/components/tokens/azure_id_config/howToUse.ts
@@ -1,3 +1,3 @@
 export const howToUse = [
-  'Save this CSS file and upload it as a custom branding stylesheet for your Azure Entra ID login portal (requires a P1 or P2 subscription).',
+  'Save the provided CSS file and upload it as a custom branding stylesheet for your Azure Entra ID login portal (requires a P1 or P2 subscription).',
 ];

--- a/frontend_vue/src/components/tokens/clonedsite/howToUse.ts
+++ b/frontend_vue/src/components/tokens/clonedsite/howToUse.ts
@@ -1,3 +1,3 @@
 export const howToUse = [
-  'Deploy on the login pages of your sensitive sites, such as OWA or tender systems.',
+  'Deploy the provided snippet on the login pages of your sensitive sites, such as OWA or tender systems.',
 ];

--- a/frontend_vue/src/components/tokens/cmd/howToUse.ts
+++ b/frontend_vue/src/components/tokens/cmd/howToUse.ts
@@ -1,5 +1,5 @@
 export const howToUse = [
-  'Ideal candidates are executables often used by attackers but seldom used by regular users (e.g., whoami.exe, net.exe, wmic.exe, etc.).',
-  "You can use this for attacker tools that are not present on your system (e.g., mimikatz.exe), and if they are ever downloaded and run you'll get an alert!",
-  'Use a network management tool to deploy across your organization.',
+  'Ideal candidates for the token are executables often used by attackers but seldom used by regular users (e.g., whoami.exe, net.exe, wmic.exe, etc.).',
+  "You can use the provided tokenized file for attacker tools that are not present on your system (e.g., mimikatz.exe), and if they are ever downloaded and run you'll get an alert!",
+  'Use a network management tool to deploy the file across your organization.',
 ];

--- a/frontend_vue/src/components/tokens/cssclonedsite/howToUse.ts
+++ b/frontend_vue/src/components/tokens/cssclonedsite/howToUse.ts
@@ -1,4 +1,4 @@
 export const howToUse = [
-  'Only the url() portion is required, you can change the selector and add display: hidden if you want to style an invisible element.',
-  "Put this CSS style inline on an HTML element on a site you aren't allowed to add Javascript to (e.g., Wordpress).",
+  'From the provided snippet, only the url() portion is required. You can change the selector and add display: hidden if you want to style an invisible element.',
+  "Put the CSS style inline on an HTML element on a site you aren't allowed to add Javascript to (e.g., Wordpress).",
 ];

--- a/frontend_vue/src/components/tokens/dns/howToUse.ts
+++ b/frontend_vue/src/components/tokens/dns/howToUse.ts
@@ -1,6 +1,6 @@
 export const howToUse = [
-  'Include in a PTR entry for dark IP space of your internal network. Quick way to determine if someone is walking your internal DNS without configuring DNS logging and monitoring.',
-  'Leave in a <code>.bash_history</code>, or  <code>.ssh/config</code>, or <code>~/servers.txt</code>',
-  'Use as a extremely simple bridge between a detection and notification action. Many possibilities, here\'s one that tails a logfile and triggers the token when someone logs in: <code>tail -f /var/log/auth.log | awk `/Accepted publickey for/ { system("host k5198sfh3cw64rhdpm29oo4ga.canarytokens.com") }`</code>',
-  'Use as the domain part of an email address.',
+  'Include the snipept in a PTR entry for dark IP space of your internal network. Quick way to determine if someone is walking your internal DNS without configuring DNS logging and monitoring.',
+  'Leave it in a <code>.bash_history</code>, or  <code>.ssh/config</code>, or <code>~/servers.txt</code>',
+  'Use the snippet as a extremely simple bridge between a detection and notification action. Many possibilities, here\'s one that tails a logfile and triggers the token when someone logs in: <code>tail -f /var/log/auth.log | awk `/Accepted publickey for/ { system("host k5198sfh3cw64rhdpm29oo4ga.canarytokens.com") }`</code>',
+  'Use the snippet  as the domain part of an email address.',
 ];

--- a/frontend_vue/src/components/tokens/fast_redirect/howToUse.ts
+++ b/frontend_vue/src/components/tokens/fast_redirect/howToUse.ts
@@ -1,6 +1,6 @@
 export const howToUse = [
-  'Replace links with these to capture user information before user is redirected to where they want to go.',
-  'Embedded in documents.',
-  'Inserted into canary webpages that are only found through brute-force.',
-  'This URL is just an example. Apart from the hostname and the actual token (the random string), you can change all other parts of the URL.',
+  'Replace links with the provided token to capture user information before user is redirected to where they want to go.',
+  'Embedded the token in documents.',
+  'Inserted the token into canary webpages that are only found through brute-force.',
+  'The provided URL is just an example. Apart from the hostname and the actual token (the random string), you can change all other parts of the URL.',
 ];

--- a/frontend_vue/src/components/tokens/fast_redirect/howToUse.ts
+++ b/frontend_vue/src/components/tokens/fast_redirect/howToUse.ts
@@ -1,6 +1,6 @@
 export const howToUse = [
   'Replace links with the provided token to capture user information before user is redirected to where they want to go.',
-  'Embedded the token in documents.',
-  'Inserted the token into canary webpages that are only found through brute-force.',
+  'Embed the token in documents.',
+  'Insert the token into canary webpages that are only found through brute-force.',
   'The provided URL is just an example. Apart from the hostname and the actual token (the random string), you can change all other parts of the URL.',
 ];

--- a/frontend_vue/src/components/tokens/kubeconfig/howToUse.ts
+++ b/frontend_vue/src/components/tokens/kubeconfig/howToUse.ts
@@ -1,4 +1,4 @@
 export const howToUse = [
-  'Place the file at <code>~/.kube/config</code> on a host, tempting an attacker to use it.',
-  'Place the file in private code repositories. If the token is triggered, it means that someone is accessing that repo without permission.',
+  'Place the tokenized file at <code>~/.kube/config</code> on a host, tempting an attacker to use it.',
+  'Place the tokenized file in private code repositories. If the token is triggered, it means that someone is accessing that repo without permission.',
 ];

--- a/frontend_vue/src/components/tokens/log4shell/howToUse.ts
+++ b/frontend_vue/src/components/tokens/log4shell/howToUse.ts
@@ -1,4 +1,4 @@
 export const howToUse = [
-'Enter the resultant string into web based search boxes and fields that will be parsed by your logging libraries.',
-'Add the string to HTTP Request Headers.',
-'Use the string in automated scanners.'];
+'Enter the provided string into web based search boxes and fields that will be parsed by your logging libraries.',
+'Add the provided string to HTTP Request Headers.',
+'Use the provided string in automated scanners.'];

--- a/frontend_vue/src/components/tokens/ms_excel/howToUse.ts
+++ b/frontend_vue/src/components/tokens/ms_excel/howToUse.ts
@@ -1,5 +1,5 @@
 export const howToUse = [
-  'Drop the file on a Windows network share.',
+  'Drop the provided file on a Windows network share.',
   'Leave the file on a web server in an inaccessible directory, to detect webserver breaches.',
-  'Attach to an email with a tempting Subject line.',
+  'Attach the file to an email with a tempting Subject line.',
 ];

--- a/frontend_vue/src/components/tokens/ms_word/howToUse.ts
+++ b/frontend_vue/src/components/tokens/ms_word/howToUse.ts
@@ -1,5 +1,5 @@
 export const howToUse = [
-  'Drop the file on a Windows network share.',
+  'Drop the provided file on a Windows network share.',
   'Leave the file on a web server in an inaccessible directory, to detect webserver breaches.',
-  'Attach to an email with a tempting Subject line.',
+  'Attach the file to an email with a tempting Subject line.',
 ];

--- a/frontend_vue/src/components/tokens/my_sql/howToUse.ts
+++ b/frontend_vue/src/components/tokens/my_sql/howToUse.ts
@@ -1,3 +1,3 @@
 export const howToUse = [
-  'Attackers who find MySQL dump files will usually throw them into a temporary database to query the data. When a dump file with this snippet is ingested, it will let us know.',
+  'Attackers who find MySQL dump files will usually throw them into a temporary database to query the data. When a dump file with the provided snippet is ingested, it will let us know.',
 ];

--- a/frontend_vue/src/components/tokens/qr_code/howToUse.ts
+++ b/frontend_vue/src/components/tokens/qr_code/howToUse.ts
@@ -1,5 +1,5 @@
 export const howToUse = [
-  'On containers left in secure locations.',
-  'Underneath your phone battery when crossing international borders.',
-  'On your desk.',
+  'Leave the provided QR code on containers left in secure locations.',
+  'Add the QR code Underneath your phone battery when crossing international borders.',
+  'Place the QR code on your desk.',
 ];

--- a/frontend_vue/src/components/tokens/slow_redirect/howToUse.ts
+++ b/frontend_vue/src/components/tokens/slow_redirect/howToUse.ts
@@ -1,6 +1,6 @@
 export const howToUse = [
-  'Replace links with these to capture user information before user is redirected to where they want to go.',
-  'Embedded in documents.',
-  'Inserted into canary webpages that are only found through brute-force.',
-  'This URL is just an example. Apart from the hostname and the actual token (the random string), you can change all other parts of the URL.',
+  'Replace links with the provided ones to capture user information before user is redirected to where they want to go.',
+  'Embed token in documents.',
+  'Insert token into canary webpages that are only found through brute-force.',
+  'The provided URL is just an example. Apart from the hostname and the actual token (the random string), you can change all other parts of the URL.',
 ];

--- a/frontend_vue/src/components/tokens/smtp/howToUse.ts
+++ b/frontend_vue/src/components/tokens/smtp/howToUse.ts
@@ -1,3 +1,3 @@
 export const howToUse = [
-  'In a database with a USERS table, drop a fake record in there with this email address. If it gets triggered you know someone has accessed your data.',
+  'Place the token in a database with a USERS table, drop a fake record in there with this email address. If it gets triggered you know someone has accessed your data.',
 ];

--- a/frontend_vue/src/components/tokens/web/howToUse.ts
+++ b/frontend_vue/src/components/tokens/web/howToUse.ts
@@ -1,5 +1,5 @@
 export const howToUse = [
-  'In an email with a juicy subject line.',
-  'Embedded in documents.',
-  'This URL is just an example. Apart from the hostname and the actual token (the random string), you can change all other parts of the URL.',
+  'Add it to an email with a juicy subject line.',
+  'Embed it in documents.',
+  'The provided URL is just an example. Apart from the hostname and the actual token (the random string), you can change all other parts of the URL.',
 ];

--- a/frontend_vue/src/components/tokens/web_image/howToUse.ts
+++ b/frontend_vue/src/components/tokens/web_image/howToUse.ts
@@ -1,6 +1,6 @@
 export const howToUse = [
-  'In an email with a juicy subject line.',
-  'Embedded in documents.',
-  'Inserted into canary webpages that are only found through brute-force.',
-  'This URL is just an example. Apart from the hostname and the actual token (the random string), you can change all other parts of the URL.',
+  'Add it to an email with a juicy subject line.',
+  'Embed it in documents.',
+  'Insert it into canary webpages that are only found through brute-force.',
+  'The provided URL is just an example. Apart from the hostname and the actual token (the random string), you can change all other parts of the URL.',
 ];

--- a/frontend_vue/src/components/tokens/windows_dir/howToUse.ts
+++ b/frontend_vue/src/components/tokens/windows_dir/howToUse.ts
@@ -1,4 +1,4 @@
 export const howToUse = [
-  'Unzip the file on a juicely named Windows network share.',
-  "Unzip the file on a folder on your CEO's laptop.",
+  'Unzip the provided file on a juicely named Windows network share.',
+  "Unzip the provided file on a folder on your CEO's laptop.",
 ];


### PR DESCRIPTION
## Proposed changes

- Add title to list of 'Ideas to use'
- Clarify instructions for every token: with the previous flow, the _ideas_ clearly referred to a newly created token/snippet. Here the connection is not that obvious, so I slightly rephrase the list of instructions.

<img width="782" alt="Screenshot 2024-06-19 at 15 45 41" src="https://github.com/thinkst/canarytokens/assets/126554007/9a75d70e-0190-457c-804e-6d9aea063d59">

