### PR TITLE
Add token exposed processing to tokens server

### DIFF
--- a/canarytokens/canarydrop.py
+++ b/canarytokens/canarydrop.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from urllib.parse import quote
 from typing import Any, Literal, Optional, Union
 
-from pydantic import BaseModel, Field, parse_obj_as, root_validator
+from pydantic import AnyHttpUrl, BaseModel, Field, parse_obj_as, root_validator
 
 from canarytokens import queries, tokens
 from canarytokens.constants import (
@@ -32,6 +32,7 @@ from canarytokens.models import (
     AnySettingsRequest,
     AnyTokenHistory,
     AnyTokenHit,
+    AnyTokenExposedHit,
     BrowserScannerSettingsRequest,
     EmailSettingsRequest,
     PWAType,
@@ -157,12 +158,13 @@ class Canarydrop(BaseModel):
     cc_v2_expiry_year: Optional[int]
     cc_v2_name_on_card: Literal["Canarytokens.org"] = "Canarytokens.org"
 
+    key_exposed_details: Optional[AnyTokenExposedHit] = None
+
     @root_validator(pre=True)
     def _validate_triggered_details(cls, values):
         """
         Ensure canarydrop `type` and `triggered_details` `token_type` match.
         """
-
         if values.get("triggered_details", None) is None:
             values["triggered_details"] = parse_obj_as(
                 AnyTokenHistory, {"token_type": values["type"], "hits": []}
@@ -179,7 +181,32 @@ class Canarydrop(BaseModel):
             {getattr(values["triggered_details"], "token_type")} != {values["type"]}
             """
             )
+
+        if "key_exposed_details" in values:
+            values["key_exposed_details"] = parse_obj_as(
+                AnyTokenExposedHit, values["key_exposed_details"]
+            )
+            token_type, expected_token_type = (
+                values["key_exposed_details"].token_type,
+                values["type"],
+            )
+            if token_type != expected_token_type:
+                raise ValueError(
+                    f"key_exposed_details token_type must match drop type. Got {token_type} instead of {expected_token_type}."
+                )
+
         return values
+
+    def build_manage_url(self, protocol: str, host: str) -> AnyHttpUrl:
+        return parse_obj_as(
+            AnyHttpUrl,
+            "{protocol}://{host}/manage?token={token}&auth={auth}".format(
+                protocol=protocol,
+                host=host,
+                token=self.canarytoken.value(),
+                auth=self.auth,
+            ),
+        )
 
     class Config:
         arbitrary_types_allowed = True
@@ -221,6 +248,16 @@ class Canarydrop(BaseModel):
             token_hit=token_hit,
             canarytoken=self.canarytoken,
         )
+
+    def add_key_exposed_hit(self, token_exposed_hit: AnyTokenExposedHit):
+        if self.key_exposed_details is not None:
+            # Only store the first event since that's the most important - gives the best indication of how
+            # long the key has been exposed
+            return
+
+        queries.save_canarydrop(self)
+        self.key_exposed_details = token_exposed_hit
+        queries.add_key_exposed_hit(token_exposed_hit, self.canarytoken)
 
     def apply_settings_change(self, setting_request: AnySettingsRequest) -> bool:
         """
@@ -417,6 +454,7 @@ class Canarydrop(BaseModel):
                     "canarytoken",
                     "switchboard_settings",
                     "triggered_details",  # V2 compatible.
+                    "key_exposed_details",
                 }
             ),
         )  # TODO: check https://github.com/samuelcolvin/pydantic/issues/1409 and swap out when possible

--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -4,7 +4,7 @@ Output channel that sends emails. Relies on Sendgrid to actually send mails.
 from pathlib import Path
 from textwrap import dedent
 import textwrap
-from typing import Optional
+from typing import Optional, Union
 import enum
 import uuid
 
@@ -26,6 +26,7 @@ from canarytokens.channel import InputChannel, OutputChannel
 from canarytokens.constants import OUTPUT_CHANNEL_EMAIL, MAILGUN_IGNORE_ERRORS
 from canarytokens.models import (
     AnyTokenHit,
+    AnyTokenExposedHit,
     readable_token_type_names,
     TokenAlertDetails,
     token_types_with_article_an,
@@ -418,7 +419,7 @@ class EmailOutputChannel(OutputChannel):
         self,
         input_channel: InputChannel,
         canarydrop: Canarydrop,
-        token_hit: AnyTokenHit,
+        token_hit: Union[AnyTokenHit, AnyTokenExposedHit],
     ):
         alert_details = input_channel.gather_alert_details(
             canarydrop=canarydrop,

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1566,6 +1566,16 @@ class AWSKeyTokenHit(TokenHit):
         return values
 
 
+class TokenExposedHit(BaseModel):
+    time_of_hit: float
+
+
+class AWSKeyTokenExposedHit(TokenExposedHit):
+    token_type: Literal[TokenTypes.AWS_KEYS] = TokenTypes.AWS_KEYS
+    public_location: Optional[str]
+    input_channel: str = "HTTP"
+
+
 class SlackAPITokenHit(TokenHit):
     token_type: Literal[TokenTypes.SLACK_API] = TokenTypes.SLACK_API
     additional_info: Optional[dict]
@@ -1797,6 +1807,8 @@ AnyTokenHit = Annotated[
     ],
     Field(discriminator="token_type"),
 ]
