### PR TITLE
Get continent from source IP country

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "5354:5354/udp"
       - "51820:51820/udp"
       - "8082:8082"
+      - "8083:8083"
     # Overrides default command so things don't shut down after the process ends.
     entrypoint: /usr/local/share/docker-init.sh
     command: sleep infinity

--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -323,6 +323,11 @@ class EmailOutputChannel(OutputChannel):
                 BasicDetails[field_name] = BasicDetails["src_data"].pop(field_name)
         BasicDetails.pop("src_data")
 
+        if "useragent" in BasicDetails and not BasicDetails["useragent"]:
+            BasicDetails.pop("useragent")
+        if "src_ip" in BasicDetails and not BasicDetails["src_ip"]:
+            BasicDetails.pop("src_ip")
+
         rendered_html = Template(template_path.open().read()).render(
             Title=EmailOutputChannel.DESCRIPTION,
             Intro=EmailOutputChannel.format_report_intro(details),

--- a/canarytokens/utils.py
+++ b/canarytokens/utils.py
@@ -2,6 +2,8 @@ import subprocess
 from pathlib import Path
 from typing import Any, Literal, Union
 
+import pycountry_convert
+
 
 def dict_to_csv(d: dict) -> str:
     """Convert dict to CSV"""
@@ -74,3 +76,22 @@ def get_deployed_commit_sha(commit_sha_file: Path = Path("/COMMIT_SHA")):
 #         return wrapper
 
 #     return inner
+
+
+def get_src_ip_continent(country: str) -> str:
+    """Helper function that returns the continent of country given it's ISO 3166-2 code.
+
+    Args:
+        country (str): ISO 3166-2 code
+
+    Returns:
+        str: A two character code representing a continent
+    """
+    # AQ is the ISO 3166-2 code for Antarctica, and is returned from IPinfo,
+    # but it's not included in pycountry_convert.
+    if country == "AQ":
+        return "AN"
+    try:
+        return pycountry_convert.country_alpha2_to_continent_code(country)
+    except KeyError:
+        return "NO_CONTINENT"

--- a/poetry.lock
+++ b/poetry.lock
@@ -934,6 +934,9 @@ files = [
     {file = "coverage-7.4.0.tar.gz", hash = "sha256:707c0f58cb1712b8809ece32b68996ee1e609f71bd14615bd8f87a1293cb610e"},
 ]
 
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
 [package.extras]
 toml = ["tomli"]
 
@@ -2211,6 +2214,17 @@ redis = ["redis"]
 tests = ["pytest (>=5.4.1)", "pytest-cov (>=2.8.1)", "pytest-mypy (>=0.8.0)", "pytest-timeout (>=2.1.0)", "redis", "sphinx (>=6.0.0)", "types-redis"]
 
 [[package]]
+name = "pprintpp"
+version = "0.4.0"
+description = "A drop-in replacement for pprint that's actually pretty"
+optional = false
+python-versions = "*"
+files = [
+    {file = "pprintpp-0.4.0-py2.py3-none-any.whl", hash = "sha256:b6b4dcdd0c0c0d75e4d7b2f21a9e933e5b2ce62b26e1a54537f9651ae5a5c01d"},
+    {file = "pprintpp-0.4.0.tar.gz", hash = "sha256:ea826108e2c7f49dc6d66c752973c3fc9749142a798d6b254e1e301cfdbc6403"},
+]
+
+[[package]]
 name = "pre-commit"
 version = "2.21.0"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
@@ -2252,6 +2266,37 @@ files = [
 
 [package.dependencies]
 pyasn1 = ">=0.4.6,<0.6.0"
+
+[[package]]
+name = "pycountry"
+version = "24.6.1"
+description = "ISO country, subdivision, language, currency and script definitions and their translations"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycountry-24.6.1-py3-none-any.whl", hash = "sha256:f1a4fb391cd7214f8eefd39556d740adcc233c778a27f8942c8dca351d6ce06f"},
+    {file = "pycountry-24.6.1.tar.gz", hash = "sha256:b61b3faccea67f87d10c1f2b0fc0be714409e8fcdcc1315613174f6466c10221"},
+]
+
+[[package]]
+name = "pycountry-convert"
+version = "0.7.2"
+description = "Extension of Python package pycountry providing conversion functions."
+optional = false
+python-versions = "*"
+files = [
+    {file = "pycountry-convert-0.7.2.tar.gz", hash = "sha256:095d310f746bf2a5ef713b3a82eea28a27262286223765b1e7be8a5c4fa7e9b9"},
+    {file = "pycountry_convert-0.7.2-py3-none-any.whl", hash = "sha256:5e33883a88b3cb752d332ca2358ac6c4de4defc86a2b93b713b36338e914952e"},
+]
+
+[package.dependencies]
+pprintpp = ">=0.3.0"
+pycountry = ">=16.11.27.1"
+pytest = ">=3.4.0"
+pytest-cov = ">=2.5.1"
+pytest-mock = ">=1.6.3"
+"repoze.lru" = ">=0.7"
+wheel = ">=0.30.0"
 
 [[package]]
 name = "pycparser"
@@ -2486,6 +2531,24 @@ pytest = ">=6.1.0"
 testing = ["coverage (==6.2)", "flaky (>=3.5.0)", "hypothesis (>=5.7.1)", "mypy (==0.931)", "pytest-trio (>=0.7.0)"]
 
 [[package]]
+name = "pytest-cov"
+version = "5.0.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
+    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
+]
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "pytest-memray"
 version = "1.5.0"
 description = "A simple plugin to use with pytest"
