### PR TITLE
Fix get_src_ip_continent and update unit tests

### DIFF
--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1326,8 +1326,9 @@ class TokenHit(BaseModel):
             if self.src_data and key in self.src_data:
                 self.src_data[replacement] = self.src_data[key]
 
-            continent = get_src_ip_continent(additional_data)
-            additional_data["geo_info"]["continent"] = continent
+            if additional_data.get("geo_info") is not None:
+                continent = get_src_ip_continent(additional_data["geo_info"])
+                additional_data["geo_info"]["continent"] = continent
 
         time = datetime.utcnow()
         additional_data["time_hm"] = time.strftime("%H:%M")

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1326,10 +1326,8 @@ class TokenHit(BaseModel):
             if self.src_data and key in self.src_data:
                 self.src_data[replacement] = self.src_data[key]
 
-        if additional_data.get("geo_info", {}).get("country") is not None:
-            additional_data["geo_info"]["continent"] = get_src_ip_continent(
-                additional_data["geo_info"]["country"]
-            )
+            continent = get_src_ip_continent(additional_data)
+            additional_data["geo_info"]["continent"] = continent
 
         time = datetime.utcnow()
         additional_data["time_hm"] = time.strftime("%H:%M")

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1326,9 +1326,9 @@ class TokenHit(BaseModel):
             if self.src_data and key in self.src_data:
                 self.src_data[replacement] = self.src_data[key]
 
-            if additional_data.get("geo_info") is not None:
-                continent = get_src_ip_continent(additional_data["geo_info"])
-                additional_data["geo_info"]["continent"] = continent
+        if additional_data.get("geo_info") is not None:
+            continent = get_src_ip_continent(additional_data["geo_info"])
+            additional_data["geo_info"]["continent"] = continent
 
         time = datetime.utcnow()
         additional_data["time_hm"] = time.strftime("%H:%M")

--- a/canarytokens/utils.py
+++ b/canarytokens/utils.py
@@ -78,20 +78,24 @@ def get_deployed_commit_sha(commit_sha_file: Path = Path("/COMMIT_SHA")):
 #     return inner
 
 
-def get_src_ip_continent(country: str) -> str:
+def get_src_ip_continent(additional_data: dict) -> str:
     """Helper function that returns the continent of country given it's ISO 3166-2 code.
 
     Args:
-        country (str): ISO 3166-2 code
+        additional_data (dict): The "country" key contains an ISO 3166-2 code
 
     Returns:
         str: A two character code representing a continent
     """
-    # AQ is the ISO 3166-2 code for Antarctica, and is returned from IPinfo,
-    # but it's not included in pycountry_convert.
-    if country == "AQ":
-        return "AN"
-    try:
-        return pycountry_convert.country_alpha2_to_continent_code(country)
-    except KeyError:
+    country = additional_data.get("geo_info", {}).get("country")
+    if country is not None:
+        # AQ is the ISO 3166-2 code for Antarctica, and is returned from IPinfo,
+        # but it's not included in pycountry_convert.
+        if country == "AQ":
+            return "AN"
+        try:
+            return pycountry_convert.country_alpha2_to_continent_code(country)
+        except KeyError:
+            return "NO_CONTINENT"
+    else:
         return "NO_CONTINENT"

--- a/canarytokens/utils.py
+++ b/canarytokens/utils.py
@@ -88,14 +88,13 @@ def get_src_ip_continent(geo_data: dict) -> str:
         str: A two character code representing a continent
     """
     country = geo_data.get("country")
-    if country is not None:
-        # AQ is the ISO 3166-2 code for Antarctica, and is returned from IPinfo,
-        # but it's not included in pycountry_convert.
-        if country == "AQ":
-            return "AN"
-        try:
-            return pycountry_convert.country_alpha2_to_continent_code(country)
-        except KeyError:
-            return "NO_CONTINENT"
-    else:
+    if country is None:
+        return "NO_CONTINENT"
+    # AQ is the ISO 3166-2 code for Antarctica, and is returned from IPinfo,
+    # but it's not included in pycountry_convert.
+    if country == "AQ":
+        return "AN"
+    try:
+        return pycountry_convert.country_alpha2_to_continent_code(country)
+    except KeyError:
         return "NO_CONTINENT"

--- a/canarytokens/utils.py
+++ b/canarytokens/utils.py
@@ -78,16 +78,16 @@ def get_deployed_commit_sha(commit_sha_file: Path = Path("/COMMIT_SHA")):
 #     return inner
 
 
-def get_src_ip_continent(additional_data: dict) -> str:
+def get_src_ip_continent(geo_data: dict) -> str:
     """Helper function that returns the continent of country given it's ISO 3166-2 code.
 
     Args:
