### PR TITLE
Add src ip to canarydrop on token create

### DIFF
--- a/canarytokens/canarydrop.py
+++ b/canarytokens/canarydrop.py
@@ -72,6 +72,8 @@ class Canarydrop(BaseModel):
     memo: str = ""
     # Make created_at v2 compatible - add timestamp as alias.
     created_at: datetime = Field(default_factory=datetime.utcnow, alias="timestamp")
+    created_from_ip: Optional[str]
+    created_from_ip_x_forwarded_for: Optional[str]
 
     auth: str = Field(default_factory=make_auth_token)
     type: TokenTypes

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -445,12 +445,20 @@ async def generate(request: Request) -> AnyTokenResponse:  # noqa: C901  # gen i
     else:
         kube_config = None
         canarytoken = Canarytoken()
+
+    src_ip = (
+        request.headers.get(switchboard_settings.REAL_IP_HEADER) or request.client.host
+    )
+    x_forwarded_for = request.headers.get("x-forwarded-for") or ""
+
     canarydrop = Canarydrop(
         type=token_request_details.token_type,
         alert_email_enabled=True if token_request_details.email else False,
         alert_email_recipient=token_request_details.email,
         alert_webhook_enabled=True if token_request_details.webhook_url else False,
         alert_webhook_url=token_request_details.webhook_url or "",
+        created_from_ip=src_ip,
+        created_from_ip_x_forwarded_for=x_forwarded_for,
         canarytoken=canarytoken,
         memo=token_request_details.memo,
         browser_scanner_enabled=False,
@@ -763,12 +771,20 @@ async def api_generate(  # noqa: C901  # gen is large
     else:
         kube_config = None
         canarytoken = Canarytoken()
+
+    src_ip = (
+        request.headers.get(switchboard_settings.REAL_IP_HEADER) or request.client.host
+    )
+    x_forwarded_for = request.headers.get("x-forwarded-for") or ""
+
     canarydrop = Canarydrop(
         type=token_request_details.token_type,
         alert_email_enabled=True if token_request_details.email else False,
         alert_email_recipient=token_request_details.email,
         alert_webhook_enabled=True if token_request_details.webhook_url else False,
         alert_webhook_url=token_request_details.webhook_url or "",
+        created_from_ip=src_ip,
+        created_from_ip_x_forwarded_for=x_forwarded_for,
         canarytoken=canarytoken,
         memo=token_request_details.memo,
         browser_scanner_enabled=False,

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -446,8 +446,8 @@ async def generate(request: Request) -> AnyTokenResponse:  # noqa: C901  # gen i
         kube_config = None
         canarytoken = Canarytoken()
 
-    src_ip = (
-        request.headers.get(switchboard_settings.REAL_IP_HEADER) or request.client.host
+    src_ip = request.headers.get(switchboard_settings.REAL_IP_HEADER) or (
+        request.client.host if request.client else ""
     )
     x_forwarded_for = request.headers.get("x-forwarded-for") or ""
 
@@ -772,8 +772,8 @@ async def api_generate(  # noqa: C901  # gen is large
         kube_config = None
         canarytoken = Canarytoken()
 
-    src_ip = (
-        request.headers.get(switchboard_settings.REAL_IP_HEADER) or request.client.host
+    src_ip = request.headers.get(switchboard_settings.REAL_IP_HEADER) or (
+        request.client.host if request.client else ""
     )
     x_forwarded_for = request.headers.get("x-forwarded-for") or ""
 

--- a/tests/units/test_canarydrops.py
+++ b/tests/units/test_canarydrops.py
@@ -34,12 +34,19 @@ def test_canarydrop(token_type):
         alert_webhook_url=None,
         canarytoken=canarytoken,
         memo="memo",
+        created_from_ip="127.0.100.1",
+        created_from_ip_x_forwarded_for="127.0.200.1",
         browser_scanner_enabled=False,
         redirect_url="https://youtube.com",
     )
     save_canarydrop(cd)
     cd_retrieved = get_canarydrop(canarytoken)
     assert cd_retrieved.memo == cd.memo
+    assert cd_retrieved.created_from_ip == cd.created_from_ip
+    assert (
+        cd_retrieved.created_from_ip_x_forwarded_for
+        == cd.created_from_ip_x_forwarded_for
+    )
     assert cd_retrieved.canarytoken.value() == cd.canarytoken.value()
     if cd_retrieved.type in [TokenTypes.SLOW_REDIRECT, TokenTypes.FAST_REDIRECT]:
         assert cd_retrieved.redirect_url == "https://youtube.com"


### PR DESCRIPTION
## Proposed changes

This adds the IP to the canarydrop from which the request came to create the canary token. Testing was also expanded to test for the headers.

The `created_from_ip` and `created_from_ip_x_forwarded_for` are optional as to not break existing tokens that do not already have the information.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
