### PR TITLE
Idp token Preview component

### DIFF
--- a/frontend_vue/components.d.ts
+++ b/frontend_vue/components.d.ts
@@ -10,6 +10,7 @@ declare module 'vue' {
     BaseButton: typeof import('./src/components/base/BaseButton.vue')['default']
     BaseCodeSnippet: typeof import('./src/components/base/BaseCodeSnippet.vue')['default']
     BaseCopyButton: typeof import('./src/components/base/BaseCopyButton.vue')['default']
+    BaseDownloadIconButtom: typeof import('./src/components/base/BaseDownloadIconButtom.vue')['default']
     BaseFormImageSelect: typeof import('./src/components/base/BaseFormImageSelect.vue')['default']
     BaseFormSelect: typeof import('./src/components/base/BaseFormSelect.vue')['default']
     BaseFormTextField: typeof import('./src/components/base/BaseFormTextField.vue')['default']

--- a/frontend_vue/src/components/base/BaseCopyButton.vue
+++ b/frontend_vue/src/components/base/BaseCopyButton.vue
@@ -5,8 +5,14 @@
       shown: isTriggered,
       triggers: tooltipTriggers,
     }"
-    class="h-[2rem] w-[2rem] font-semibold text-white rounded-full bg-green hover:bg-green-300 transition duration-100"
+    :class="
+      props.disabled
+        ? 'cursor-not-allowed bg-grey-200 hover:bg-grey-200'
+        : 'cursor-pointer  bg-green hover:bg-green-300 '
+    "
+    class="h-[2rem] w-[2rem] font-semibold text-white rounded-full transition duration-100"
     aria-label="Copy to clipboard"
+    :disabled="props.disabled || !isSupported"
     @click="copyContent"
   >
     <Transition
