### PR TITLE
Add Slack webhook exposed key handling

### DIFF
--- a/canarytokens/channel.py
+++ b/canarytokens/channel.py
@@ -5,7 +5,7 @@ Base class for all canarydrop channels.
 from __future__ import annotations
 
 import datetime
-from typing import Any, Coroutine, List, Optional, Union
+from typing import Any, Coroutine, Optional, Union
 
 import twisted.internet.reactor
 from twisted.internet import threads
@@ -24,8 +24,6 @@ from canarytokens.models import (
     GoogleChatHeader,
     GoogleChatSection,
     Memo,
-    SlackAttachment,
-    SlackField,
     DiscordDetails,
     DiscordEmbeds,
     DiscordAuthorField,
@@ -34,33 +32,11 @@ from canarytokens.models import (
     MsTeamsPotentialAction,
     TokenAlertDetails,
     TokenAlertDetailsGoogleChat,
-    TokenAlertDetailsSlack,
     TokenAlertDetailsDiscord,
     TokenAlertDetailsMsTeams,
 )
 
 log = Logger()
-
-
-def format_as_slack_canaryalert(details: TokenAlertDetails) -> TokenAlertDetailsSlack:
-    """
-    Transforms `TokenAlertDetails` to `TokenAlertDetailsSlack`.
-    """
-    fields: List[SlackField] = [
-        SlackField(title="Channel", value=details.channel),
-        SlackField(title="Memo", value=details.memo),
-        SlackField(
-            title="time",
-            value=details.time.strftime("%Y-%m-%d %H:%M:%S (UTC)"),
-        ),
-        SlackField(title="Manage", value=details.manage_url),
-    ]
-
-    attchments = [SlackAttachment(title_link=details.manage_url, fields=fields)]
-    return TokenAlertDetailsSlack(
-        # channel="#general",
-        attachments=attchments,
-    )
 
 
 def format_as_googlechat_canaryalert(

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -49,7 +49,12 @@ from canarytokens.constants import (
     CANARY_IMAGE_URL,
     MEMO_MAX_CHARACTERS,
 )
-from canarytokens.utils import prettify_snake_case, dict_to_csv, get_src_ip_continent
+from canarytokens.utils import (
+    json_safe_dict,
+    prettify_snake_case,
+    dict_to_csv,
+    get_src_ip_continent,
+)
 
 CANARYTOKEN_RE = re.compile(
     ".*([" + "".join(CANARYTOKEN_ALPHABET) + "]{" + str(CANARYTOKEN_LENGTH) + "}).*",
@@ -399,10 +404,6 @@ BlankRequestTokenType = Literal[
     # TokenTypes.CLONEDSITE,
     # TokenTypes.LOG4SHELL,
 ]
-
-
-def json_safe_dict(m: BaseModel, exclude: Tuple = ()) -> Dict[str, str]:
-    return json.loads(m.json(exclude_none=True, exclude=set(exclude)))
 
 
 class TokenRequest(BaseModel):
@@ -2138,25 +2139,6 @@ class TokenExposedDetails(BaseModel):
         }
 
 
-class SlackField(BaseModel):
-    title: str
-    value: str
-    short: bool = True
-
-
-class SlackAttachment(BaseModel):
-    title: str = "Canarytoken Triggered"
-    title_link: HttpUrl
-    mrkdwn_in: List[str] = ["title"]
-    fallback: str = ""
-    fields: List[SlackField]
-
-    def __init__(__pydantic_self__, **data: Any) -> None:
-        # HACK: We can do better here.
-        data["fallback"] = f"Canarytoken Triggered: {data['title_link']}"
-        super().__init__(**data)
-
-
 class GoogleChatDecoratedText(BaseModel):
     topLabel: str = ""
     text: str = ""
@@ -2296,15 +2278,6 @@ class DiscordEmbeds(BaseModel):
 
 class TokenAlertDetailsGoogleChat(BaseModel):
     cardsV2: List[GoogleChatCardV2]
-
-    def json_safe_dict(self) -> Dict[str, str]:
-        return json_safe_dict(self)
-
-
-class TokenAlertDetailsSlack(BaseModel):
-    """Details that are sent to slack webhooks."""
-
-    attachments: List[SlackAttachment]
 
     def json_safe_dict(self) -> Dict[str, str]:
         return json_safe_dict(self)

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -7,7 +7,7 @@ import json
 import re
 import secrets
 from ipaddress import IPv4Address
-from typing import Dict, List, Literal, Optional, Tuple, Union
+from typing import Dict, List, Literal, Optional, Tuple
 
 import advocate
 import requests
@@ -876,29 +876,8 @@ def validate_webhook(url, token_type: models.TokenTypes):
     if len(url) > constants.MAX_WEBHOOK_URL_LENGTH:
         raise WebhookTooLongError()
 
-    payload: Union[
-        models.TokenAlertDetails,
-        models.TokenAlertDetailsSlack,
-        models.TokenAlertDetailsGoogleChat,
-        models.TokenAlertDetailsDiscord,
-        models.TokenAlertDetailsMsTeams,
-    ]
     webhook_type = get_webhook_type(url)
-    if webhook_type == WebhookType.SLACK:
-        payload = models.TokenAlertDetailsSlack(
-            attachments=[
-                models.SlackAttachment(
-                    title_link=HttpUrl("https://test.com/check", scheme="https"),
-                    fields=[
-                        models.SlackField(
-                            title="test",
-                            value="Working",
-                        )
-                    ],
-                )
-            ]
-        )
-    elif webhook_type == WebhookType.GOOGLE_CHAT:
+    if webhook_type == WebhookType.GOOGLE_CHAT:
         # construct google chat alert card
         card = models.GoogleChatCard(
             header=models.GoogleChatHeader(

--- a/canarytokens/utils.py
+++ b/canarytokens/utils.py
@@ -1,8 +1,14 @@
+import json
 import subprocess
 from pathlib import Path
-from typing import Any, Literal, Union
+from typing import Any, Dict, Literal, Tuple, Union
 
 import pycountry_convert
+from pydantic import BaseModel
+
+
+def json_safe_dict(m: BaseModel, exclude: Tuple = ()) -> Dict[str, str]:
+    return json.loads(m.json(exclude_none=True, exclude=set(exclude)))
 
 
 def dict_to_csv(d: dict) -> str:

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -278,7 +278,7 @@ def _format_as_slack_token_exposed(
         fields.insert(
             0,
             SlackTextObject(
-                text=f":arrow_right: *<{details.public_location}|View exposed key>*"
+                text=f":link: *<{details.public_location}|View exposed key>*"
             ),
         )
 

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -306,7 +306,7 @@ def _data_to_slack_blocks(data: dict[str, Union[str, dict]]) -> list[SlackBlock]
 
 
 class SlackTextObject(BaseModel):
-    type: Union[Literal["plain_text"] | Literal["mrkdwn"]] = "mrkdwn"
+    type: Union[Literal["plain_text"], Literal["mrkdwn"]] = "mrkdwn"
     text: str
 
 

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -1,28 +1,50 @@
 from __future__ import annotations
-from typing import Union
+import json
+from typing import Any, Dict, List, Optional, Union
 from enum import Enum
 import re
 from functools import partial
 from datetime import datetime
 
-from pydantic import HttpUrl, parse_obj_as
+from pydantic import BaseModel, HttpUrl, parse_obj_as
 
 from canarytokens import constants
 from canarytokens.channel import (
     format_as_discord_canaryalert,
     format_as_googlechat_canaryalert,
     format_as_ms_teams_canaryalert,
-    format_as_slack_canaryalert,
 )
 from canarytokens.models import (
+    readable_token_type_names,
     Memo,
     TokenTypes,
     TokenAlertDetails,
     TokenExposedDetails,
 )
+from canarytokens.utils import json_safe_dict, prettify_snake_case
 
 
+CANARY_LOGO_ROUND_PUBLIC_URL = parse_obj_as(
+    HttpUrl,
+    constants.CANARY_IMAGE_URL,
+)
 WEBHOOK_TEST_URL = parse_obj_as(HttpUrl, "http://example.com/test/url/for/webhook")
+TOKEN_EXPOSED_DESCRIPTION = "One of your {readable_type} Canarytokens has been found on the internet. A publicly exposed token will provide very low quality alerts. We recommend that you disable and replace this token on private infrastructure."
+MAX_INLINE_LENGTH = 40  # Max length of content to share a line with other content
+
+
+class HexColor(Enum):
+    WARNING = "#ed6c02"
+    ERROR = "#d32f2f"
+    CANARY_GREEN = "#3ad47f"
+
+    @property
+    def decimal_value(self):
+        return int(self.value_without_hash, 16)
+
+    @property
+    def value_without_hash(self):
+        return self.value[1:]
 
 
 class WebhookType(Enum):
@@ -78,7 +100,7 @@ def _format_alert_details_for_webhook(
     webhook_type: WebhookType, details: TokenAlertDetails
 ):
     if webhook_type == WebhookType.SLACK:
-        return format_as_slack_canaryalert(details)
+        return _format_as_slack_canaryalert(details)
     elif webhook_type == WebhookType.GOOGLE_CHAT:
         return format_as_googlechat_canaryalert(details)
     elif webhook_type == WebhookType.DISCORD:
@@ -97,9 +119,7 @@ def _format_exposed_details_for_webhook(
     webhook_type: WebhookType, details: TokenExposedDetails
 ):
     if webhook_type == WebhookType.SLACK:
-        raise NotImplementedError(
-            f"_format_exposed_details_for_webhook not implemented for webhook type: {webhook_type}"
-        )
+        return _format_as_slack_token_exposed(details)
     elif webhook_type == WebhookType.GOOGLE_CHAT:
         raise NotImplementedError(
             f"_format_exposed_details_for_webhook not implemented for webhook type: {webhook_type}"
@@ -122,8 +142,17 @@ def _format_exposed_details_for_webhook(
 
 def generate_webhook_test_payload(webhook_type: WebhookType, token_type: TokenTypes):
     if webhook_type == WebhookType.SLACK:
-        raise NotImplementedError(
-            "generate_webhook_test_payload not implemented for SLACK"
+        return TokenAlertDetailsSlack(
+            attachments=[
+                SlackAttachment(
+                    title="Validating new Canarytokens webhook",
+                    text="It's working :tada:!",
+                    color=HexColor.CANARY_GREEN.value,
+                    footer="Canarytokens",
+                    footer_icon=CANARY_LOGO_ROUND_PUBLIC_URL,
+                    fields=[],
+                )
+            ]
         )
     elif webhook_type == WebhookType.GOOGLE_CHAT:
         raise NotImplementedError(
@@ -159,9 +188,137 @@ def generate_webhook_test_payload(webhook_type: WebhookType, token_type: TokenTy
         )
 
 
+def _format_as_slack_canaryalert(details: TokenAlertDetails) -> TokenAlertDetailsSlack:
+    """
+    Transforms `TokenAlertDetails` to `TokenAlertDetailsSlack`.
+    """
+    fields: List[SlackField] = [
+        SlackField(title="Channel", value=details.channel),
+        SlackField(title="Token Reminder", value=details.memo),
+        SlackField(
+            title="Time",
+            value=details.time.strftime("%Y-%m-%d %H:%M:%S (UTC)"),
+        ),
+    ]
+
+    if details.src_data:
+        fields.extend(_data_to_slack_fields(details.src_data))
+    if details.additional_data:
+        fields.extend(_data_to_slack_fields(details.additional_data))
+
+    fields.append(
+        SlackField(title="Manage token", value=details.manage_url, short=False)
+    )
+
+    attachments = [
+        SlackAttachment(
+            title_link=details.manage_url,
+            fields=fields,
+            footer="Canarytokens",
+            footer_icon=CANARY_LOGO_ROUND_PUBLIC_URL,
+            ts=details.time.timestamp(),
+            color=HexColor.ERROR.value,
+        )
+    ]
+    return TokenAlertDetailsSlack(attachments=attachments)
+
+
+def _format_as_slack_token_exposed(
+    details: TokenExposedDetails,
+) -> TokenAlertDetailsSlack:
+    fields: List[SlackField] = [
+        SlackField(title="Token Reminder", value=details.memo),
+        SlackField(title="Key ID", value=details.key_id),
+        SlackField(title="Manage token", value=details.manage_url, short=False),
+    ]
+
+    if details.public_location:
+        fields.insert(
+            2,
+            SlackField(
+                title="Key exposed here", value=details.public_location, short=False
+            ),
+        )
+
+    attachments = [
+        SlackAttachment(
+            title="Canarytoken Exposed",
+            title_link=details.manage_url,
+            fields=fields,
+            text=_get_exposed_token_description(details.token_type),
+            footer="Canarytokens",
+            footer_icon=CANARY_LOGO_ROUND_PUBLIC_URL,
+            ts=details.exposed_time.timestamp(),
+            color=HexColor.WARNING.value,
+        )
+    ]
+    return TokenAlertDetailsSlack(
+        attachments=attachments,
+    )
+
+
+def _data_to_slack_fields(data: dict[str, Union[str, dict]]) -> list[SlackField]:
+    fields: list[SlackField] = []
+    for label, value in data.items():
+        if not label or not value:
+            continue
+
+        message_text = json.dumps(value) if isinstance(value, dict) else value
+        fields.append(
+            SlackField(
+                title=prettify_snake_case(label),
+                value=message_text,
+                short=len(max(message_text.split("\n"))) < MAX_INLINE_LENGTH,
+            )
+        )
+
+    return fields
+
+
+class SlackField(BaseModel):
+    title: str
+    value: str
+    short: bool = True
+
+
+class SlackAttachment(BaseModel):
+    title: str = "Canarytoken Triggered"
+    title_link: Optional[HttpUrl] = None
+    mrkdwn_in: List[str] = ["title"]
+    fallback: str = ""
+    fields: List[SlackField]
+    text: Optional[str] = None
+    footer: Optional[str] = None
+    footer_icon: Optional[HttpUrl] = None
+    ts: Optional[int] = None
+    color: Optional[str] = None
+
+    def __init__(self, **data: Any) -> None:
+        # HACK: We can do better here.
+        title = data.get("title", "Canarytoken Triggered")
+        title_link_str = f": {data['title_link']}" if "title_link" in data else ""
+        data["fallback"] = f"{title}{title_link_str}"
+        super().__init__(**data)
+
+
+class TokenAlertDetailsSlack(BaseModel):
+    """Details that are sent to slack webhooks."""
+
+    attachments: List[SlackAttachment]
+
+    def json_safe_dict(self) -> Dict[str, str]:
+        return json_safe_dict(self)
+
+
 class TokenAlertDetailGeneric(TokenAlertDetails):
     ...
 
 
 class TokenExposedDetailGeneric(TokenExposedDetails):
     ...
+
+
+def _get_exposed_token_description(token_type: TokenTypes) -> str:
+    return TOKEN_EXPOSED_DESCRIPTION.format(
+        readable_type=readable_token_type_names[token_type]
+    )

--- a/tests/units/test_webhook_formatting.py
+++ b/tests/units/test_webhook_formatting.py
@@ -3,6 +3,7 @@ from typing import Literal, Union
 import pytest
 from canarytokens.models import Memo, TokenAlertDetails, TokenExposedDetails, TokenTypes
 from canarytokens.webhook_formatting import (
+    TokenAlertDetailsSlack,
     WebhookType,
     format_details_for_webhook,
     get_webhook_type,
@@ -42,6 +43,8 @@ def test_get_webhook_type(url: str, expected_type: WebhookType):
     [
         ("alert", WebhookType.GENERIC, TokenAlertDetailGeneric),
         ("exposed", WebhookType.GENERIC, TokenExposedDetailGeneric),
+        ("alert", WebhookType.SLACK, TokenAlertDetailsSlack),
+        ("exposed", WebhookType.SLACK, TokenAlertDetailsSlack),
     ],
 )
 def test_format_details_for_webhook_alert_type(


### PR DESCRIPTION
## Proposed changes

Add Slack webhook support for exposed API key alerts. While we're in the area also do some refactoring and general improvements for the Slack webhook.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] New feature (non-breaking change which adds functionality)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

I tested the changes to the Slack webhook by creating a new AWS API key token, triggering it normally and manually creating an exposed key alert with CURL (with 25 Dec as the exposed time) and checked that all three Slack messages displayed correctly.

![CleanShot 2024-11-14 at 17 31 41@2x](https://github.com/user-attachments/assets/4f8d32fc-4a0f-491a-a37b-dbf4f993a2eb)

An example of the current (before this change) Slack message format is shown below.

![CleanShot 2024-11-07 at 15 54 14@2x](https://github.com/user-attachments/assets/d82c7c1f-64d2-455d-ac2e-ffccd61951b5)