@@ -2504,6 +2567,23 @@ pytest = ">=7.2"
 docs = ["furo (>=2022.12.7)", "sphinx (>=6.1.3)", "sphinx-argparse (>=0.4)", "sphinx-inline-tabs (>=2022.1.2b11)", "sphinxcontrib-programoutput (>=0.17)", "towncrier (>=22.12)"]
 lint = ["black (==22.12)", "isort (==5.11.4)", "mypy (==0.991)", "ruff (==0.0.272)"]
 test = ["covdefaults (>=2.2.2)", "coverage (>=7.0.5)", "flaky (>=3.7)", "pytest (>=7.2)", "pytest-xdist (>=3.1)"]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.0"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0"},
+    {file = "pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "pytest-twisted"
@@ -2707,6 +2787,21 @@ async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2
 [package.extras]
 hiredis = ["hiredis (>=1.0.0)"]
 ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
+
+[[package]]
+name = "repoze-lru"
+version = "0.7"
+description = "A tiny LRU cache implementation and decorator"
+optional = false
+python-versions = "*"
+files = [
+    {file = "repoze.lru-0.7-py3-none-any.whl", hash = "sha256:f77bf0e1096ea445beadd35f3479c5cff2aa1efe604a133e67150bc8630a62ea"},
+    {file = "repoze.lru-0.7.tar.gz", hash = "sha256:0429a75e19380e4ed50c0694e26ac8819b4ea7851ee1fc7583c8572db80aff77"},
+]
+
+[package.extras]
+docs = ["Sphinx"]
+testing = ["coverage", "nose"]
 
 [[package]]
 name = "requests"
@@ -3264,6 +3359,20 @@ docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2)", "sphinx-
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
 [[package]]
+name = "wheel"
+version = "0.43.0"
+description = "A built-package format for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "wheel-0.43.0-py3-none-any.whl", hash = "sha256:55c570405f142630c6b9f72fe09d9b67cf1477fcf543ae5b8dcb1f5b7377da81"},
+    {file = "wheel-0.43.0.tar.gz", hash = "sha256:465ef92c69fa5c5da2d1cf8ac40559a8c940886afcef87dcf14b9470862f1d85"},
+]
+
+[package.extras]
+test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
+
+[[package]]
 name = "zipp"
 version = "3.17.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -3376,4 +3485,4 @@ web = ["fastapi", "sentry-sdk", "uvicorn"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "3802ec1d66d5f93db5d2430523e633cfd82c642201a8900a7538249d9e9db977"
+content-hash = "d2137085d3bbdbf531fb83d68ef1178d184817d0fc9a7063f4041f0159d3e71c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ azure-core = "^1.23.1"
 azure-identity = "^1.10.0"
 cssutils = "^1.0.2"
 advocate = {git = "https://github.com/JordanMilne/Advocate.git"}
+pycountry-convert = "^0.7.2"
 
 [tool.poetry.extras]
 web = ["fastapi", "uvicorn", "sentry-sdk"]

--- a/tests/units/test_models.py
+++ b/tests/units/test_models.py
@@ -533,6 +533,7 @@ def test_get_additional_data_for_webhook(
                 src_ip="127.0.0.1",
                 is_tor_relay=True,
                 input_channel="HTTP",
+                **seed_data,
             )
         ]
     )

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -1,6 +1,7 @@
 from canarytokens.utils import (
     coerce_to_float,
     get_deployed_commit_sha,
+    get_src_ip_continent,
 )
 
 
@@ -19,3 +20,14 @@ def test_coerce_to_float():
     assert 10.3 == coerce_to_float("10.3")
     assert 10 == coerce_to_float("10")
     assert not coerce_to_float("notafloat")
+
+
+def test_get_src_ip_continent():
+    assert "AF" == get_src_ip_continent("ZA")
+    assert "AN" == get_src_ip_continent("AQ")
+    assert "AS" == get_src_ip_continent("CN")
+    assert "EU" == get_src_ip_continent("GB")
+    assert "NA" == get_src_ip_continent("US")
+    assert "OC" == get_src_ip_continent("AU")
+    assert "SA" == get_src_ip_continent("AR")
+    assert "NO_CONTINENT" == get_src_ip_continent("1234")


### PR DESCRIPTION
## Proposed changes

This change uses the country code returned in the responses from the IPinfo API to get the continent that that country is in. That will then be used to display an icon of the continent next to the source IP location in the alert email.

Other changes: 
- Added the switchboard port to the devcontainer network configuration to make testing easier.
- Added code that removes the useragent and src_info keys if their values are falsy.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion