### PR TITLE
Delay the confetti shot until the dynamic component is loaded

### DIFF
--- a/frontend_vue/src/components/ModalContentActivatedToken.vue
+++ b/frontend_vue/src/components/ModalContentActivatedToken.vue
@@ -53,4 +53,6 @@ async function loadComponent() {
   console.log(dynamicComponent)
   launchConfetti(tokenType)
 }
+
+loadComponent();
 </script>

--- a/frontend_vue/src/components/ModalContentActivatedToken.vue
+++ b/frontend_vue/src/components/ModalContentActivatedToken.vue
@@ -29,10 +29,11 @@
 </template>
 
 <script setup lang="ts">
-import { defineAsyncComponent, ref } from 'vue';
+import { defineAsyncComponent, shallowRef } from 'vue';
 import { tokenServices } from '@/utils/tokenServices';
 import getImageUrl from '@/utils/getImageUrl';
 import TokenIcon from '@/components/icons/TokenIcon.vue';
+import { launchConfetti } from '@/utils/confettiEffect';
 
 const props = defineProps<{
   newTokenResponse: { token_type: string } & Record<string, unknown>;
@@ -40,15 +41,20 @@ const props = defineProps<{
 
 defineEmits(['howToUse']);
 
-const dynamicComponent = ref({
-  props: {},
-});
+const dynamicComponent = shallowRef();
+
 const tokenType = props.newTokenResponse.token_type;
 
 async function loadComponent() {
   dynamicComponent.value = defineAsyncComponent(
     () => import(`@/components/tokens/${tokenType}/ActivatedToken.vue`)
   );
+  // When defining an async component
+  // Vue adds an __asyncLoader() method to the component instance.
+  // This method returns a promise that resolves when the component finishes loading.
+  await dynamicComponent.value.__asyncLoader();
+
+  launchConfetti(tokenType)
 }
 
 loadComponent();

--- a/frontend_vue/src/components/ModalContentActivatedToken.vue
+++ b/frontend_vue/src/components/ModalContentActivatedToken.vue
@@ -33,7 +33,6 @@ import { defineAsyncComponent, ref } from 'vue';
 import { tokenServices } from '@/utils/tokenServices';
 import getImageUrl from '@/utils/getImageUrl';
 import TokenIcon from '@/components/icons/TokenIcon.vue';
-import { launchConfetti } from '@/utils/confettiEffect';
 
 const props = defineProps<{
   newTokenResponse: { token_type: string } & Record<string, unknown>;
@@ -50,9 +49,6 @@ async function loadComponent() {
   dynamicComponent.value = defineAsyncComponent(
     () => import(`@/components/tokens/${tokenType}/ActivatedToken.vue`)
   );
-  setTimeout(() => {
-    launchConfetti(tokenType)
-  }, 1500);
 }
 
 loadComponent();

--- a/frontend_vue/src/components/ModalContentActivatedToken.vue
+++ b/frontend_vue/src/components/ModalContentActivatedToken.vue
@@ -50,10 +50,7 @@ async function loadComponent() {
   dynamicComponent.value = defineAsyncComponent(
     () => import(`@/components/tokens/${tokenType}/ActivatedToken.vue`)
   );
+  console.log(dynamicComponent)
+  launchConfetti(tokenType)
 }
-
-const comp = loadComponent();
-console.log(comp)
-
-launchConfetti(tokenType)
 </script>

--- a/frontend_vue/src/components/ModalContentActivatedToken.vue
+++ b/frontend_vue/src/components/ModalContentActivatedToken.vue
@@ -50,8 +50,9 @@ async function loadComponent() {
   dynamicComponent.value = defineAsyncComponent(
     () => import(`@/components/tokens/${tokenType}/ActivatedToken.vue`)
   );
-  console.log(dynamicComponent)
-  launchConfetti(tokenType)
+  setTimeout(() => {
+    launchConfetti(tokenType)
+  }, 1500);
 }
 
 loadComponent();

--- a/frontend_vue/src/components/ModalContentActivatedToken.vue
+++ b/frontend_vue/src/components/ModalContentActivatedToken.vue
@@ -33,6 +33,7 @@ import { defineAsyncComponent, ref } from 'vue';
 import { tokenServices } from '@/utils/tokenServices';
 import getImageUrl from '@/utils/getImageUrl';
 import TokenIcon from '@/components/icons/TokenIcon.vue';
+import { launchConfetti } from '@/utils/confettiEffect';
 
 const props = defineProps<{
   newTokenResponse: { token_type: string } & Record<string, unknown>;
@@ -51,5 +52,8 @@ async function loadComponent() {
   );
 }
 
-loadComponent();
+const comp = loadComponent();
+console.log(comp)
+
+launchConfetti(tokenType)
 </script>

--- a/frontend_vue/src/components/ModalContentActivatedToken.vue
+++ b/frontend_vue/src/components/ModalContentActivatedToken.vue
@@ -37,6 +37,7 @@ import { launchConfetti } from '@/utils/confettiEffect';
 
 const props = defineProps<{
   newTokenResponse: { token_type: string } & Record<string, unknown>;
+  shootConfetti: boolean;
 }>();
 
 defineEmits(['howToUse']);
@@ -51,8 +52,7 @@ async function loadComponent() {
   );
   //  Wait for the dynamic component to load before firing the confetti
   await dynamicComponent.value.__asyncLoader();
-
-  launchConfetti(tokenType)
+  if (props.shootConfetti) launchConfetti(tokenType);
 }
 
 loadComponent();

--- a/frontend_vue/src/components/ModalContentActivatedToken.vue
+++ b/frontend_vue/src/components/ModalContentActivatedToken.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="relative">
-    <component
-      :is=tokenIcon
+    <TokenIcon
       :title="tokenServices[tokenType].label"
       :logo-img-url="tokenServices[tokenType].icon"
       class="w-[6rem] pb-16"
@@ -43,7 +42,6 @@ const props = defineProps<{
 defineEmits(['howToUse']);
 
 const dynamicComponent = shallowRef();
-const tokenIcon = shallowRef();
 
 const tokenType = props.newTokenResponse.token_type;
 
@@ -51,12 +49,9 @@ async function loadComponent() {
   dynamicComponent.value = defineAsyncComponent(
     () => import(`@/components/tokens/${tokenType}/ActivatedToken.vue`)
   );
-  tokenIcon.value = defineAsyncComponent(
-    () => import(`@/components/icons/TokenIcon.vue`)
-  );
+  //  Wait for the dynamic component to load before firing the confetti
+  await dynamicComponent.value.__asyncLoader();
 
-  // Wait for the token icon to load before firing the confetti
-  await tokenIcon.value.__asyncLoader();
   launchConfetti(tokenType)
 }
 

--- a/frontend_vue/src/components/ModalContentActivatedToken.vue
+++ b/frontend_vue/src/components/ModalContentActivatedToken.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="relative">
-    <TokenIcon
+    <component
+      :is=tokenIcon
       :title="tokenServices[tokenType].label"
       :logo-img-url="tokenServices[tokenType].icon"
       class="w-[6rem] pb-16"
@@ -42,6 +43,7 @@ const props = defineProps<{
 defineEmits(['howToUse']);
 
 const dynamicComponent = shallowRef();
+const tokenIcon = shallowRef();
 
 const tokenType = props.newTokenResponse.token_type;
 
@@ -49,11 +51,12 @@ async function loadComponent() {
   dynamicComponent.value = defineAsyncComponent(
     () => import(`@/components/tokens/${tokenType}/ActivatedToken.vue`)
   );
-  // When defining an async component
-  // Vue adds an __asyncLoader() method to the component instance.
-  // This method returns a promise that resolves when the component finishes loading.
-  await dynamicComponent.value.__asyncLoader();
+  tokenIcon.value = defineAsyncComponent(
+    () => import(`@/components/icons/TokenIcon.vue`)
+  );
 
+  // Wait for the token icon to load before firing the confetti
+  await tokenIcon.value.__asyncLoader();
   launchConfetti(tokenType)
 }
 

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -263,9 +263,6 @@ async function handleGenerateToken(formValues: BaseFormValuesType) {
     modalType.value = ModalType.NewToken;
     // Keep track of loaded components
     componentStack.value.push(modalType.value);
-    setTimeout(() => {
-      launchConfetti(props.selectedToken)
-    }, 1000);
   } catch (err) {
     triggerSubmit.value = false;
     isGenerateTokenError.value = true;

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -134,7 +134,6 @@ import ButtonHowToDeploy from '@/components/ui/ButtonHowToDeploy.vue';
 import { generateToken } from '@/api/main';
 import { TOKENS_TYPE } from './constants';
 import { tokenServices } from '@/utils/tokenServices';
-import { launchConfetti } from '@/utils/confettiEffect';
 
 enum ModalType {
   AddToken = 'addToken',

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -263,6 +263,9 @@ async function handleGenerateToken(formValues: BaseFormValuesType) {
     modalType.value = ModalType.NewToken;
     // Keep track of loaded components
     componentStack.value.push(modalType.value);
+    setTimeout(() => {
+      launchConfetti(props.selectedToken)
+    }, 1000);
   } catch (err) {
     triggerSubmit.value = false;
     isGenerateTokenError.value = true;

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -47,6 +47,7 @@
     <Suspense v-if="modalType === ModalType.NewToken">
       <ModalContentActivatedToken
         :new-token-response="newTokenResponse"
+        :shoot-confetti=shootConfetti
         @how-to-use="handleHowToUseButton"
       />
       <template #fallback>
@@ -162,6 +163,7 @@ const errorMessage = ref('');
 const isLoadngSubmit = ref(false);
 const isLoading = ref(false);
 const showTooltip = ref(false);
+const shootConfetti = ref(false);
 // Stack to keep track of loaded components
 // Used for Modal navigation
 const componentStack = ref<string[]>([]);
@@ -300,6 +302,14 @@ watch(isLoading, () => {
     setTimeout(() => {
       showTooltip.value = false;
     }, 2000);
+  }
+});
+// Only shoot confetti after generating a new token
+watch(modalType, (newVal, oldVal) => {
+  if (oldVal === 'addToken' && newVal === 'newToken') {
+    shootConfetti.value =  true;
+  } else {
+    shootConfetti.value =  false;
   }
 });
 </script>

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -263,7 +263,9 @@ async function handleGenerateToken(formValues: BaseFormValuesType) {
     modalType.value = ModalType.NewToken;
     // Keep track of loaded components
     componentStack.value.push(modalType.value);
-    launchConfetti(props.selectedToken);
+    // setTimeout(() => {
+    //   launchConfetti(props.selectedToken);
+    // }, 1000);
   } catch (err) {
     triggerSubmit.value = false;
     isGenerateTokenError.value = true;

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -263,9 +263,6 @@ async function handleGenerateToken(formValues: BaseFormValuesType) {
     modalType.value = ModalType.NewToken;
     // Keep track of loaded components
     componentStack.value.push(modalType.value);
-    // setTimeout(() => {
-    //   launchConfetti(props.selectedToken);
-    // }, 1000);
   } catch (err) {
     triggerSubmit.value = false;
     isGenerateTokenError.value = true;

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -306,7 +306,7 @@ watch(isLoading, () => {
 });
 // Only shoot confetti after generating a new token
 watch(modalType, (newVal, oldVal) => {
-  if (oldVal === 'addToken' && newVal === 'newToken') {
+  if (oldVal === ModalType.AddToken && newVal === ModalType.NewToken) {
     shootConfetti.value =  true;
   } else {
     shootConfetti.value =  false;

--- a/frontend_vue/src/utils/confettiEffect.ts
+++ b/frontend_vue/src/utils/confettiEffect.ts
@@ -35,7 +35,7 @@ export function launchConfetti(token_type: string) {
   myConfetti({
     particleCount: 100,
     spread: 160,
-    origin: { y: 0.4 },
+    origin: { y: 0.3 },
     colors: TOKEN_COLOR_PALETTES[token_type] || [
       '#F2059F',
       '#04D9B2',


### PR DESCRIPTION
## Proposed changes
- This PR adds a delay to fire the confetti only after the dynamic component is loaded up

## How to test
- https://honeypdfs.net/nest/

## Demo

https://github.com/thinkst/canarytokens/assets/145110595/225d6fbb-941d-4ab2-b6d4-d90d4cc50759

_Only show confetti after creating a new token_

https://github.com/thinkst/canarytokens/assets/145110595/2f27cf3e-75b6-4e09-b7f1-688137bd9fe0


