### PR TITLE
Use byte string to access user-agent value

### DIFF
--- a/canarytokens/channel_input_mtls.py
+++ b/canarytokens/channel_input_mtls.py
@@ -76,7 +76,7 @@ class mTLS(basic.LineReceiver):
             line.split(b":")[0]: line.split(b":")[1].strip()
             for line in self.lines[2:-1]
         }
-        user_agent = headers.get("User-Agent", "Unknown")
+        user_agent = headers.get(b"User-Agent", "Unknown")
 
         try:
             peer_certificate = Certificate.peerFromTransport(self.transport)


### PR DESCRIPTION
## Proposed changes

`User-Agent` value defaults to `Unknown` currently for all kubeconfig token triggers. This is due to the fact that the code tries to use a normal string to access the value from the headers, whereas all keys and values in the headers dict are byte strings.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

Before:
<img width="837" alt="image" src="https://github.com/user-attachments/assets/51e6fafe-d6b6-4f14-919d-ce5661d33a38">

After:
<img width="837" alt="image" src="https://github.com/user-attachments/assets/794fe9c0-7404-41d0-aad1-9b2bc3093004">