+
+AnyTokenExposedHit = AWSKeyTokenExposedHit
 
 TH = TypeVar("TH", bound=AnyTokenHit)
 
@@ -2085,6 +2097,45 @@ class TokenAlertDetails(BaseModel):
         }
 
 
+class TokenExposedDetails(BaseModel):
+    token_type: TokenTypes
+    token: str
+    memo: Memo
+    key_id: str
+    public_location: Optional[str]
+    exposed_time: datetime
+    manage_url: AnyHttpUrl
+    public_domain: Optional[str] = "my.domain"
+
+    @validator("exposed_time", pre=True)
+    def validate_time(cls, value):
+        if isinstance(value, str):
+            return datetime.strptime(value, "%Y-%m-%d %H:%M:%S (UTC)")
+        return value
+
+    def json_safe_dict(self) -> Dict[str, str]:
+        return json_safe_dict(self)
+
+    @property
+    def history_url(self):
+        return HttpUrl(
+            self.manage_url.replace("manage", "history"), scheme=self.manage_url.scheme
+        )
+
+    @property
+    def time_hm(self) -> str:
+        return self.exposed_time.strftime("%H:%M")
+
+    @property
+    def time_ymd(self) -> str:
+        return self.exposed_time.strftime("%Y/%m/%d")
+
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.strftime("%Y-%m-%d %H:%M:%S (UTC)"),
+        }
+
+
 class SlackField(BaseModel):
     title: str
     value: str
@@ -2328,10 +2379,6 @@ class TokenAlertDetailsDiscord(BaseModel):
 
     def json_safe_dict(self) -> Dict[str, str]:
         return json_safe_dict(self)
-
-
-class TokenAlertDetailGeneric(TokenAlertDetails):
-    ...
 
 
 class UserName(ConstrainedStr):

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -41,6 +41,11 @@ from canarytokens.redismanager import (  # KEY_BITCOIN_ACCOUNT,; KEY_BITCOIN_ACC
     KEY_WEBHOOK_IDX,
     KEY_WIREGUARD_KEYMAP,
 )
+from canarytokens.webhook_formatting import (
+    WebhookType,
+    generate_webhook_test_payload,
+    get_webhook_type,
+)
 
 log = Logger()
 
@@ -63,6 +68,10 @@ def get_canarydrop(canarytoken: tokens.Canarytoken) -> Optional[cand.Canarydrop]
     if "user" in canarydrop.keys():
         # Make user in redis fully supported.
         canarydrop["user"] = models.User(name=canarydrop["user"])
+    if "key_exposed_details" in canarydrop:
+        canarydrop["key_exposed_details"] = json.loads(
+            canarydrop.pop("key_exposed_details")
+        )
 
     canarydrop["canarytoken"] = canarytoken
     try:
@@ -313,6 +322,16 @@ def add_canarydrop_hit(token_hit: models.AnyTokenHit, canarytoken):
         json.dumps(token_history.serialize_for_v2()),
     )
     return token_hit.time_of_hit
+
+
+def add_key_exposed_hit(
+    token_exposed_hit: models.AnyTokenExposedHit, canarytoken: tokens.Canarytoken
+):
+    DB.get_db().hset(
+        KEY_CANARYDROP + canarytoken.value(),
+        "key_exposed_details",
+        json.dumps(token_exposed_hit.dict()),
+    )
 
 
 # def get_canarydrop_history():
@@ -844,7 +863,8 @@ def validate_webhook(url, token_type: models.TokenTypes):
         models.TokenAlertDetailsDiscord,
         models.TokenAlertDetailsMsTeams,
     ]
-    if url.startswith(constants.WEBHOOK_BASE_URL_SLACK):
+    webhook_type = get_webhook_type(url)
+    if webhook_type == WebhookType.SLACK:
         payload = models.TokenAlertDetailsSlack(
             attachments=[
                 models.SlackAttachment(
@@ -858,7 +878,7 @@ def validate_webhook(url, token_type: models.TokenTypes):
                 )
             ]
         )
