### PR TITLE
Modify ipinfo 503 Response handling

### DIFF
--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -417,7 +417,10 @@ def get_geoinfo_from_ip(ip: str) -> Dict[str, str]:
         resp.raise_for_status()
         info = resp.json()
     except requests.exceptions.HTTPError as e:
-        log.error(f"ip info error: {e}")
+        if e.response.status_code == 503:
+            log.info(f"ip info error: {e}")
+        else:
+            log.error(f"ip info error: {e}")
         # not strictly Bogon , we have no info
         info = models.GeoIPBogonInfo(ip=ip, bogon=True).dict()
     return info


### PR DESCRIPTION
## Proposed changes

To get the geo information of an IP address a query is made to the `http://ipinfo.io` service.

We log an error for any error response from this service. Including a `503` status-code response.
This means if the `http://ipinfo.io` service is unavailable, we can get a flood of errors logged.

If we have alarms set to alert us of any logged errors, a lot of noise gets created when the `http://ipinfo.io` service is unavailable.

Furthermore if the `http://ipinfo.io` service is unavailable, there isn't much we can do besides to wait for it to be available.

With these changes, a `503` status-code response from the `http://ipinfo.io` service is logged as an `INFO` level log rather than an `ERROR` level log.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

