### PR TITLE
Add Discord webhook exposed key handling

### DIFF
--- a/canarytokens/channel.py
+++ b/canarytokens/channel.py
@@ -19,46 +19,15 @@ from canarytokens.models import (
     AnyTokenHit,
     AnyTokenExposedHit,
     Memo,
-    DiscordDetails,
-    DiscordEmbeds,
-    DiscordAuthorField,
     MsTeamsTitleSection,
     MsTeamsDetailsSection,
     MsTeamsPotentialAction,
     TokenAlertDetails,
-    TokenAlertDetailsDiscord,
     TokenAlertDetailsMsTeams,
 )
 
 log = Logger()
 
-
-
-def format_as_discord_canaryalert(
-    details: TokenAlertDetails,
-) -> TokenAlertDetailsDiscord:
-    embeds = DiscordEmbeds(
-        author=DiscordAuthorField(
-            icon_url="https://s3-eu-west-1.amazonaws.com/email-images.canary.tools/canary-logo-round.png",
-        ),
-        url=details.manage_url,
-        timestamp=details.time.strftime("%Y-%m-%dT%H:%M:%S"),
-    )
-
-    embeds.add_fields(
-        fields_info=DiscordDetails(
-            canarytoken=details.token,
-            token_reminder=details.memo,
-            src_data=details.src_data if details.src_data else None,
-        ).get_discord_data(),
-    )
-
-    if details.additional_data:
-        embeds.add_fields(
-            fields_info=details.additional_data,
-        )
-
-    return TokenAlertDetailsDiscord(embeds=[embeds])
 
 
 def format_as_ms_teams_canaryalert(

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -2140,66 +2140,6 @@ class TokenExposedDetails(BaseModel):
 
 
 
-class DiscordFieldEntry(BaseModel):
-    name: str = ""
-    value: str = ""
-    inline: bool = False
-
-
-class DiscordDetails(BaseModel):
-    canarytoken: Canarytoken
-    token_reminder: Memo
-    src_data: Optional[dict[str, Any]]
-
-    def get_discord_data(self) -> Dict[str, str]:
-        data = json_safe_dict(self)
-        data["Canarytoken"] = data.pop("canarytoken", "")
-        data["Token Reminder"] = data.pop("token_reminder", "")
-        if "src_data" in data:
-            data["Source Data"] = data.pop("src_data", "")
-        return data
-
-
-class DiscordAuthorField(BaseModel):
-    name: str = "Canary Alerts"
-    icon_url: str
-
-
-class DiscordEmbeds(BaseModel):
-    author: DiscordAuthorField
-    color: int = 3724415  # Magic colour number. Trust the process
-    title: str = "Canarytoken Triggered"
-    url: Optional[HttpUrl]
-    timestamp: datetime
-    fields: List[DiscordFieldEntry] = []
-
-    def add_fields(self, fields_info: Optional[Dict[str, str]] = {}) -> None:
-        for label, text in fields_info.items():
-            if not label or not text:
-                continue
-            message_text = (
-                json.dumps(text) if isinstance(text, dict) else "{}".format(text)
-            )
-            self.fields.append(
-                DiscordFieldEntry(
-                    name=label,
-                    value=message_text,
-                    inline=len(max(message_text.split("\n"))) < 40,
-                )
-            )
-
-    @validator("timestamp", pre=True)
-    def validate_timestamp(cls, value):
-        if isinstance(value, str):
-            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
-        return value
-
-    class Config:
-        json_encoders = {
-            datetime: lambda v: v.strftime("%Y-%m-%dT%H:%M:%S"),
-        }
-
-
 
 class MsTeamsDetailsSection(BaseModel):
     canarytoken: Canarytoken
@@ -2260,15 +2200,6 @@ class TokenAlertDetailsMsTeams(BaseModel):
     themeColor = "ff0000"
     sections: Optional[List[Union[MsTeamsTitleSection, MsTeamsDetailsSection]]] = None
     potentialAction: Optional[List[MsTeamsPotentialAction]] = None
-
-    def json_safe_dict(self) -> Dict[str, str]:
-        return json_safe_dict(self)
-
-
-class TokenAlertDetailsDiscord(BaseModel):
-    """Details that are sent to Discord webhooks"""
-
-    embeds: List[DiscordEmbeds]
 
     def json_safe_dict(self) -> Dict[str, str]:
         return json_safe_dict(self)

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -7,7 +7,7 @@ import json
 import re
 import secrets
 from ipaddress import IPv4Address
-from typing import Dict, List, Literal, Optional, Tuple
+from typing import Literal, Optional
 
 import advocate
 import requests
@@ -110,7 +110,7 @@ def add_canary_path_element(path_element: str) -> int:
     return DB.get_db().sadd(KEY_CANARY_PATH_ELEMENTS, path_element)
 
 
-def get_all_canary_pages() -> List[str]:
+def get_all_canary_pages() -> list[str]:
     return list(DB.get_db().smembers(KEY_CANARY_PAGES))
 
 
@@ -421,7 +421,7 @@ def get_geoinfo(ip: str):
             return ""
 
 
-def get_geoinfo_from_ip(ip: str) -> Dict[str, str]:
+def get_geoinfo_from_ip(ip: str) -> dict[str, str]:
     """
     Performs IP info lookup if cache check failed.
     Don't use directly, use get_geoinfo() instead.
@@ -999,7 +999,7 @@ def save_kc_endpoint(ip: IPv4Address, port: models.Port):
     DB.get_db().set(KEY_KUBECONFIG_SERVEREP, f"{ip}:{port}")
 
 
-def get_kc_endpoint() -> Tuple[Optional[IPv4Address], Optional[models.Port]]:
+def get_kc_endpoint() -> tuple[Optional[IPv4Address], Optional[models.Port]]:
     endpoint = DB.get_db().get(KEY_KUBECONFIG_SERVEREP)
     if endpoint is None:
         return None, None

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -877,18 +877,7 @@ def validate_webhook(url, token_type: models.TokenTypes):
         raise WebhookTooLongError()
 
     webhook_type = get_webhook_type(url)
-    if webhook_type == WebhookType.DISCORD:
-        # construct discord alert card
-        embeds = models.DiscordEmbeds(
-            author=models.DiscordAuthorField(
-                icon_url="https://s3-eu-west-1.amazonaws.com/email-images.canary.tools/canary-logo-round.png"
-            ),
-            title="Validating new canarytokens webhook",
-            fields=[],
-            timestamp=datetime.datetime.now(),
-        )
-        payload = models.TokenAlertDetailsDiscord(embeds=[embeds])
-    elif webhook_type == WebhookType.MS_TEAMS:
+    if webhook_type == WebhookType.MS_TEAMS:
         section = models.MsTeamsTitleSection(
             activityTitle="<b>Validating new Canarytokens webhook</b>"
         )

--- a/canarytokens/utils.py
+++ b/canarytokens/utils.py
@@ -1,13 +1,14 @@
 import json
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, Literal, Tuple, Union
+from typing import Any, Literal, Union
+import json
 
 import pycountry_convert
 from pydantic import BaseModel
 
 
-def json_safe_dict(m: BaseModel, exclude: Tuple = ()) -> Dict[str, str]:
+def json_safe_dict(m: BaseModel, exclude: tuple = ()) -> dict[str, str]:
     return json.loads(m.json(exclude_none=True, exclude=set(exclude)))
 
 

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
+from typing import Union, Optional, Literal
 import json
-from typing import Optional, List, Union, Literal, Dict
 from enum import Enum
 import re
 from functools import partial
@@ -720,9 +720,9 @@ class DiscordEmbeds(BaseModel):
     description: Optional[str] = None
     url: Optional[HttpUrl]
     timestamp: datetime
-    fields: List[DiscordFieldEntry] = []
+    fields: list[DiscordFieldEntry] = []
 
-    def add_fields(self, fields_info: Dict[str, str]) -> None:
+    def add_fields(self, fields_info: dict[str, str]) -> None:
         for label, text in fields_info.items():
             if not label or not text:
                 continue
@@ -755,9 +755,9 @@ class DiscordEmbeds(BaseModel):
 class TokenAlertDetailsDiscord(BaseModel):
     """Details that are sent to Discord webhooks"""
 
-    embeds: List[DiscordEmbeds]
+    embeds: list[DiscordEmbeds]
 
-    def json_safe_dict(self) -> Dict[str, str]:
+    def json_safe_dict(self) -> dict[str, str]:
         return json_safe_dict(self)
 
 

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 import json
-from typing import Optional, Union, Literal
+from typing import Optional, List, Union, Literal, Dict
 from enum import Enum
 import re
 from functools import partial
 from datetime import datetime
 
-from pydantic import BaseModel, HttpUrl, parse_obj_as
+from pydantic import BaseModel, HttpUrl, parse_obj_as, validator
 
 from canarytokens import constants
+from canarytokens.utils import json_safe_dict, prettify_snake_case
 from canarytokens.channel import (
-    format_as_discord_canaryalert,
     format_as_ms_teams_canaryalert,
 )
 from canarytokens.models import (
@@ -44,6 +44,12 @@ class HexColor(Enum):
     @property
     def value_without_hash(self):
         return self.value[1:]
+
+
+class DecimalColor(Enum):
+    WARNING = HexColor.WARNING.decimal_value
+    ERROR = HexColor.ERROR.decimal_value
+    CANARY_GREEN = HexColor.CANARY_GREEN.decimal_value
 
 
 class WebhookType(Enum):
@@ -103,7 +109,7 @@ def _format_alert_details_for_webhook(
     elif webhook_type == WebhookType.GOOGLE_CHAT:
         return _format_as_googlechat_canaryalert(details)
     elif webhook_type == WebhookType.DISCORD:
-        return format_as_discord_canaryalert(details)
+        return _format_as_discord_canaryalert(details)
     elif webhook_type == WebhookType.MS_TEAMS:
         return format_as_ms_teams_canaryalert(details)
     elif webhook_type == WebhookType.GENERIC:
@@ -122,9 +128,7 @@ def _format_exposed_details_for_webhook(
     elif webhook_type == WebhookType.GOOGLE_CHAT:
         return _format_as_googlechat_token_exposed(details)
     elif webhook_type == WebhookType.DISCORD:
-        raise NotImplementedError(
-            f"_format_exposed_details_for_webhook not implemented for webhook type: {webhook_type}"
-        )
+        return _format_as_discord_token_exposed(details)
     elif webhook_type == WebhookType.MS_TEAMS:
         raise NotImplementedError(
             f"_format_exposed_details_for_webhook not implemented for webhook type: {webhook_type}"
@@ -163,9 +167,14 @@ def generate_webhook_test_payload(webhook_type: WebhookType, token_type: TokenTy
             cardsV2=[GoogleChatCardV2(cardId="unique-card-id", card=card)]
         )
     elif webhook_type == WebhookType.DISCORD:
-        raise NotImplementedError(
-            "generate_webhook_test_payload not implemented for DISCORD"
+        embeds = DiscordEmbeds(
+            author=DiscordAuthorField(icon_url=CANARY_LOGO_ROUND_PUBLIC_URL),
+            url=WEBHOOK_TEST_URL,
+            title="Validating new Canarytokens webhook",
+            fields=[],
+            timestamp=datetime.now(),
         )
+        return TokenAlertDetailsDiscord(embeds=[embeds])
     elif webhook_type == WebhookType.MS_TEAMS:
         raise NotImplementedError(
             "generate_webhook_test_payload not implemented for MS_TEAMS"
@@ -637,6 +646,118 @@ class TokenAlertDetailsGoogleChat(BaseModel):
     cardsV2: list[GoogleChatCardV2]
 
     def json_safe_dict(self) -> dict[str, str]:
+        return json_safe_dict(self)
+
+
+def _format_as_discord_canaryalert(
+    details: TokenAlertDetails,
+) -> TokenAlertDetailsDiscord:
+    embeds = DiscordEmbeds(
+        author=DiscordAuthorField(
+            icon_url=CANARY_LOGO_ROUND_PUBLIC_URL,
+        ),
+        url=details.manage_url,
+        timestamp=details.time.strftime("%Y-%m-%dT%H:%M:%S"),
+        color=DecimalColor.ERROR.value,
+    )
+
+    embeds.add_fields(
+        {
+            "canarytoken": details.token,
+            "token_reminder": details.memo,
+            "src_data": details.src_data if details.src_data else None,
+        }
+    )
+
+    if details.additional_data:
+        embeds.add_fields(details.additional_data)
+
+    embeds.add_fields({"Manage token": details.manage_url})
+
+    return TokenAlertDetailsDiscord(embeds=[embeds])
+
+
+def _format_as_discord_token_exposed(
+    details: TokenExposedDetails,
+) -> TokenAlertDetailsDiscord:
+    embeds = DiscordEmbeds(
+        author=DiscordAuthorField(
+            icon_url=CANARY_LOGO_ROUND_PUBLIC_URL,
+        ),
+        url=details.manage_url,
+        timestamp=details.exposed_time.strftime("%Y-%m-%dT%H:%M:%S"),
+        description=_get_exposed_token_description(details.token_type),
+        color=DecimalColor.WARNING.value,
+    )
+
+    embeds.add_fields(
+        {
+            "Key ID": details.key_id,
+            "Token Reminder": details.memo,
+            "Key exposed here": details.public_location,
+            "Manage token": details.manage_url,
+        }
+    )
+
+    return TokenAlertDetailsDiscord(embeds=[embeds])
+
+
+class DiscordFieldEntry(BaseModel):
+    name: str = ""
+    value: str = ""
+    inline: bool = False
+
+
+class DiscordAuthorField(BaseModel):
+    name: str = "Canary Alerts"
+    icon_url: str
+
+
+class DiscordEmbeds(BaseModel):
+    author: DiscordAuthorField
+    color: int = DecimalColor.CANARY_GREEN.value
+    title: str = "Canarytoken Triggered"
+    description: Optional[str] = None
+    url: Optional[HttpUrl]
+    timestamp: datetime
+    fields: List[DiscordFieldEntry] = []
+
+    def add_fields(self, fields_info: Dict[str, str]) -> None:
+        for label, text in fields_info.items():
+            if not label or not text:
+                continue
+
+            message_text = (
+                f"```{json.dumps(text)}```"
+                if isinstance(text, dict)
+                else "{}".format(text)
+            )
+            self.fields.append(
+                DiscordFieldEntry(
+                    name=prettify_snake_case(label),
+                    value=message_text,
+                    inline=len(max(message_text.split("\n"))) < MAX_INLINE_LENGTH,
+                )
+            )
+
+    @validator("timestamp", pre=True)
+    def validate_timestamp(cls, value):
+        if isinstance(value, str):
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%S")
+        return value
+
+    class Config:
+        json_encoders = {
+            datetime: lambda v: v.strftime("%Y-%m-%dT%H:%M:%S"),
+        }
+
+
+class TokenAlertDetailsDiscord(BaseModel):
+    """Details that are sent to Discord webhooks"""
+
+    embeds: List[DiscordEmbeds]
+
+    def json_safe_dict(self) -> Dict[str, str]:
         return json_safe_dict(self)
 
 

--- a/tests/units/test_webhook_formatting.py
+++ b/tests/units/test_webhook_formatting.py
@@ -9,6 +9,7 @@ from canarytokens.webhook_formatting import (
     get_webhook_type,
     TokenAlertDetailGeneric,
     TokenAlertDetailsGoogleChat,
+    TokenAlertDetailsDiscord,
     TokenExposedDetailGeneric,
 )
 
@@ -48,6 +49,8 @@ def test_get_webhook_type(url: str, expected_type: WebhookType):
         ("exposed", WebhookType.SLACK, TokenAlertDetailsSlack),
         ("alert", WebhookType.GOOGLE_CHAT, TokenAlertDetailsGoogleChat),
         ("exposed", WebhookType.GOOGLE_CHAT, TokenAlertDetailsGoogleChat),
+        ("alert", WebhookType.DISCORD, TokenAlertDetailsDiscord),
+        ("exposed", WebhookType.DISCORD, TokenAlertDetailsDiscord),
     ],
 )
 def test_format_details_for_webhook_alert_type(


### PR DESCRIPTION
## Proposed changes

Add Discord webhook support for exposed API key alerts. While we're in the area also do some refactoring and general improvements for the Discord webhook.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

I tested the changes to the Discord webhook by creating a new AWS API key token, triggering it normally and manually creating an exposed key alert with CURL (with 25 Dec as the exposed time) and checked that all three Discord messages displayed correctly.

![CleanShot 2024-11-13 at 13 08 17@2x](https://github.com/user-attachments/assets/11128e4f-a464-4e02-acd7-7fb40da5b70c)

An example of the current (before this change) Discord message format is shown below.

![CleanShot 2024-11-07 at 15 54 34@2x](https://github.com/user-attachments/assets/53e07c7a-14d7-4299-ac27-bb866fbe7a6b)