-    elif url.startswith(constants.WEBHOOK_BASE_URL_GOOGLE_CHAT):
+    elif webhook_type == WebhookType.GOOGLE_CHAT:
         # construct google chat alert card
         card = models.GoogleChatCard(
             header=models.GoogleChatHeader(
@@ -873,7 +893,7 @@ def validate_webhook(url, token_type: models.TokenTypes):
         payload = models.TokenAlertDetailsGoogleChat(
             cardsV2=[models.GoogleChatCardV2(cardId="unique-card-id", card=card)]
         )
-    elif url.startswith(constants.WEBHOOK_BASE_URL_DISCORD):
+    elif webhook_type == WebhookType.DISCORD:
         # construct discord alert card
         embeds = models.DiscordEmbeds(
             author=models.DiscordAuthorField(
@@ -884,7 +904,7 @@ def validate_webhook(url, token_type: models.TokenTypes):
             timestamp=datetime.datetime.now(),
         )
         payload = models.TokenAlertDetailsDiscord(embeds=[embeds])
-    elif re.match(constants.WEBHOOK_BASE_URL_REGEX_MS_TEAMS, url):
+    elif webhook_type == WebhookType.MS_TEAMS:
         section = models.MsTeamsTitleSection(
             activityTitle="<b>Validating new Canarytokens webhook</b>"
         )
@@ -892,23 +912,8 @@ def validate_webhook(url, token_type: models.TokenTypes):
             summary="Validating new Canarytokens webhook", sections=[section]
         )
     else:
-        payload = models.TokenAlertDetails(
-            manage_url=HttpUrl(
-                "http://example.com/test/url/for/webhook", scheme="http"
-            ),
-            channel="HTTP",
-            memo=models.Memo("Congrats! The newly saved webhook works"),
-            token="a+test+token",
-            token_type=token_type,
-            src_ip="127.0.0.1",
-            additional_data={
-                "src_ip": "1.1.1.1",
-                "useragent": "Mozilla/5.0...",
-                "referer": "http://example.com/referrer",
-                "location": "http://example.com/location",
-            },
-            time=datetime.datetime.now(),
-        )
+        payload = generate_webhook_test_payload(webhook_type, token_type)
+
     response = advocate.post(
         url,
         payload.json(),
@@ -918,18 +923,6 @@ def validate_webhook(url, token_type: models.TokenTypes):
     )
     # TODO: this accepts 3xx which is probably too lenient. We probably want any 2xx code.
     response.raise_for_status()
-    # return True
-    # except requests.exceptions.Timeout as e:
-    #     log.error("Timed out sending test payload to webhook: {url}".format(url=url))
-    #     return False
-    # except requests.exceptions.RequestException as e:
-    #     log.error(
-    #         "Failed sending test payload to webhook: {url} with error {error}".format(
-    #             url=url,
-    #             error=e,
-    #         ),
-    #     )
-    #     return False
 
 
 def is_valid_email(email):

--- a/canarytokens/switchboard.py
+++ b/canarytokens/switchboard.py
@@ -1,16 +1,17 @@
 """
 Class that receives alerts, and dispatches them to the registered endpoint.
 """
+
 from __future__ import annotations
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from twisted.logger import Logger
 
 from canarytokens import channel, queries
 from canarytokens.canarydrop import Canarydrop
 from canarytokens.exceptions import DuplicateChannel, InvalidChannel
-from canarytokens.models import AnyTokenHit
+from canarytokens.models import AnyTokenHit, AnyTokenExposedHit
 from canarytokens.settings import SwitchboardSettings
 
 log = Logger()
@@ -54,7 +55,9 @@ class Switchboard:
 
         self.output_channels[name] = channel
 
-    def dispatch(self, canarydrop: Canarydrop, token_hit: AnyTokenHit) -> str:
+    def dispatch(
+        self, canarydrop: Canarydrop, token_hit: Union[AnyTokenHit, AnyTokenExposedHit]
+    ) -> str:
         """
         Calls the correct alerting method for the trigger and channel combination.
         """
@@ -64,9 +67,11 @@ class Switchboard:
             )
 
         if not canarydrop.alertable(
-            alert_limit=self.switchboard_settings.MAX_ALERTS_PER_MINUTE
-            if self.switchboard_settings
-            else 1000
+            alert_limit=(
+                self.switchboard_settings.MAX_ALERTS_PER_MINUTE
+                if self.switchboard_settings
+                else 1000
+            )
         ):
             log.warn(
                 "Token {token} is not alertable at this stage.".format(

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+from typing import Union
+from enum import Enum
+import re
+from functools import partial
+from datetime import datetime
+
+from pydantic import HttpUrl, parse_obj_as
+
+from canarytokens import constants
+from canarytokens.channel import (
+    format_as_discord_canaryalert,
+    format_as_googlechat_canaryalert,
+    format_as_ms_teams_canaryalert,
+    format_as_slack_canaryalert,
+)
+from canarytokens.models import (
+    Memo,
+    TokenTypes,
+    TokenAlertDetails,
+    TokenExposedDetails,
+)
+
+
+WEBHOOK_TEST_URL = parse_obj_as(HttpUrl, "http://example.com/test/url/for/webhook")
+
+
+class WebhookType(Enum):
+    SLACK = "slack"
+    GOOGLE_CHAT = "google-chat"
+    DISCORD = "discord"
+    MS_TEAMS = "ms-teams"
+    GENERIC = "generic"
+
+
+def _match_url_start(url: str, match_str: str) -> bool:
+    return url.startswith(match_str)
+
+
+def _match_url_regex(url: str, match_regex: str) -> bool:
+    return bool(re.match(match_regex, url))
+
+
+_WEBHOOK_URL_MATCH_CRITERIA = {
+    WebhookType.SLACK: partial(
+        _match_url_start, match_str=constants.WEBHOOK_BASE_URL_SLACK
+    ),
+    WebhookType.GOOGLE_CHAT: partial(
+        _match_url_start, match_str=constants.WEBHOOK_BASE_URL_GOOGLE_CHAT
+    ),
+    WebhookType.DISCORD: partial(
+        _match_url_start, match_str=constants.WEBHOOK_BASE_URL_DISCORD
+    ),
+    WebhookType.MS_TEAMS: partial(
+        _match_url_regex, match_regex=constants.WEBHOOK_BASE_URL_REGEX_MS_TEAMS
+    ),
+}
+
+
+def get_webhook_type(url: str) -> WebhookType:
+    for webhook_type, match_func in _WEBHOOK_URL_MATCH_CRITERIA.items():
+        if match_func(url):
+            return webhook_type
+    else:
+        return WebhookType.GENERIC
+
+
+def format_details_for_webhook(
+    webhook_type: WebhookType, details: Union[TokenAlertDetails, TokenExposedDetails]
+):
+    match (webhook_type, details):
+        case (WebhookType.SLACK, TokenAlertDetails()):
+            return format_as_slack_canaryalert(details=details)
+        case (WebhookType.GOOGLE_CHAT, TokenAlertDetails()):
+            return format_as_googlechat_canaryalert(details=details)
+        case (WebhookType.DISCORD, TokenAlertDetails()):
+            return format_as_discord_canaryalert(details=details)
+        case (WebhookType.MS_TEAMS, TokenAlertDetails()):
+            return format_as_ms_teams_canaryalert(details=details)
+        case (WebhookType.GENERIC, TokenAlertDetails()):
+            return TokenAlertDetailGeneric(**details.dict())
+        case (WebhookType.SLACK, TokenExposedDetails()):
+            raise NotImplementedError(
+                f"format_details_for_webhook not {webhook_type} - {details}"
+            )
+        case (WebhookType.GOOGLE_CHAT, TokenExposedDetails()):
+            raise NotImplementedError(
+                f"format_details_for_webhook not {webhook_type} - {details}"
+            )
+        case (WebhookType.DISCORD, TokenExposedDetails()):
+            raise NotImplementedError(
+                f"format_details_for_webhook not {webhook_type} - {details}"
+            )
+        case (WebhookType.MS_TEAMS, TokenExposedDetails()):
+            raise NotImplementedError(
+                f"format_details_for_webhook not {webhook_type} - {details}"
+            )
+        case (WebhookType.GENERIC, TokenExposedDetails()):
+            return TokenExposedDetailGeneric(**details.dict())
+        case _:
+            raise Exception(
+                f"Unhandled combination of webhook type and details type: {webhook_type=} | {details}"
+            )
+
+
+def generate_webhook_test_payload(webhook_type: WebhookType, token_type: TokenTypes):
+    match webhook_type:
+        case WebhookType.SLACK:
+            raise NotImplementedError(
+                "generate_webhook_test_payload not implemented for SLACK"
+            )
+        case WebhookType.GOOGLE_CHAT:
+            raise NotImplementedError(
+                "generate_webhook_test_payload not implemented for GOOGLE_CHAT"
+            )
+        case WebhookType.DISCORD:
+            raise NotImplementedError(
+                "generate_webhook_test_payload not implemented for DISCORD"
+            )
+        case WebhookType.MS_TEAMS:
+            raise NotImplementedError(
+                "generate_webhook_test_payload not implemented for MS_TEAMS"
+            )
+        case WebhookType.GENERIC:
+            return TokenAlertDetails(
+                manage_url=WEBHOOK_TEST_URL,
+                channel="HTTP",
+                memo=Memo("Congrats! The newly saved webhook works"),
+                token="a+test+token",
+                token_type=token_type,
+                src_ip="127.0.0.1",
+                additional_data={
+                    "src_ip": "1.1.1.1",
+                    "useragent": "Mozilla/5.0...",
+                    "referer": "http://example.com/referrer",
+                    "location": "http://example.com/location",
+                },
+                time=datetime.now(),
+            )
+        case _:
+            raise NotImplementedError(
+                f"generate_webhook_test_payload not implemented for {webhook_type}"
+            )
+
+
+class TokenAlertDetailGeneric(TokenAlertDetails):
+    ...
+
+
+class TokenExposedDetailGeneric(TokenExposedDetails):
+    ...

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -121,43 +121,42 @@ def _format_exposed_details_for_webhook(
 
 
 def generate_webhook_test_payload(webhook_type: WebhookType, token_type: TokenTypes):
-    match webhook_type:
-        case WebhookType.SLACK:
-            raise NotImplementedError(
-                "generate_webhook_test_payload not implemented for SLACK"
-            )
-        case WebhookType.GOOGLE_CHAT:
-            raise NotImplementedError(
-                "generate_webhook_test_payload not implemented for GOOGLE_CHAT"
-            )
-        case WebhookType.DISCORD:
-            raise NotImplementedError(
-                "generate_webhook_test_payload not implemented for DISCORD"
-            )
-        case WebhookType.MS_TEAMS:
-            raise NotImplementedError(
-                "generate_webhook_test_payload not implemented for MS_TEAMS"
-            )
-        case WebhookType.GENERIC:
-            return TokenAlertDetails(
-                manage_url=WEBHOOK_TEST_URL,
-                channel="HTTP",
-                memo=Memo("Congrats! The newly saved webhook works"),
-                token="a+test+token",
-                token_type=token_type,
-                src_ip="127.0.0.1",
-                additional_data={
-                    "src_ip": "1.1.1.1",
-                    "useragent": "Mozilla/5.0...",
-                    "referer": "http://example.com/referrer",
-                    "location": "http://example.com/location",
-                },
-                time=datetime.now(),
-            )
-        case _:
-            raise NotImplementedError(
-                f"generate_webhook_test_payload not implemented for {webhook_type}"
-            )
+    if webhook_type == WebhookType.SLACK:
+        raise NotImplementedError(
+            "generate_webhook_test_payload not implemented for SLACK"
+        )
+    elif webhook_type == WebhookType.GOOGLE_CHAT:
+        raise NotImplementedError(
+            "generate_webhook_test_payload not implemented for GOOGLE_CHAT"
+        )
+    elif webhook_type == WebhookType.DISCORD:
+        raise NotImplementedError(
+            "generate_webhook_test_payload not implemented for DISCORD"
+        )
+    elif webhook_type == WebhookType.MS_TEAMS:
+        raise NotImplementedError(
+            "generate_webhook_test_payload not implemented for MS_TEAMS"
+        )
+    elif webhook_type == WebhookType.GENERIC:
+        return TokenAlertDetails(
+            manage_url=WEBHOOK_TEST_URL,
+            channel="HTTP",
+            memo=Memo("Congrats! The newly saved webhook works"),
+            token="a+test+token",
+            token_type=token_type,
+            src_ip="127.0.0.1",
+            additional_data={
+                "src_ip": "1.1.1.1",
+                "useragent": "Mozilla/5.0...",
+                "referer": "http://example.com/referrer",
+                "location": "http://example.com/location",
+            },
+            time=datetime.now(),
+        )
+    else:
+        raise NotImplementedError(
+            f"generate_webhook_test_payload not implemented for {webhook_type}"
+        )
 
 
 class TokenAlertDetailGeneric(TokenAlertDetails):

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -68,39 +68,56 @@ def get_webhook_type(url: str) -> WebhookType:
 def format_details_for_webhook(
     webhook_type: WebhookType, details: Union[TokenAlertDetails, TokenExposedDetails]
 ):
-    match (webhook_type, details):
-        case (WebhookType.SLACK, TokenAlertDetails()):
-            return format_as_slack_canaryalert(details=details)
-        case (WebhookType.GOOGLE_CHAT, TokenAlertDetails()):
-            return format_as_googlechat_canaryalert(details=details)
-        case (WebhookType.DISCORD, TokenAlertDetails()):
-            return format_as_discord_canaryalert(details=details)
-        case (WebhookType.MS_TEAMS, TokenAlertDetails()):
-            return format_as_ms_teams_canaryalert(details=details)
-        case (WebhookType.GENERIC, TokenAlertDetails()):
-            return TokenAlertDetailGeneric(**details.dict())
-        case (WebhookType.SLACK, TokenExposedDetails()):
-            raise NotImplementedError(
-                f"format_details_for_webhook not {webhook_type} - {details}"
-            )
-        case (WebhookType.GOOGLE_CHAT, TokenExposedDetails()):
-            raise NotImplementedError(
-                f"format_details_for_webhook not {webhook_type} - {details}"
-            )
-        case (WebhookType.DISCORD, TokenExposedDetails()):
-            raise NotImplementedError(
-                f"format_details_for_webhook not {webhook_type} - {details}"
-            )
-        case (WebhookType.MS_TEAMS, TokenExposedDetails()):
-            raise NotImplementedError(
-                f"format_details_for_webhook not {webhook_type} - {details}"
-            )
-        case (WebhookType.GENERIC, TokenExposedDetails()):
-            return TokenExposedDetailGeneric(**details.dict())
-        case _:
-            raise Exception(
-                f"Unhandled combination of webhook type and details type: {webhook_type=} | {details}"
-            )
+    if isinstance(details, TokenAlertDetails):
+        return _format_alert_details_for_webhook(webhook_type, details)
+    else:
+        return _format_exposed_details_for_webhook(webhook_type, details)
+
+
+def _format_alert_details_for_webhook(
+    webhook_type: WebhookType, details: TokenAlertDetails
+):
+    if webhook_type == WebhookType.SLACK:
+        return format_as_slack_canaryalert(details)
+    elif webhook_type == WebhookType.GOOGLE_CHAT:
+        return format_as_googlechat_canaryalert(details)
+    elif webhook_type == WebhookType.DISCORD:
+        return format_as_discord_canaryalert(details)
+    elif webhook_type == WebhookType.MS_TEAMS:
+        return format_as_ms_teams_canaryalert(details)
+    elif webhook_type == WebhookType.GENERIC:
+        return TokenAlertDetailGeneric(**details.dict())
+    else:
+        raise NotImplementedError(
+            f"_format_alert_details_for_webhook not implemented for webhook type: {webhook_type}"
+        )
+
+
+def _format_exposed_details_for_webhook(
+    webhook_type: WebhookType, details: TokenExposedDetails
+):
+    if webhook_type == WebhookType.SLACK:
+        raise NotImplementedError(
+            f"_format_exposed_details_for_webhook not implemented for webhook type: {webhook_type}"
+        )
+    elif webhook_type == WebhookType.GOOGLE_CHAT:
+        raise NotImplementedError(
+            f"_format_exposed_details_for_webhook not implemented for webhook type: {webhook_type}"
+        )
+    elif webhook_type == WebhookType.DISCORD:
+        raise NotImplementedError(
+            f"_format_exposed_details_for_webhook not implemented for webhook type: {webhook_type}"
+        )
+    elif webhook_type == WebhookType.MS_TEAMS:
+        raise NotImplementedError(
+            f"_format_exposed_details_for_webhook not implemented for webhook type: {webhook_type}"
+        )
+    elif webhook_type == WebhookType.GENERIC:
+        return TokenExposedDetailGeneric(**details.dict())
+    else:
+        raise NotImplementedError(
+            f"_format_alert_details_for_webhook not implemented for webhook type: {webhook_type}"
+        )
 
 
 def generate_webhook_test_payload(webhook_type: WebhookType, token_type: TokenTypes):

--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -82,6 +82,17 @@
           time{{ hasAlerts > 1 ? 's' : '' }}</span
         >
       </BaseMessageBox>
+      <BaseMessageBox
+        v-if="keyExposedHit"
+        class="mt-32"
+        variant="warning"
+        text-link="Go to token"
+        @click="handleGoToExposedToken"
+      >
+        This Canarytoken has been found
+        <a class="font-bold" :href="keyExposedHit.public_location" target="_blank">here</a>
+        on the internet. Please replace it with a new Canarytoken.
+      </BaseMessageBox>
       <DeleteTokenButton
         :memo="manageTokenResponse.canarydrop.memo"
         :token="manageTokenResponse.canarydrop.canarytoken._value"
@@ -121,6 +132,7 @@ const dynamicComponent = ref({
 });
 
 const hasAlerts = ref(0);
+const keyExposedHit = ref();
 
 /* AZURE CONFIG Exception handler */
 /* CSS Cloned Site type can be an Azure ID Config token */
@@ -139,6 +151,11 @@ function handleCheckHistory() {
   router.push({ name: 'history', params: { auth, token } });
 }
 
+function handleGoToExposedToken() {
+  window.open(keyExposedHit.value.public_location, '_blank');
+}
+
+
 async function fetchTokenData() {
   isLoading.value = true;
 
@@ -154,6 +171,7 @@ async function fetchTokenData() {
     tokenLogoUrl.value = `token_icons/${tokenServices[getTokenType.value].icon}`;
     hasAlerts.value =
       manageTokenResponse.value.canarydrop.triggered_details.hits.length;
+    keyExposedHit.value = manageTokenResponse.value.canarydrop.key_exposed_details;
     loadComponent();
   } catch (err: any) {
     console.log(err, 'err!');

--- a/tests/integration/test_against_token_server.py
+++ b/tests/integration/test_against_token_server.py
@@ -33,7 +33,6 @@ from canarytokens.models import (
     SMTPTokenHistory,
     SMTPTokenRequest,
     SMTPTokenResponse,
-    TokenAlertDetailGeneric,
     WebBugTokenHistory,
     WebBugTokenRequest,
     WebBugTokenResponse,
@@ -41,6 +40,7 @@ from canarytokens.models import (
     WindowsDirectoryTokenRequest,
     WindowsDirectoryTokenResponse,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from canarytokens.settings import SwitchboardSettings
 from tests.utils import (
     clear_stats_on_webhook,

--- a/tests/integration/test_cmd_token.py
+++ b/tests/integration/test_cmd_token.py
@@ -7,8 +7,8 @@ from canarytokens.models import (
     CMDTokenHistory,
     CMDTokenRequest,
     CMDTokenResponse,
-    TokenAlertDetailGeneric,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 
 from tests.utils import (
     clear_stats_on_webhook,

--- a/tests/integration/test_custom_binary.py
+++ b/tests/integration/test_custom_binary.py
@@ -13,10 +13,10 @@ from canarytokens.models import (
     CustomBinaryTokenRequest,
     CustomBinaryTokenResponse,
     Memo,
-    TokenAlertDetailGeneric,
     TokenTypes,
     UploadedExe,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import (
     create_token,
     get_stats_from_webhook,

--- a/tests/integration/test_custom_image.py
+++ b/tests/integration/test_custom_image.py
@@ -11,11 +11,11 @@ from canarytokens.models import (
     CustomImageTokenRequest,
     CustomImageTokenResponse,
     Memo,
-    TokenAlertDetailGeneric,
     TokenTypes,
     UploadedImage,
     WebImageSettingsRequest,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import (
     create_token,
     get_stats_from_webhook,

--- a/tests/integration/test_kubeconfig_token.py
+++ b/tests/integration/test_kubeconfig_token.py
@@ -11,9 +11,9 @@ from canarytokens.models import (
     KubeconfigTokenRequest,
     KubeconfigTokenResponse,
     Memo,
-    TokenAlertDetailGeneric,
     TokenTypes,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import (
     create_token,
     get_stats_from_webhook,

--- a/tests/integration/test_microsoft_excel_document.py
+++ b/tests/integration/test_microsoft_excel_document.py
@@ -11,9 +11,9 @@ from canarytokens.models import (
     MsExcelDocumentTokenHistory,
     MsExcelDocumentTokenRequest,
     MsExcelDocumentTokenResponse,
-    TokenAlertDetailGeneric,
     TokenTypes,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import (
     create_token,
     get_stats_from_webhook,

--- a/tests/integration/test_microsoft_word_document.py
+++ b/tests/integration/test_microsoft_word_document.py
@@ -9,9 +9,9 @@ from canarytokens.models import (
     MsWordDocumentTokenHistory,
     MsWordDocumentTokenRequest,
     MsWordDocumentTokenResponse,
-    TokenAlertDetailGeneric,
     TokenTypes,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import (
     create_token,
     get_stats_from_webhook,

--- a/tests/integration/test_qr_token_against_server.py
+++ b/tests/integration/test_qr_token_against_server.py
@@ -11,9 +11,9 @@ from canarytokens.models import (
     QRCodeTokenHistory,
     QRCodeTokenRequest,
     QRCodeTokenResponse,
-    TokenAlertDetailGeneric,
     TokenTypes,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import (
     create_token,
     get_stats_from_webhook,

--- a/tests/integration/test_sql_server_token.py
+++ b/tests/integration/test_sql_server_token.py
@@ -10,9 +10,9 @@ from canarytokens.models import (
     SQLServerTokenHistory,
     SQLServerTokenRequest,
     SQLServerTokenResponse,
-    TokenAlertDetailGeneric,
     TokenTypes,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import create_token, get_stats_from_webhook, get_token_history, v2
 
 

--- a/tests/integration/test_svn_token.py
+++ b/tests/integration/test_svn_token.py
@@ -11,9 +11,9 @@ from canarytokens.models import (
     SvnTokenHistory,
     SvnTokenRequest,
     SvnTokenResponse,
-    TokenAlertDetailGeneric,
     TokenTypes,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import (
     create_token,
     get_stats_from_webhook,

--- a/tests/integration/test_windows_folder.py
+++ b/tests/integration/test_windows_folder.py
@@ -10,12 +10,12 @@ import requests
 
 from canarytokens.models import (
     Memo,
-    TokenAlertDetailGeneric,
     TokenTypes,
     WindowsDirectoryTokenHistory,
     WindowsDirectoryTokenRequest,
     WindowsDirectoryTokenResponse,
 )
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import (
     create_token,
     get_stats_from_webhook,

--- a/tests/units/test_channel_output_webhook.py
+++ b/tests/units/test_channel_output_webhook.py
@@ -19,6 +19,7 @@ from canarytokens.settings import FrontendSettings, SwitchboardSettings
 from canarytokens.switchboard import Switchboard
 from canarytokens.tokens import Canarytoken
 from canarytokens.constants import CANARY_IMAGE_URL
+from canarytokens.webhook_formatting import format_details_for_webhook, get_webhook_type
 
 
 def test_broken_webhook(
@@ -230,12 +231,10 @@ def test_canaryalert_googlechat_webhook(
     )
     cd.add_canarydrop_hit(token_hit=token_hit)
 
-    canaryalert_webhook_payload = input_channel.format_webhook_canaryalert(
-        canarydrop=cd,
-        protocol=input_channel.switchboard_scheme,
-        host=input_channel.hostname,
-    )
-    assert isinstance(canaryalert_webhook_payload, TokenAlertDetailsGoogleChat)
+    webhook_type = get_webhook_type(cd.alert_webhook_url)
+    details = input_channel.gather_alert_details(cd, "http", "example.com")
+    payload = format_details_for_webhook(webhook_type, details)
+    assert isinstance(payload, TokenAlertDetailsGoogleChat)
 
 
 def test_ms_teams_webhook_format(
@@ -334,12 +333,10 @@ def test_canaryalert_ms_teams_webhook(
     )
     cd.add_canarydrop_hit(token_hit=token_hit)
 
-    canaryalert_webhook_payload = input_channel.format_webhook_canaryalert(
-        canarydrop=cd,
-        protocol=input_channel.switchboard_scheme,
-        host=input_channel.hostname,
-    )
-    assert isinstance(canaryalert_webhook_payload, TokenAlertDetailsMsTeams)
+    webhook_type = get_webhook_type(cd.alert_webhook_url)
+    details = input_channel.gather_alert_details(cd, "http", "example.com")
+    payload = format_details_for_webhook(webhook_type, details)
+    assert isinstance(payload, TokenAlertDetailsMsTeams)
 
 
 @pytest.mark.parametrize(

--- a/tests/units/test_models.py
+++ b/tests/units/test_models.py
@@ -31,7 +31,6 @@ from canarytokens.models import (
     SMTPMailField,
     SMTPTokenHistory,
     SMTPTokenHit,
-    TokenAlertDetailGeneric,
     TokenRequest,
     TokenTypes,
     WebBugTokenHistory,
@@ -39,6 +38,7 @@ from canarytokens.models import (
     json_safe_dict,
 )
 from canarytokens.tokens import Canarytoken
+from canarytokens.webhook_formatting import TokenAlertDetailGeneric
 from tests.utils import v2, v3
 
 

--- a/tests/units/test_webhook_formatting.py
+++ b/tests/units/test_webhook_formatting.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Literal
+from typing import Literal, Union
 import pytest
 from canarytokens.models import Memo, TokenAlertDetails, TokenExposedDetails, TokenTypes
 from canarytokens.webhook_formatting import (
@@ -45,7 +45,7 @@ def test_get_webhook_type(url: str, expected_type: WebhookType):
     ],
 )
 def test_format_details_for_webhook_alert_type(
-    details_type: Literal["alert"] | Literal["exposed"],
+    details_type: Union[Literal["alert"], Literal["exposed"]],
     webhook_type: WebhookType,
     expected_payload_type,
 ):

--- a/tests/units/test_webhook_formatting.py
+++ b/tests/units/test_webhook_formatting.py
@@ -1,0 +1,74 @@
+from datetime import datetime
+from typing import Literal
+import pytest
+from canarytokens.models import Memo, TokenAlertDetails, TokenExposedDetails, TokenTypes
+from canarytokens.webhook_formatting import (
+    WebhookType,
+    format_details_for_webhook,
+    get_webhook_type,
+    TokenAlertDetailGeneric,
+    TokenExposedDetailGeneric,
+)
+
+
+@pytest.mark.parametrize(
+    ["url", "expected_type"],
+    [
+        (
+            "https://hooks.slack.com/services/A0B1C2D3E/A0B1C2D3E4F/a0B1c2D3e4F5g6H7i8J9k0L1",
+            WebhookType.SLACK,
+        ),
+        (
+            "https://discord.com/api/webhooks/0123456789012345678/ABCDEFGHIJKLMNOPQRST_NB14QRp-iybHHFMtYKW8v76CqxnR69HV9tG5HrrVEo3BT9P",
+            WebhookType.DISCORD,
+        ),
+        (
+            "https://chat.googleapis.com/v1/spaces/AAAAabcdefg/messages?key=ABCDEFGHIJKLMNOPQRTSTU-AbCdEfGhIjKlMnOp&token=1a2b3c4d_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            WebhookType.GOOGLE_CHAT,
+        ),
+        (
+            "https://azurebasethinkst.webhook.office.com/webhookb2/aaaaaaaa-bbbb-cccc-dddd-111111111111@aaaaaaaa-bbbb-cccc-dddd-111111111111/IncomingWebhook/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbb-cccc-dddd-1111-eeeeeeeeeeee/ABCDEFG123456789ABCDEFG123456789abcdefg1234567",
+            WebhookType.MS_TEAMS,
+        ),
+        ("http://example.com/abc", WebhookType.GENERIC),
+    ],
+)
+def test_get_webhook_type(url: str, expected_type: WebhookType):
+    assert get_webhook_type(url) == expected_type
+
+
+@pytest.mark.parametrize(
+    ["details_type", "webhook_type", "expected_payload_type"],
+    [
+        ("alert", WebhookType.GENERIC, TokenAlertDetailGeneric),
+        ("exposed", WebhookType.GENERIC, TokenExposedDetailGeneric),
+    ],
+)
+def test_format_details_for_webhook_alert_type(
+    details_type: Literal["alert"] | Literal["exposed"],
+    webhook_type: WebhookType,
+    expected_payload_type,
+):
+    """
+    format_details_for_webhook should return the correct payload type based on the webhook type
+    """
+    if details_type == "alert":
+        details = TokenAlertDetails(
+            time=datetime.now(),
+            memo=Memo("test"),
+            additional_data=None,
+            manage_url="http://example.com",
+        )
+    else:
+        details = TokenExposedDetails(
+            token_type=TokenTypes.AWS_KEYS,
+            token="",
+            memo=Memo("test"),
+            key_id="",
+            public_location="",
+            exposed_time=datetime.now(),
+            manage_url="http://example.com",
+        )
+
+    payload = format_details_for_webhook(webhook_type, details)
+    assert isinstance(payload, expected_payload_type)


### PR DESCRIPTION
## Proposed changes

As part of a bigger change to add exposed key monitoring to AWS keys, this PR adds the functionality to the tokens server to accept POST requests (that will come from a lambda) to add a token exposed event to a token. This information is then displayed on the frontend.

This PR also adds support for this new type of alert (an exposed key alert) in the generic webhook channel, but leaves the implementation of the exposed key alert for other channels (email and the other webhooks) for a future PR to keep this PR small (we can do this since the lambda that will create these POST requests doesn't exist yet so these events won't be created under normal circumstances yet).

## Types of changes

What types of changes does your code introduce to this repository?

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Additional testing

- Created a web bug token with a MS Teams webhook and checked that the webhook test message and token hit message were correct on MS Teams.
- Triggered an AWS API key token (using aws cli) and checked that the alert was sent to the specified email and generic webhook and that it displayed on the frontend.
- Triggered the exposed key alert with the following command

```
curl -X POST https://honeypdfs.net/$token --data-urlencode 'token_exposed=true' --data-urlencode 'exposed_time=1730710853' --data-urlencode 'public_location=https://google.com'
```

- Checked that the correct data was sent to the generic webhook

```
{
  "token_type": "aws_keys",
  "token": "... snip ...",
  "memo": "generic webhook test",
  "key_id": "... snip ...",
  "public_location": "https://google.com",
  "exposed_time": "2024-11-04 09:00:53 (UTC)",
  "manage_url": "https://honeypdfs.com/manage?token=... snip ...&auth=... snip ...",
  "public_domain": "honeypdfs.com"
}
```

- Checked that the data was displayed correctly on the frontend

![CleanShot 2024-11-04 at 11 04 51@2x](https://github.com/user-attachments/assets/7bb5bf7e-4ae6-4329-b7d8-25b197e45319)
