### PR TITLE
Fixing the Display Name for SMTP send mail function

### DIFF
--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -238,7 +238,7 @@ def smtp_send(
         fromaddr = from_email
         toaddr = email_address
         smtpmsg = MIMEMultipart("alternative")
-        smtpmsg["From"] = f"{from_display} <{from_email}"
+        smtpmsg["From"] = f"{from_display} <{from_email}>"
         smtpmsg["To"] = email_address
         smtpmsg["Subject"] = email_subject
         part1 = MIMEText(email_content_text, "plain")

--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -238,7 +238,7 @@ def smtp_send(
         fromaddr = from_email
         toaddr = email_address
         smtpmsg = MIMEMultipart("alternative")
-        smtpmsg["From"] = from_display
+        smtpmsg["From"] = f"{from_display} <{from_email}"
         smtpmsg["To"] = email_address
         smtpmsg["Subject"] = email_subject
         part1 = MIMEText(email_content_text, "plain")


### PR DESCRIPTION
## Proposed changes

Display Email was not working as it was expecting exactly the From mail address fixed the syntax in send_mail function.

Issue link: https://github.com/thinkst/canarytokens-docker/issues/184


## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Linked to the relevant github issue or github discussion

## Further comments

I have tested locally and this fix should start supporting the From Display address.