@@ -39,6 +45,7 @@ import { useClipboard } from '@vueuse/core';
 const props = withDefaults(
   defineProps<{
     content: string;
+    disabled?: boolean;
   }>(),
   {
     content: '',

--- a/frontend_vue/src/components/base/BaseDownloadIconButtom.vue
+++ b/frontend_vue/src/components/base/BaseDownloadIconButtom.vue
@@ -1,0 +1,35 @@
+<template>
+  <div
+    :class="props.disabled ? 'hover:brightness-100' : 'hover:brightness-110'"
+    class="relative flex items-center justify-center p-8 duration-100 bg-white border cursor-pointer rounded-2xl border-grey-200"
+  >
+    <a
+      v-bind="$attrs"
+      class="bg-cover min-w-[4rem] min-h-[4rem] rounded-2xl duration-100"
+      :class="{ 'bg-grey-200 cursor-default': props.disabled }"
+      :style="
+        !props.disabled && props.url
+          ? { backgroundImage: `url(${props.url})` }
+          : ''
+      "
+      :disabled="props.disabled"
+      download
+      :href="props.url"
+    >
+      <span class="sr-only">{{ props.alt }} Download</span>
+      <span
+        :class="{ hidden: props.disabled }"
+        class="absolute w-[2rem] rounded-full h-[2rem] bg-green top-[-.5rem] right-[-.5rem] flex items-center justify-center text-white"
+        ><font-awesome-icon icon="arrow-down"></font-awesome-icon
+      ></span>
+    </a>
+  </div>
+</template>
+
+<script lang="ts" setup>
+const props = defineProps<{
+  url?: string;
+  alt?: string;
+  disabled?: boolean;
+}>();
+</script>

--- a/frontend_vue/src/components/base/BaseFormSelect.vue
+++ b/frontend_vue/src/components/base/BaseFormSelect.vue
@@ -29,6 +29,21 @@
           class="w-6 h-6 hover:text-grey-400"
       /></span>
     </template>
+    <template #option="option">
+      <slot
+        name="option"
+        :option="option"
+        :value="option.value"
+      >
+      </slot>
+    </template>
+    <template #selected-option="option">
+      <slot
+        name="selected-option"
+        :option="option"
+        :value="option.value"
+      ></slot>
+    </template>
   </v-select>
 </template>
 
@@ -36,10 +51,14 @@
 import { toRef, onMounted } from 'vue';
 import { useField } from 'vee-validate';
 
+type OptionType = {
+  [key: string]: string;
+};
+
 const props = defineProps<{
   id: string;
   label: string;
-  options: string[];
+  options: string[] | OptionType[];
   placeholder?: string;
 }>();
 
@@ -61,9 +80,11 @@ onMounted(() => {
   }
 });
 
-function handleSelectOption(value: string) {
+function handleSelectOption(selectedVal: string | OptionType) {
+  const value =
+    typeof selectedVal === 'object' ? selectedVal.value : selectedVal;
   handleChange(value);
-  emits('selectOption', value);
+  emits('selectOption', selectedVal);
 }
 </script>
 

--- a/frontend_vue/src/components/base/BaseLabelArrow.vue
+++ b/frontend_vue/src/components/base/BaseLabelArrow.vue
@@ -1,6 +1,7 @@
 <!-- eslint-disable vue/no-v-html -->
 <template>
   <BaseLabel
+    v-bind="$attrs"
     :id="id"
     class="container relative mb-8"
   >

--- a/frontend_vue/src/components/tokens/idp_app/ActivatedToken.vue
+++ b/frontend_vue/src/components/tokens/idp_app/ActivatedToken.vue
@@ -9,6 +9,7 @@
     When the fake app is opened from your IdP dashboard you receive an alert.
     <ButtonActivateTokenTips @how-to-use="$emit('howToUse')" />
   </p>
+  <CreateAppPreview />
 </template>
 
 <script setup lang="ts">
@@ -16,6 +17,7 @@ import { ref } from 'vue';
 import TokenDisplay from './TokenDisplay.vue';
 import type { NewTokenBackendType } from '@/components/tokens/types';
 import ButtonActivateTokenTips from '@/components/ui/ButtonActivateTokenTips.vue';
+import CreateAppPreview from './CreateAppPreview.vue';
 
 const props = defineProps<{
   tokenData: NewTokenBackendType;

--- a/frontend_vue/src/components/tokens/idp_app/ActivatedToken.vue
+++ b/frontend_vue/src/components/tokens/idp_app/ActivatedToken.vue
@@ -9,6 +9,11 @@
     When the fake app is opened from your IdP dashboard you receive an alert.
     <ButtonActivateTokenTips @how-to-use="$emit('howToUse')" />
   </p>
+  <BaseMessageBox
+    variant="info"
+    class="mt-32"
+    >Some info here to tell user what the Preview is about</BaseMessageBox
+  >
   <CreateAppPreview />
 </template>
 

--- a/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
+++ b/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
@@ -41,7 +41,7 @@
       >
         Preview
       </h3>
-      <div class="grid gap-16 md:grid-cols-2 sm:grid-cols-1 sm:gap-24">
+      <div class="grid grid-cols-1 gap-16 sm:gap-24">
         <div class="flex flex-col items-center justify-center gap-8">
           <BaseLabelArrow
             id="idp-app-img"
@@ -66,10 +66,12 @@
             class="text-center"
           />
           <div
-            class="flex flex-row items-center gap-16 p-16 bg-white rounded-2xl"
+            class="flex flex-row items-center justify-center gap-16 p-16 bg-white rounded-2xl"
           >
             <!-- Copy Name Input Readonly -->
-            <div class="relative flex flex-col grow">
+            <div
+              class="relative flex flex-col grow max-w-[60ch] items-center gap-8"
+            >
               <label
                 for="text-input"
                 class="sr-only"

--- a/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
+++ b/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
@@ -1,0 +1,123 @@
+<template>
+  <div class="flex flex-col gap-16 mt-24 mb-32">
+    <base-form-select
+      id="idp-app-look"
+      label="Select Custom App look"
+      :options="idpOptions"
+      placeholder="Select an option"
+      @select-option="handleSelectedApp"
+    >
+      <template #option="{ option }">
+        <div class="flex flex-row items-center gap-16">
+          <div
+            alt="icon"
+            :style="{ backgroundImage: `url(${getImageUrl(option.iconUrl)})` }"
+            class="bg-cover w-[2rem] h-[2rem] rounded-2xl duration-100"
+          ></div>
+          {{ option.value }}
+        </div>
+      </template>
+
+      <template #selected-option="{ option }">
+        <div class="flex flex-row items-center gap-16">
+          <div
+            alt="icon"
+            :style="{ backgroundImage: `url(${getImageUrl(option.iconUrl)})` }"
+            class="bg-cover w-[1.5rem] h-[1.5rem] rounded-2xl duration-100"
+          ></div>
+          {{ option.value }}
+        </div>
+      </template>
+    </base-form-select>
+
+    <div class="p-16 border border-grey-200 rounded-xl">
+      <h3
+        class="flex flex-row gap-8 mb-16 text-sm font-semibold text-left text-grey-400"
+      >
+        Preview
+      </h3>
+      <div class="grid gap-16 md:grid-cols-2 sm:grid-cols-1 sm:gap-24">
+        <div class="flex flex-col items-center justify-center gap-8">
+          <BaseLabelArrow
+            id="idp-app-img"
+            :arrow-word-position="4"
+            label="Download custom App Icon"
+            arrow-variant="one"
+            class="text-center"
+          />
+          <BaseDownloadIconButtom
+            :url="
+              selectedApp?.iconUrl && getImageUrl(`${selectedApp?.iconUrl}`)
+            "
+            :disabled="!selectedApp?.iconUrl"
+          />
+        </div>
+        <div class="flex flex-col gap-8">
+          <BaseLabelArrow
+            id="idp-app-name"
+            :arrow-word-position="3"
+            label="Copy custom App name"
+            arrow-variant="two"
+            class="text-center"
+          />
+          <div
+            class="flex flex-row items-center gap-16 p-16 bg-white rounded-2xl"
+          >
+            <div class="relative flex flex-col grow">
+              <label
+                for="text-input"
+                class="sr-only"
+                >App name</label
+              >
+              <input
+                id="text-input"
+                type="text"
+                placeholder="App name"
+                :value="selectedApp?.value"
+                readonly
+                class="h-[3rem] w-full px-16 py-8 border resize-none shadow-inner-shadow-grey rounded-3xl border-grey-400 focus:ring-green-600 focus-visible:ring-1"
+              />
+              <BaseCopyButton
+                :content="selectedApp?.value ? selectedApp?.value : ''"
+                :disabled="!selectedApp?.value"
+                class="absolute top-8 right-16"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import getImageUrl from '@/utils/getImageUrl';
+import { ref } from 'vue';
+
+type SelectedAppType = {
+  value: string;
+  iconUrl: string;
+};
+
+const selectedApp = ref<SelectedAppType>();
+
+const idpOptions = [
+  {
+    value: 'Custom app',
+    iconUrl: 'pwa_icons/pwa_facebook.png',
+  },
+  {
+    value: 'Gmail app',
+    iconUrl: 'pwa_icons/pwa_rbc.png',
+  },
+  {
+    value: 'Outlook app',
+    iconUrl: 'pwa_icons/pwa_snapchat.png',
+  },
+];
+
+function handleSelectedApp(selected: { value: string; iconUrl: string }) {
+  console.log('Selected app:', selected);
+  selectedApp.value = selected;
+}
+</script>

--- a/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
+++ b/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
@@ -68,6 +68,7 @@
           <div
             class="flex flex-row items-center gap-16 p-16 bg-white rounded-2xl"
           >
+            <!-- Copy Name Input Readonly -->
             <div class="relative flex flex-col grow">
               <label
                 for="text-input"

--- a/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
+++ b/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="flex flex-col gap-16 mt-24 mb-32">
+  <div
+    class="flex flex-col gap-16 p-16 mt-24 mb-32 border border-grey-200 rounded-xl"
+  >
+    <h3 class="flex flex-row text-sm font-semibold text-left text-grey-400">
+      App Custom appareance
+    </h3>
     <base-form-select
       id="idp-app-look"
       label="Select Custom App look"
@@ -30,7 +35,7 @@
       </template>
     </base-form-select>
 
-    <div class="p-16 border border-grey-200 rounded-xl">
+    <div class="p-16 bg-white rounded-xl">
       <h3
         class="flex flex-row gap-8 mb-16 text-sm font-semibold text-left text-grey-400"
       >

--- a/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
+++ b/frontend_vue/src/components/tokens/idp_app/CreateAppPreview.vue
@@ -3,11 +3,11 @@
     class="flex flex-col gap-16 p-16 mt-24 mb-32 border border-grey-200 rounded-xl"
   >
     <h3 class="flex flex-row text-sm font-semibold text-left text-grey-400">
-      App Custom appareance
+      App appareance
     </h3>
     <base-form-select
       id="idp-app-look"
-      label="Select Custom App look"
+      label="Select App"
       :options="idpOptions"
       placeholder="Select an option"
       @select-option="handleSelectedApp"
@@ -35,63 +35,52 @@
       </template>
     </base-form-select>
 
-    <div class="p-16 bg-white rounded-xl">
-      <h3
-        class="flex flex-row gap-8 mb-16 text-sm font-semibold text-left text-grey-400"
+    <div class="flex flex-col w-full gap-24 p-16 bg-white rounded-xl">
+      <div class="flex flex-col items-center justify-center gap-8">
+        <BaseLabelArrow
+          id="idp-app-img"
+          :arrow-word-position="3"
+          label="Download App Icon"
+          arrow-variant="one"
+          class="text-center"
+        />
+        <BaseDownloadIconButtom
+          :url="selectedApp?.iconUrl && getImageUrl(`${selectedApp?.iconUrl}`)"
+          :disabled="!selectedApp?.iconUrl"
+        />
+      </div>
+      <div
+        class="flex flex-col items-center justify-center bg-white rounded-2xl"
       >
-        Preview
-      </h3>
-      <div class="grid grid-cols-1 gap-16 sm:gap-24">
-        <div class="flex flex-col items-center justify-center gap-8">
-          <BaseLabelArrow
-            id="idp-app-img"
-            :arrow-word-position="4"
-            label="Download custom App Icon"
-            arrow-variant="one"
-            class="text-center"
-          />
-          <BaseDownloadIconButtom
-            :url="
-              selectedApp?.iconUrl && getImageUrl(`${selectedApp?.iconUrl}`)
-            "
-            :disabled="!selectedApp?.iconUrl"
-          />
-        </div>
-        <div class="flex flex-col gap-8">
-          <BaseLabelArrow
-            id="idp-app-name"
-            :arrow-word-position="3"
-            label="Copy custom App name"
-            arrow-variant="two"
-            class="text-center"
-          />
-          <div
-            class="flex flex-row items-center justify-center gap-16 p-16 bg-white rounded-2xl"
+        <BaseLabelArrow
+          id="idp-app-name"
+          :arrow-word-position="3"
+          label="Copy App name"
+          arrow-variant="two"
+          class="z-10 text-center"
+        />
+        <!-- Copy Name Input Readonly -->
+        <div
+          class="relative flex flex-col w-full max-w-[40ch] items-center gap-8"
+        >
+          <label
+            for="text-input"
+            class="sr-only"
+            >App name</label
           >
-            <!-- Copy Name Input Readonly -->
-            <div
-              class="relative flex flex-col grow max-w-[60ch] items-center gap-8"
-            >
-              <label
-                for="text-input"
-                class="sr-only"
-                >App name</label
-              >
-              <input
-                id="text-input"
-                type="text"
-                placeholder="App name"
-                :value="selectedApp?.value"
-                readonly
-                class="h-[3rem] w-full px-16 py-8 border resize-none shadow-inner-shadow-grey rounded-3xl border-grey-400 focus:ring-green-600 focus-visible:ring-1"
-              />
-              <BaseCopyButton
-                :content="selectedApp?.value ? selectedApp?.value : ''"
-                :disabled="!selectedApp?.value"
-                class="absolute top-8 right-16"
-              />
-            </div>
-          </div>
+          <input
+            id="text-input"
+            type="text"
+            placeholder="App name"
+            :value="selectedApp?.value"
+            readonly
+            class="h-[3rem] w-full px-16 py-8 border resize-none shadow-inner-shadow-grey rounded-3xl border-grey-400 focus:ring-green-600 focus-visible:ring-1"
+          />
+          <BaseCopyButton
+            :content="selectedApp?.value ? selectedApp?.value : ''"
+            :disabled="!selectedApp?.value"
+            class="absolute top-8 right-16"
+          />
         </div>
       </div>
     </div>

--- a/frontend_vue/src/components/tokens/idp_app/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/idp_app/ManageToken.vue
@@ -5,12 +5,14 @@
     :token-url="tokenUrl"
     :entity-id="entityId"
   />
+  <CreateAppPreview />
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue';
 import TokenDisplay from './TokenDisplay.vue';
 import type { ManageTokenBackendType } from '@/components/tokens/types.ts';
+import CreateAppPreview from './CreateAppPreview.vue';
 
 const props = defineProps<{
   tokenBackendResponse: ManageTokenBackendType;

--- a/frontend_vue/src/components/tokens/idp_app/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/idp_app/ManageToken.vue
@@ -5,6 +5,11 @@
     :token-url="tokenUrl"
     :entity-id="entityId"
   />
+  <BaseMessageBox
+    variant="info"
+    class="mt-32"
+    >Some info here to tell user what the Preview is about</BaseMessageBox
+  >
   <CreateAppPreview />
 </template>
 

--- a/frontend_vue/src/components/tokens/idp_app/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/idp_app/TokenDisplay.vue
@@ -1,16 +1,18 @@
 <template>
-  <base-code-snippet
-    lang="javascript"
-    label="Login URL"
-    is-single-line
-    :code="tokenUrl"
-  ></base-code-snippet>
-  <base-code-snippet
-    lang="javascript"
-    label="Entity ID"
-    is-single-line
-    :code="entityId"
-  ></base-code-snippet>
+  <div class="flex flex-col gap-16">
+    <base-code-snippet
+      lang="javascript"
+      label="Login URL"
+      is-single-line
+      :code="tokenUrl"
+    ></base-code-snippet>
+    <base-code-snippet
+      lang="javascript"
+      label="Entity ID"
+      is-single-line
+      :code="entityId"
+    ></base-code-snippet>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/frontend_vue/src/main.ts
+++ b/frontend_vue/src/main.ts
@@ -1,10 +1,7 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
-import {
-  library,
-  type IconDefinition,
-} from '@fortawesome/fontawesome-svg-core';
+import { library } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
 import {
   faBars,
@@ -31,7 +28,7 @@ import {
   faFileExcel,
   faFile,
   faQuoteLeft,
-  faArrowUpRightFromSquare
+  faArrowUpRightFromSquare,
 } from '@fortawesome/free-solid-svg-icons';
 import { createVfm } from 'vue-final-modal';
 import { vTooltip } from 'floating-vue';
@@ -69,7 +66,7 @@ library.add(
   faFileExcel,
   faFile,
   faQuoteLeft,
-  faArrowUpRightFromSquare,
+  faArrowUpRightFromSquare
 );
 
 const vfm = createVfm();

--- a/frontend_vue/src/views/ComponentPreview.vue
+++ b/frontend_vue/src/views/ComponentPreview.vue
@@ -1,6 +1,11 @@
 <template>
   <div>
     <hr class="my-24" />
+    <h1>App preview</h1>
+    <CreateAppPreview />
+  </div>
+  <div>
+    <hr class="my-24" />
     <h1>Image Select</h1>
     <div class="flex flex-col gap-16 mt-24 mb-32">
       <BaseFormImageSelect
@@ -10,7 +15,10 @@
           { value: 'image1', url: `${getImageUrl('pwa_icons/pwa_fnb.png')}` },
           { value: 'image2', url: `${getImageUrl('pwa_icons/pwa_axis.png')}` },
           { value: 'image3', url: `${getImageUrl('pwa_icons/pwa_rbc.png')}` },
-          { value: 'image4', url: `${getImageUrl('pwa_icons/pwa_tiktok.png')}` },
+          {
+            value: 'image4',
+            url: `${getImageUrl('pwa_icons/pwa_tiktok.png')}`,
+          },
         ]"
       />
       <BaseFormImageSelect
@@ -18,10 +26,22 @@
         label="Select an image"
         image-class="w-[100px] h-[100px]"
         :options="[
-          { value: 'image5', url: `${getImageUrl('pwa_icons/pwa_snapchat.png')}` },
-          { value: 'image6', url: `${getImageUrl('pwa_icons/pwa_paypal.png')}` },
-          { value: 'image7', url: `${getImageUrl('pwa_icons/pwa_messenger.png')}` },
-          { value: 'image8', url: `${getImageUrl('pwa_icons/pwa_tiktok.png')}` },
+          {
+            value: 'image5',
+            url: `${getImageUrl('pwa_icons/pwa_snapchat.png')}`,
+          },
+          {
+            value: 'image6',
+            url: `${getImageUrl('pwa_icons/pwa_paypal.png')}`,
+          },
+          {
+            value: 'image7',
+            url: `${getImageUrl('pwa_icons/pwa_messenger.png')}`,
+          },
+          {
+            value: 'image8',
+            url: `${getImageUrl('pwa_icons/pwa_tiktok.png')}`,
+          },
         ]"
       />
     </div>
@@ -68,6 +88,10 @@
   <div class="flex flex-col max-w-[200px] gap-16">
     <h1>Copy button</h1>
     <BaseCopyButton content="Content to copy is here" />
+    <BaseCopyButton
+      content="Content to copy is here"
+      disabled
+    />
   </div>
   <hr class="my-24" />
   <div class="flex flex-col max-w-[300px] gap-16">
@@ -356,6 +380,7 @@ import BannerDeviceCanarytools from '@/components/ui/BannerDeviceCanarytools.vue
 import BannerBirdCanarytools from '@/components/ui/BannerBirdCanarytools.vue';
 import BannerTextCanarytools from '@/components/ui/BannerTextCanarytools.vue';
 import getImageUrl from '@/utils/getImageUrl';
+import CreateAppPreview from '@/components/tokens/idp_app/CreateAppPreview.vue';
 
 const { open } = useModal({
   component: ModalToken,


### PR DESCRIPTION
## Proposed changes

Adds a Preview component that should help users to setup their App
Note: the current app list and the current copy is TBD. Text and app names/icons are placeholders

<img width="728" alt="Screenshot 2024-11-07 at 10 22 37" src="https://github.com/user-attachments/assets/6ae4b6e1-8f65-4181-94ff-eec6416b0f16">
<img width="723" alt="Screenshot 2024-11-07 at 10 22 45" src="https://github.com/user-attachments/assets/2f071f52-a73c-4ba7-b2dc-6b9656645b5d">

mobile:

<img width="332" alt="Screenshot 2024-11-07 at 10 21 51" src="https://github.com/user-attachments/assets/bd9676f8-eac0-4974-9ccd-52860f4e8bfb">

Modal
<img width="849" alt="Screenshot 2024-11-07 at 10 21 40" src="https://github.com/user-attachments/assets/92b4a893-79a3-4735-9332-2bd07a139ad7">

Page
<img width="837" alt="Screenshot 2024-11-07 at 10 20 48" src="https://github.com/user-attachments/assets/125851fb-fb80-4fe3-98ef-421475191e16">
