### PR TITLE
Update MySQL command with new syntax

### DIFF
--- a/canarytokens/canarydrop.py
+++ b/canarytokens/canarydrop.py
@@ -343,10 +343,10 @@ class Canarydrop(BaseModel):
     def generate_mysql_usage(
         token: str, domain: str, port: int, encoded: bool = True
     ) -> str:
-        magic_sauce = "SET @bb = CONCAT(\"CHANGE MASTER TO MASTER_PASSWORD='my-secret-pw', MASTER_RETRY_COUNT=1, "
-        magic_sauce += f"MASTER_PORT={port}, "
-        magic_sauce += f"MASTER_HOST='{domain}', "
-        magic_sauce += f'MASTER_USER=\'{token}", @@lc_time_names, @@hostname, "\';");'
+        magic_sauce = "SET @bb = CONCAT(\"CHANGE REPLICATION SOURCE TO SOURCE_PASSWORD='my-secret-pw', SOURCE_RETRY_COUNT=1, "
+        magic_sauce += f"SOURCE_PORT={port}, "
+        magic_sauce += f"SOURCE_HOST='{domain}', "
+        magic_sauce += f'SOURCE_USER=\'{token}", @@lc_time_names, @@hostname, "\';");'
         if not encoded:
             usage = textwrap.dedent(
                 f"""

--- a/canarytokens/mysql.py
+++ b/canarytokens/mysql.py
@@ -100,8 +100,8 @@ if __name__ == "__main__":
     c = CanarydropTest()
 
     magic_sauce = (
-        "SET @bb = CONCAT(\"CHANGE MASTER TO MASTER_PASSWORD='my-secret-pw', MASTER_RETRY_COUNT=1, MASTER_PORT=3306,"
-        + f"MASTER_HOST='{c.get_hostname()}', MASTER_USER='{c.canarytoken()}\", @@lc_time_names, @@hostname, \"';\");"
+        "SET @bb = CONCAT(\"CHANGE REPLICATION SOURCE TO SOURCE_PASSWORD='my-secret-pw', SOURCE_RETRY_COUNT=1, SOURCE_PORT=3306,"
+        + f"SOURCE_HOST='{c.get_hostname()}', SOURCE_USER='{c.canarytoken()}\", @@lc_time_names, @@hostname, \"';\");"
     )
 
     with open("mysql_dump.sql.gz", "wb+") as f:

--- a/templates/generate_new.html
+++ b/templates/generate_new.html
@@ -1558,7 +1558,7 @@ START REPLICA;
           }
         }
         var _handleMySQLResponse = function(data) {
-          var cmd = `SET @bb = CONCAT(\"CHANGE MASTER TO MASTER_PASSWORD='my-secret-pw', MASTER_RETRY_COUNT=1, MASTER_PORT=3306, MASTER_HOST='${data['hostname']}', MASTER_USER='${data['token']}\", @@lc_time_names, @@hostname, \"';\");`
+          var cmd = `SET @bb = CONCAT(\"CHANGE REPLICATION SOURCE TO SOURCE_PASSWORD='my-secret-pw', SOURCE_RETRY_COUNT=1, SOURCE_PORT=3306, SOURCE_HOST='${data['hostname']}', SOURCE_USER='${data['token']}\", @@lc_time_names, @@hostname, \"';\");`
 
           $('.mysql-cmd').text(btoa(cmd));
           $('.mysql-cmd-decoded').text(cmd);

--- a/templates/manage_new.html
+++ b/templates/manage_new.html
@@ -651,7 +651,7 @@ START REPLICA;
         aws_keys_token.innerHTML = aws_keys_token.innerHTML.trim()
       }
       var _handleMySQLResponse = function(data) {
-          var cmd = `SET @bb = CONCAT(\"CHANGE MASTER TO MASTER_PASSWORD='my-secret-pw', MASTER_RETRY_COUNT=1, MASTER_PORT=3306, MASTER_HOST='${data['generated_hostname']}', MASTER_USER='${data['token']}\", @@lc_time_names, @@hostname, \"';\");`
+          var cmd = `SET @bb = CONCAT(\"CHANGE REPLICATION SOURCE TO SOURCE_PASSWORD='my-secret-pw', SOURCE_RETRY_COUNT=1, SOURCE_PORT=3306, SOURCE_HOST='${data['generated_hostname']}', SOURCE_USER='${data['token']}\", @@lc_time_names, @@hostname, \"';\");`
 
           $('.mysql-cmd').text(btoa(cmd));
           $('.mysql-cmd-decoded').text(cmd);


### PR DESCRIPTION
## Proposed changes

Update MySQL syntax to reflect [changes made](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-23.html#:~:text=From%20MySQL%208.0.23,versions%20are%20used.) in version 8.0.23 and over. Prior to this syntax update, the Canarytoken wouldn't fire on newer versions of MySQL.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion