### PR TITLE
Add native browser transitions

### DIFF
--- a/frontend_vue/src/components/HistoryToken.vue
+++ b/frontend_vue/src/components/HistoryToken.vue
@@ -101,7 +101,7 @@ import CustomMap from '@/components/ui/CustomMap.vue';
 import BannerDeviceCanarytools from '@/components/ui/BannerDeviceCanarytools.vue';
 import IncidentDetails from '@/components/ui/IncidentDetails.vue';
 import AlertsListDownload from '@/components/ui/AlertsListDownload.vue';
-import { startViewTransition } from '@/utils/utils';
+import { addViewTransition } from '@/utils/utils';
 
 const emits = defineEmits(['update-token-title']);
 
@@ -144,7 +144,7 @@ async function fetchTokenHistoryData() {
 }
 
 async function handleSelectAlert(incident: HitsType) {
-  await startViewTransition(() => (selectedAlert.value = incident));
+  await addViewTransition(() => (selectedAlert.value = incident));
   const container = document.getElementById('incident_detail');
   container
     ? container.scrollTo({ top: 0, behavior: 'smooth' })

--- a/frontend_vue/src/components/HistoryToken.vue
+++ b/frontend_vue/src/components/HistoryToken.vue
@@ -101,6 +101,7 @@ import CustomMap from '@/components/ui/CustomMap.vue';
 import BannerDeviceCanarytools from '@/components/ui/BannerDeviceCanarytools.vue';
 import IncidentDetails from '@/components/ui/IncidentDetails.vue';
 import AlertsListDownload from '@/components/ui/AlertsListDownload.vue';
+import { startViewTransition } from '@/utils/utils';
 
 const emits = defineEmits(['update-token-title']);
 
@@ -142,8 +143,8 @@ async function fetchTokenHistoryData() {
   }
 }
 
