### PR TITLE
Fix minor typo on frontend_vue/src/components/base/BaseModal.vue

### DIFF
--- a/frontend_vue/src/components/base/BaseModal.vue
+++ b/frontend_vue/src/components/base/BaseModal.vue
@@ -4,7 +4,7 @@
   <!-- @vue-expect-error content-transition ts error -->
   <VueFinalModal
     overlay-class="blur-bg"
-    conten-class="absolute inset-[0px]"
+    content-class="absolute inset-[0px]"
     overlay-transition="vfm-fade"
     :content-transition="modalCustomTransition"
     @update:model-value="(val) => emit('update:modelValue', val)"


### PR DESCRIPTION
This PR includes the following:

<img width="1376" alt="Captura de ecrã 2024-09-25, às 14 36 20" src="https://github.com/user-attachments/assets/fcc1b07b-757a-4480-97b2-ae715c0f5a43">


Fix minor typo above on `frontend_vue/src/components/base/BaseModal.vue`