### PR TITLE
Fix log 4shell link, tiny fix on how it works button for the hp

### DIFF
--- a/frontend_vue/src/components/tokens/log4shell/ActivatedToken.vue
+++ b/frontend_vue/src/components/tokens/log4shell/ActivatedToken.vue
@@ -7,14 +7,6 @@
   <p class="mt-16 text-sm">
     If this works, you will also obtain the hostname of the vulnerable server.
   </p>
-  <p class="mt-16 text-sm">
-    You can read more on this issue at
-    <base-link
-      href="https://www.lunasec.io/docs/blog/log4j-zero-day/"
-      target="_blank"
-      >LunaSec</base-link
-    >
-  </p>
 </template>
 
 <script setup lang="ts">

--- a/frontend_vue/src/views/HomeView.vue
+++ b/frontend_vue/src/views/HomeView.vue
@@ -13,7 +13,7 @@
           target="_blank"
         >
           <div
-            class="inline-block w-[1.1rem] h-[1.1rem] text-xs duration-150 bg-transparent border border-solid rounded-full hover:text-white hover:bg-green-600 hover:border-green-300 border-grey-300 text-grey-300"
+            class="inline-block w-[1.1rem] h-[1.1rem] text-xs duration-150 bg-transparent border border-solid rounded-full hover:text-white hover:bg-green-600 hover:border-green-300 border-grey-200 text-grey-300"
           >
             <font-awesome-icon
               icon="question"


### PR DESCRIPTION
## Proposed changes

Removes a broken link from log4shell helps
1 char css fix for the border of button ? 

before
<img width="422" alt="Screenshot 2024-07-05 at 14 34 22" src="https://github.com/thinkst/canarytokens/assets/126554007/8286de97-c97b-470e-a444-4a87fb66d92c">

after
<img width="428" alt="Screenshot 2024-07-05 at 14 34 15" src="https://github.com/thinkst/canarytokens/assets/126554007/e2cc8a8e-a724-4209-81de-f73473b73fb2">