-function handleSelectAlert(incident: HitsType) {
-  selectedAlert.value = incident;
+async function handleSelectAlert(incident: HitsType) {
+  await startViewTransition(() => (selectedAlert.value = incident));
   const container = document.getElementById('incident_detail');
   container
     ? container.scrollTo({ top: 0, behavior: 'smooth' })

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -136,7 +136,7 @@ import { generateToken } from '@/api/main';
 import { TOKENS_TYPE } from './constants';
 import { tokenServices } from '@/utils/tokenServices';
 import { launchConfetti } from '@/utils/confettiEffect';
-import { startViewTransition } from '@/utils/utils';
+import { addViewTransition } from '@/utils/utils';
 
 enum ModalType {
   AddToken = 'addToken',
@@ -213,7 +213,7 @@ function handleAddTokenButton() {
 }
 
 async function handleHowToUseButton() {
-  await startViewTransition(
+  await addViewTransition(
     () => (modalType.value = ModalType.HowToUse)
     // Keep track of loaded components
   ).then(() => componentStack.value.push(modalType.value));
@@ -233,7 +233,7 @@ async function handleBackButton() {
     props.closeModal();
   } else {
     // Otherwise, show the top component from the stack
-    await startViewTransition(
+    await addViewTransition(
       () =>
         (modalType.value =
           componentStack.value[componentStack.value.length - 1])
@@ -268,7 +268,7 @@ async function handleGenerateToken(formValues: BaseFormValuesType) {
     isLoadngSubmit.value = false;
     triggerSubmit.value = false;
 
-    await startViewTransition(
+    await addViewTransition(
       () => (modalType.value = ModalType.NewToken)
       // Keep track of loaded components
     ).then(() => componentStack.value.push(modalType.value));

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -135,6 +135,8 @@ import ButtonHowToDeploy from '@/components/ui/ButtonHowToDeploy.vue';
 import { generateToken } from '@/api/main';
 import { TOKENS_TYPE } from './constants';
 import { tokenServices } from '@/utils/tokenServices';
+import { launchConfetti } from '@/utils/confettiEffect';
+import { startViewTransition } from '@/utils/utils';
 
 enum ModalType {
   AddToken = 'addToken',
@@ -210,10 +212,11 @@ function handleAddTokenButton() {
   triggerSubmit.value = true;
 }
 
-function handleHowToUseButton() {
-  modalType.value = ModalType.HowToUse;
-  // Keep track of loaded components
-  componentStack.value.push(modalType.value);
+async function handleHowToUseButton() {
+  await startViewTransition(
+    () => (modalType.value = ModalType.HowToUse)
+    // Keep track of loaded components
+  ).then(() => componentStack.value.push(modalType.value));
 }
 
 function handleManageTokenButton() {
@@ -223,14 +226,18 @@ function handleManageTokenButton() {
   props.closeModal();
 }
 
-function handleBackButton() {
+async function handleBackButton() {
   componentStack.value.pop();
   // If the stack is empty, close the modal
   if (componentStack.value.length === 0) {
     props.closeModal();
   } else {
     // Otherwise, show the top component from the stack
-    modalType.value = componentStack.value[componentStack.value.length - 1];
+    await startViewTransition(
+      () =>
+        (modalType.value =
+          componentStack.value[componentStack.value.length - 1])
+    );
   }
 }
 
@@ -259,11 +266,13 @@ async function handleGenerateToken(formValues: BaseFormValuesType) {
     isGenerateTokenError.value = false;
     errorMessage.value = '';
     isLoadngSubmit.value = false;
-
     triggerSubmit.value = false;
-    modalType.value = ModalType.NewToken;
-    // Keep track of loaded components
-    componentStack.value.push(modalType.value);
+
+    await startViewTransition(
+      () => (modalType.value = ModalType.NewToken)
+      // Keep track of loaded components
+    ).then(() => componentStack.value.push(modalType.value));
+    launchConfetti(props.selectedToken);
   } catch (err) {
     triggerSubmit.value = false;
     isGenerateTokenError.value = true;

--- a/frontend_vue/src/components/ModalToken.vue
+++ b/frontend_vue/src/components/ModalToken.vue
@@ -135,7 +135,6 @@ import ButtonHowToDeploy from '@/components/ui/ButtonHowToDeploy.vue';
 import { generateToken } from '@/api/main';
 import { TOKENS_TYPE } from './constants';
 import { tokenServices } from '@/utils/tokenServices';
-import { launchConfetti } from '@/utils/confettiEffect';
 import { addViewTransition } from '@/utils/utils';
 
 enum ModalType {
@@ -272,7 +271,6 @@ async function handleGenerateToken(formValues: BaseFormValuesType) {
       () => (modalType.value = ModalType.NewToken)
       // Keep track of loaded components
     ).then(() => componentStack.value.push(modalType.value));
-    launchConfetti(props.selectedToken);
   } catch (err) {
     triggerSubmit.value = false;
     isGenerateTokenError.value = true;

--- a/frontend_vue/src/components/ui/AppLogo.vue
+++ b/frontend_vue/src/components/ui/AppLogo.vue
@@ -1,12 +1,23 @@
 <template>
-  <RouterLink
-    to="/"
+  <button
     class="focus-visible:border-none focus-visible:outline-none focus-visible:ring-2 focus:ring-offset-2 focus:ring-green-500"
+    type="button"
+    @click="handleLinkClick('/')"
   >
+    <span class="sr-only">Home</span>
     <LogoNavbar class="w-[15rem] min-w-[12rem]" />
-  </RouterLink>
+  </button>
 </template>
 
 <script setup lang="ts">
 import LogoNavbar from '@/components/icons/LogoNavbar.vue';
+import { useRouter } from 'vue-router';
+import { startViewTransition } from '@/utils/utils';
+
+const router = useRouter();
+
+function handleLinkClick(path: string) {
+  //@ts-ignore
+  startViewTransition(() => router.push(path));
+}
 </script>

--- a/frontend_vue/src/components/ui/AppLogo.vue
+++ b/frontend_vue/src/components/ui/AppLogo.vue
@@ -12,12 +12,12 @@
 <script setup lang="ts">
 import LogoNavbar from '@/components/icons/LogoNavbar.vue';
 import { useRouter } from 'vue-router';
-import { startViewTransition } from '@/utils/utils';
+import { addViewTransition } from '@/utils/utils';
 
 const router = useRouter();
 
 function handleLinkClick(path: string) {
   //@ts-ignore
-  startViewTransition(() => router.push(path));
+  addViewTransition(() => router.push(path));
 }
 </script>

--- a/frontend_vue/src/style.css
+++ b/frontend_vue/src/style.css
@@ -29,7 +29,6 @@
 body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
-  view-transition-name: page;
 }
 
 img,
@@ -92,6 +91,11 @@ p {
 }
 
 @media (prefers-reduced-motion: reduce) {
+  ::view-transition-group(*),
+  ::view-transition-old(*),
+  ::view-transition-new(*) {
+    animation: none !important;
+  }
   * {
     animation: none !important;
     transition: none !important;

--- a/frontend_vue/src/utils/utils.ts
+++ b/frontend_vue/src/utils/utils.ts
@@ -34,8 +34,7 @@ export const sqlInjectionPattern = /\b(or 1=1|OR 1=1)\b/;
 // Adds transition to the view
 // Available only on last versions of Chrome, Edge, Opera
 // https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API#browser_compatibility
-export function startViewTransition(callback: () => void) {
-
+export function addViewTransition(callback: () => void) {
   return new Promise<void>((resolve) => {
     const transitionCallback = () => {
       callback();

--- a/frontend_vue/src/utils/utils.ts
+++ b/frontend_vue/src/utils/utils.ts
@@ -30,3 +30,23 @@ export function isObject(val: Record<string, string> | string | number) {
 }
 
 export const sqlInjectionPattern = /\b(or 1=1|OR 1=1)\b/;
+
+// Adds transition to the view
+// Available only on last versions of Chrome, Edge, Opera
+// https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API#browser_compatibility
+export function startViewTransition(callback: () => void) {
+
+  return new Promise<void>((resolve) => {
+    const transitionCallback = () => {
+      callback();
+      resolve();
+    };
+    //@ts-ignore
+    if (!document.startViewTransition) {
+      transitionCallback();
+    } else {
+      //@ts-ignore
+      document.startViewTransition(transitionCallback);
+    }
+  });
+}


### PR DESCRIPTION
## Proposed changes

Adds smooth transition to the change view on Modals, Home page and Alerts page.

Currently Vue doesn't handle well the transitions between v-if v-else states.
Router link it's quite cumbersome and a bit messy to work with.
As result, the transition between modals and pages looks quite stiff at the moment.

The PR Introduces a utility function `addViewTransition`, which adds a smooth transition between the current view and the new view triggered by the callback.

`document.startViewTransition` is part of the View Transitions API and allows for smoother transitions between states in web applications.

It's currently available for the last versions of Chrome, Edge, Opera.
For older browser, the api simply gets ignored

more info about the api https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API#browser_compatibility