### PR TITLE
Alert history ordered, add request arg and move basic info at top

### DIFF
--- a/frontend_vue/src/components/HistoryToken.vue
+++ b/frontend_vue/src/components/HistoryToken.vue
@@ -128,7 +128,8 @@ async function fetchTokenHistoryData() {
   try {
     const res = await historyToken(params);
     const historyTokenData = (await res.data) as HistoryTokenBackendType;
-    hitsList.value = historyTokenData.history.hits;
+    hitsList.value = historyTokenData.history.hits.sort((a, b) => b.time_of_hit - a.time_of_hit);
+    
     emits(
       'update-token-title',
       historyTokenData.history.token_type,

--- a/frontend_vue/src/utils/incidentAlertService.ts
+++ b/frontend_vue/src/utils/incidentAlertService.ts
@@ -113,19 +113,6 @@ export function buildIncidentDetails(
 ): FormattedHitsType | HitsType {
   try {
     const incidentDetails = {
-      time_of_hit: convertUnixTimeStampToDate(hitAlert.time_of_hit),
-      src_ip: hitAlert.src_ip,
-      geo_info: !hitAlert.geo_info.bogon
-        ? {
-            ...hitAlert.geo_info,
-          }
-        : {
-            ip: hitAlert.geo_info.ip,
-            bogon: hitAlert.geo_info.bogon,
-          },
-      is_tor_relay: !isCreditCardtoken(hitAlert.token_type)
-        ? hitAlert.is_tor_relay
-        : null,
       basic_info: {
         // TODO: add token memo
         token_type: formatTokenTypeLabel(hitAlert.token_type),
@@ -141,7 +128,21 @@ export function buildIncidentDetails(
         mail: hitAlert.mail || null,
         referer: hitAlert.referer || null,
         location: hitAlert.location || null,
+        request_args: hitAlert.request_args || null,
       },
+      time_of_hit: convertUnixTimeStampToDate(hitAlert.time_of_hit),
+      src_ip: hitAlert.src_ip,
+      geo_info: !hitAlert.geo_info.bogon
+        ? {
+            ...hitAlert.geo_info,
+          }
+        : {
+            ip: hitAlert.geo_info.ip,
+            bogon: hitAlert.geo_info.bogon,
+          },
+      is_tor_relay: !isCreditCardtoken(hitAlert.token_type)
+        ? hitAlert.is_tor_relay
+        : null,
       additional_info: {
         ...hitAlert.additional_info,
         aws_key_log_data:


### PR DESCRIPTION
## Proposed changes
This pull request includes the following updates and improvements:

1. **Alert History Ordered**: The alert history is now ordered in descending order for better chronological visibility.
2. **Add Request Argument**: The missing request argument has been added to the basic information section, enhancing its completeness and accuracy.
3. **Move Basic Info to the Top**: The basic information has been repositioned to the top of the section, improving visibility and user experience.