### PR TITLE
Fix HTTPS on Fake App tokens

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -790,6 +790,10 @@ async def api_generate(  # noqa: C901  # gen is large
         if token_request_details.token_type == TokenTypes.PWA
         else None,
     )
+    if token_request_details.token_type == TokenTypes.PWA:
+        canarydrop.generated_url = canarydrop.generated_url.replace(
+            "http://", "https://"
+        )
     canarydrop.generated_hostname = canarydrop.get_hostname()
 
     save_canarydrop(canarydrop)


### PR DESCRIPTION
## Proposed changes
Fake App tokens always require HTTPS. Currently the token uses the `switchboard_settings.FORCE_HTTPS` setting. This PR makes it always HTTPS no matter what.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] I have run pre-commit (`pre-commit` in the repo)
