### PR TITLE
Update syntax for MySQL token

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,11 +36,11 @@ repos:
         - id: terraform_fmt
         # - id: terraform_tfsec install is suboptimal
 
--   repo: local
-    hooks:
-    -   id: typescript-check
-        name: Typescript Checker
-        entry: npm run --prefix frontend_vue type-check
-        types_or: [javascript, jsx, ts, tsx, vue]
-        language: system
-        pass_filenames: false
+# -   repo: local
+#     hooks:
+#     -   id: typescript-check
+#         name: Typescript Checker
+#         entry: npm run --prefix frontend_vue type-check
+#         types_or: [javascript, jsx, ts, tsx, vue]
+#         language: system
+#         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,11 +36,11 @@ repos:
         - id: terraform_fmt
         # - id: terraform_tfsec install is suboptimal
 
-# -   repo: local
-#     hooks:
-#     -   id: typescript-check
-#         name: Typescript Checker
-#         entry: npm run --prefix frontend_vue type-check
-#         types_or: [javascript, jsx, ts, tsx, vue]
-#         language: system
-#         pass_filenames: false
+-   repo: local
+    hooks:
+    -   id: typescript-check
+        name: Typescript Checker
+        entry: npm run --prefix frontend_vue type-check
+        types_or: [javascript, jsx, ts, tsx, vue]
+        language: system
+        pass_filenames: false

--- a/frontend_vue/src/components/tokens/my_sql/generateMysqlToken.ts
+++ b/frontend_vue/src/components/tokens/my_sql/generateMysqlToken.ts
@@ -3,19 +3,19 @@ export default function generateMysqlToken(
   token: string,
   encoded: boolean
 ) {
-  const decodedCode = `SET @bb = CONCAT(\"CHANGE MASTER TO MASTER_PASSWORD='my-secret-pw', MASTER_RETRY_COUNT=1, MASTER_PORT=3306, MASTER_HOST='${hostname}', MASTER_USER='${token}\", @@lc_time_names, @@hostname, \"';\")`;
+  const decodedCode = `SET @bb = CONCAT(\"CHANGE REPLICATION SOURCE TO SOURCE_PASSWORD='my-secret-pw', SOURCE_RETRY_COUNT=1, SOURCE_PORT=3306, SOURCE_HOST='${hostname}', SOURCE_USER='${token}\", @@lc_time_names, @@hostname, \"';\")`;
   const encodedCode = btoa(
-    `SET @bb = CONCAT(\"CHANGE MASTER TO MASTER_PASSWORD='my-secret-pw', MASTER_RETRY_COUNT=1, MASTER_PORT=3306, MASTER_HOST='${hostname}', MASTER_USER='${token}\", @@lc_time_names, @@hostname, \"';\"`
+    `SET @bb = CONCAT(\"CHANGE REPLICATION SOURCE TO SOURCE_PASSWORD='my-secret-pw', SOURCE_RETRY_COUNT=1, SOURCE_PORT=3306, SOURCE_HOST='${hostname}', SOURCE_USER='${token}\", @@lc_time_names, @@hostname, \"';\"`
   );
   const code = encoded
-    ? `SET @b = ${encodedCode}; 
+    ? `SET @b = ${encodedCode};
 SET @s2 = FROM_BASE64(@b);
 PREPARE stmt1 FROM @s2;
 EXECUTE stmt1;
 PREPARE stmt2 FROM @bb;
 EXECUTE stmt2;
 START REPLICA;`
-    : `${decodedCode}; 
+    : `${decodedCode};
 PREPARE stmt FROM @bb;
 EXECUTE stmt;
 START REPLICA;`;


### PR DESCRIPTION
Changes to MySQL token's syntax that have gone in on `master` [here](https://github.com/thinkst/canarytokens/pull/496).