-        additional_data (dict): The "country" key contains an ISO 3166-2 code
+        geo_data (dict): The "country" key contains an ISO 3166-2 code
 
     Returns:
         str: A two character code representing a continent
     """
-    country = additional_data.get("geo_info", {}).get("country")
+    country = geo_data.get("country")
     if country is not None:
         # AQ is the ISO 3166-2 code for Antarctica, and is returned from IPinfo,
         # but it's not included in pycountry_convert.

--- a/tests/units/test_models.py
+++ b/tests/units/test_models.py
@@ -19,7 +19,6 @@ from canarytokens.models import (
     DNSTokenRequest,
     DownloadContentTypes,
     DownloadMSWordResponse,
-    GeoIPBogonInfo,
     GeoIPInfo,
     LegacyTokenHistory,
     LegacyTokenHit,
@@ -476,11 +475,19 @@ def test_all_requests_have_a_response():
             WebBugTokenHit,
             {
                 "useragent": "python 3.10",
-                "geo_info": GeoIPBogonInfo(ip="127.0.0.1", bogon=True),
+                "geo_info": {
+                    "ip": "127.0.0.1",
+                    "bogon": True,
+                    "continent": "NO_CONTINENT",
+                },
             },
             {
                 "useragent": "python 3.10",
-                "geo_info": GeoIPBogonInfo(ip="127.0.0.1", bogon=True),
+                "geo_info": {
+                    "ip": "127.0.0.1",
+                    "bogon": True,
+                    "continent": "NO_CONTINENT",
+                },
             },
         ),
         (
@@ -584,11 +591,19 @@ def test_get_additional_data_for_email(history_type, hit_type, seed_data):
         (
             {
                 "useragent": "python 3.10",
-                "geo_info": GeoIPBogonInfo(ip="127.0.0.1", bogon=True),
+                "geo_info": {
+                    "ip": "127.0.0.1",
+                    "bogon": True,
+                    "continent": "NO_CONTINENT",
+                },
             },
             {
                 "useragent": "python 3.10",
-                "geo_info": GeoIPBogonInfo(ip="127.0.0.1", bogon=True),
+                "geo_info": {
+                    "ip": "127.0.0.1",
+                    "bogon": True,
+                    "continent": "NO_CONTINENT",
+                },
             },
         ),
         (

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -25,19 +25,19 @@ def test_coerce_to_float():
 
 
 @pytest.mark.parametrize(
-    "additional_data, continent",
+    "geo_info, continent",
     [
-        ({"geo_info": {"country": "ZA"}}, "AF"),
-        ({"geo_info": {"country": "AQ"}}, "AN"),
-        ({"geo_info": {"country": "CN"}}, "AS"),
-        ({"geo_info": {"country": "GB"}}, "EU"),
-        ({"geo_info": {"country": "US"}}, "NA"),
-        ({"geo_info": {"country": "AU"}}, "OC"),
-        ({"geo_info": {"country": "AR"}}, "SA"),
-        ({"geo_info": {"country": "Mordor"}}, "NO_CONTINENT"),
-        ({"geo_info": {"bogon": True}}, "NO_CONTINENT"),
-        ({"geo_info": {}}, "NO_CONTINENT"),
+        ({"country": "ZA"}, "AF"),
+        ({"country": "AQ"}, "AN"),
+        ({"country": "CN"}, "AS"),
+        ({"country": "GB"}, "EU"),
+        ({"country": "US"}, "NA"),
+        ({"country": "AU"}, "OC"),
+        ({"country": "AR"}, "SA"),
+        ({"country": "Mordor"}, "NO_CONTINENT"),
+        ({"bogon": True}, "NO_CONTINENT"),
+        ({}, "NO_CONTINENT"),
     ],
 )
-def test_get_src_ip_continent(additional_data, continent):
-    assert continent == get_src_ip_continent(additional_data)
+def test_get_src_ip_continent(geo_info, continent):
+    assert continent == get_src_ip_continent(geo_info)

--- a/tests/units/test_utils.py
+++ b/tests/units/test_utils.py
@@ -1,3 +1,5 @@
+import pytest
+
 from canarytokens.utils import (
     coerce_to_float,
     get_deployed_commit_sha,
@@ -22,12 +24,20 @@ def test_coerce_to_float():
     assert not coerce_to_float("notafloat")
 
 
-def test_get_src_ip_continent():
-    assert "AF" == get_src_ip_continent("ZA")
-    assert "AN" == get_src_ip_continent("AQ")
-    assert "AS" == get_src_ip_continent("CN")
-    assert "EU" == get_src_ip_continent("GB")
-    assert "NA" == get_src_ip_continent("US")
-    assert "OC" == get_src_ip_continent("AU")
-    assert "SA" == get_src_ip_continent("AR")
-    assert "NO_CONTINENT" == get_src_ip_continent("1234")
+@pytest.mark.parametrize(
+    "additional_data, continent",
+    [
+        ({"geo_info": {"country": "ZA"}}, "AF"),
+        ({"geo_info": {"country": "AQ"}}, "AN"),
+        ({"geo_info": {"country": "CN"}}, "AS"),
+        ({"geo_info": {"country": "GB"}}, "EU"),
+        ({"geo_info": {"country": "US"}}, "NA"),
+        ({"geo_info": {"country": "AU"}}, "OC"),
+        ({"geo_info": {"country": "AR"}}, "SA"),
+        ({"geo_info": {"country": "Mordor"}}, "NO_CONTINENT"),
+        ({"geo_info": {"bogon": True}}, "NO_CONTINENT"),
+        ({"geo_info": {}}, "NO_CONTINENT"),
+    ],
+)
+def test_get_src_ip_continent(additional_data, continent):
+    assert continent == get_src_ip_continent(additional_data)


### PR DESCRIPTION
## Proposed changes

The get_src_ip_continent function and the code that calls it has been updated to take into account that the IPinfo API can return a response without a country key when the IP address in the request is in a bogon IP address range.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [ x] Lint and unit tests pass locally with my changes (if applicable)
- [ x] I have run pre-commit (`pre-commit` in the repo)
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion