### PR TITLE
Avoid SMTP AUTH when SMTP_USERNAME or SMTP_PASSWORD are empty

### DIFF
--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -248,7 +248,8 @@ def smtp_send(
 
         with smtplib.SMTP(smtp_server, smtp_port) as server:
             server.starttls()
-            server.login(smtp_username, smtp_password)
+            if smtp_username != "" or smtp_password != "":
+                server.login(smtp_username, smtp_password)
             server.sendmail(fromaddr, toaddr, smtpmsg.as_string())
     except smtplib.SMTPException as e:
         log.error("A smtp error occurred: %s - %s" % (e.__class__, e))

--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -248,7 +248,7 @@ def smtp_send(
 
         with smtplib.SMTP(smtp_server, smtp_port) as server:
             server.starttls()
-            if smtp_username != "" or smtp_password != "":
+            if smtp_username is not None or smtp_password is not None:
                 server.login(smtp_username, smtp_password)
             server.sendmail(fromaddr, toaddr, smtpmsg.as_string())
     except smtplib.SMTPException as e:


### PR DESCRIPTION
## Proposed changes

Some SMTP servers do not support AUTH. Unconditionally trying to login will result in an exception. Only login when username or password are supplied.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
