### PR TITLE
Add MS Teams webhook exposed key handling

### DIFF
--- a/canarytokens/channel.py
+++ b/canarytokens/channel.py
@@ -19,37 +19,11 @@ from canarytokens.models import (
     AnyTokenHit,
     AnyTokenExposedHit,
     Memo,
-    MsTeamsTitleSection,
-    MsTeamsDetailsSection,
-    MsTeamsPotentialAction,
     TokenAlertDetails,
-    TokenAlertDetailsMsTeams,
 )
 
 log = Logger()
 
-
-
-def format_as_ms_teams_canaryalert(
-    details: TokenAlertDetails,
-) -> TokenAlertDetailsMsTeams:
-    sections = [
-        MsTeamsTitleSection(activityTitle="<b>Canarytoken triggered</b>"),
-        MsTeamsDetailsSection(
-            canarytoken=details.token,
-            token_reminder=details.memo,
-            src_data=details.src_data if details.src_data else None,
-            additional_data=details.additional_data,
-        ),
-    ]
-
-    return TokenAlertDetailsMsTeams(
-        summary="Canarytoken triggered",
-        sections=sections,
-        potentialAction=[
-            MsTeamsPotentialAction(name="Manage", target=[details.manage_url])
-        ],
-    )
 
 
 class Channel(object):

--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -46,7 +46,6 @@ from typing_extensions import Annotated
 from canarytokens.constants import (
     CANARYTOKEN_ALPHABET,
     CANARYTOKEN_LENGTH,
-    CANARY_IMAGE_URL,
     MEMO_MAX_CHARACTERS,
 )
 from canarytokens.utils import (
@@ -2138,71 +2137,6 @@ class TokenExposedDetails(BaseModel):
             datetime: lambda v: v.strftime("%Y-%m-%d %H:%M:%S (UTC)"),
         }
 
-
-
-
-class MsTeamsDetailsSection(BaseModel):
-    canarytoken: Canarytoken
-    token_reminder: Memo
-    src_data: Optional[dict[str, Any]] = None
-    additional_data: Optional[dict[str, Any]] = None
-
-    def dict(self, *args, **kwargs):
-        data = json_safe_dict(self)
-        data["Canarytoken"] = data.pop("canarytoken", "")
-        data["Token Reminder"] = data.pop("token_reminder", "")
-        if "src_data" in data:
-            data["Source Data"] = data.pop("src_data", "")
-
-        if data["additional_data"]:
-            add_data = data.pop("additional_data", {})
-            data.update(add_data)
-
-        facts = []
-        for k, v in data.items():
-            if not v:
-                continue
-
-            if isinstance(v, dict):
-                v = dict_to_csv(v)
-            else:
-                v = str(v)
-
-            facts.append({"name": prettify_snake_case(k), "value": v})
-
-        return {"facts": facts}
-
-
-class MsTeamsTitleSection(BaseModel):
-    activityTitle: str
-    activityImage = CANARY_IMAGE_URL
-
-
-class MsTeamsPotentialAction(BaseModel):
-    name: str
-    target: List[AnyHttpUrl]
-    type: str = "ViewAction"
-    context: str = "http://schema.org"
-
-    def dict(self, *args, **kwargs):
-        d = super().dict(*args, **kwargs)
-
-        d["@type"] = d.pop("type")
-        d["@context"] = d.pop("context")
-
-        return d
-
-
-class TokenAlertDetailsMsTeams(BaseModel):
-    """Details that are sent to MS Teams webhooks."""
-
-    summary: str
-    themeColor = "ff0000"
-    sections: Optional[List[Union[MsTeamsTitleSection, MsTeamsDetailsSection]]] = None
-    potentialAction: Optional[List[MsTeamsPotentialAction]] = None
-
-    def json_safe_dict(self) -> Dict[str, str]:
-        return json_safe_dict(self)
 
 
 class UserName(ConstrainedStr):

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -42,7 +42,6 @@ from canarytokens.redismanager import (  # KEY_BITCOIN_ACCOUNT,; KEY_BITCOIN_ACC
     KEY_WIREGUARD_KEYMAP,
 )
 from canarytokens.webhook_formatting import (
-    WebhookType,
     generate_webhook_test_payload,
     get_webhook_type,
 )

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -7,7 +7,7 @@ import json
 import re
 import secrets
 from ipaddress import IPv4Address
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 import advocate
 import requests
@@ -877,15 +877,7 @@ def validate_webhook(url, token_type: models.TokenTypes):
         raise WebhookTooLongError()
 
     webhook_type = get_webhook_type(url)
-    if webhook_type == WebhookType.MS_TEAMS:
-        section = models.MsTeamsTitleSection(
-            activityTitle="<b>Validating new Canarytokens webhook</b>"
-        )
-        payload = models.TokenAlertDetailsMsTeams(
-            summary="Validating new Canarytokens webhook", sections=[section]
-        )
-    else:
-        payload = generate_webhook_test_payload(webhook_type, token_type)
+    payload = generate_webhook_test_payload(webhook_type, token_type)
 
     response = advocate.post(
         url,

--- a/canarytokens/utils.py
+++ b/canarytokens/utils.py
@@ -2,7 +2,6 @@ import json
 import subprocess
 from pathlib import Path
 from typing import Any, Literal, Union
-import json
 
 import pycountry_convert
 from pydantic import BaseModel

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -9,8 +9,6 @@ from datetime import datetime
 from pydantic import BaseModel, HttpUrl, parse_obj_as, validator
 
 from canarytokens import constants
-from canarytokens.utils import json_safe_dict, prettify_snake_case
-
 from canarytokens.utils import json_safe_dict, prettify_snake_case, dict_to_csv
 from canarytokens.models import (
     readable_token_type_names,
@@ -19,8 +17,6 @@ from canarytokens.models import (
     TokenAlertDetails,
     TokenExposedDetails,
 )
-from canarytokens.utils import json_safe_dict, prettify_snake_case
-
 
 CANARY_LOGO_ROUND_PUBLIC_URL = parse_obj_as(
     HttpUrl,
@@ -849,7 +845,7 @@ class MsTeamsTitleSection(BaseModel):
 
 class MsTeamsPotentialAction(BaseModel):
     name: str
-    target: List[HttpUrl]
+    target: list[HttpUrl]
     type: str = "ViewAction"
     context: str = "http://schema.org"
 
@@ -867,11 +863,11 @@ class TokenAlertDetailsMsTeams(BaseModel):
 
     summary: str
     themeColor: str = HexColor.CANARY_GREEN.value
-    sections: Optional[List[Union[MsTeamsTitleSection, MsTeamsDetailsSection]]] = None
-    potentialAction: Optional[List[MsTeamsPotentialAction]] = None
+    sections: Optional[list[Union[MsTeamsTitleSection, MsTeamsDetailsSection]]] = None
+    potentialAction: Optional[list[MsTeamsPotentialAction]] = None
     text: Optional[str] = None
 
-    def json_safe_dict(self) -> Dict[str, str]:
+    def json_safe_dict(self) -> dict[str, str]:
         return json_safe_dict(self)
 
 

--- a/canarytokens/webhook_formatting.py
+++ b/canarytokens/webhook_formatting.py
@@ -10,9 +10,8 @@ from pydantic import BaseModel, HttpUrl, parse_obj_as, validator
 
 from canarytokens import constants
 from canarytokens.utils import json_safe_dict, prettify_snake_case
-from canarytokens.channel import (
-    format_as_ms_teams_canaryalert,
-)
+
+from canarytokens.utils import json_safe_dict, prettify_snake_case, dict_to_csv
 from canarytokens.models import (
     readable_token_type_names,
     Memo,
@@ -111,7 +110,7 @@ def _format_alert_details_for_webhook(
     elif webhook_type == WebhookType.DISCORD:
         return _format_as_discord_canaryalert(details)
     elif webhook_type == WebhookType.MS_TEAMS:
-        return format_as_ms_teams_canaryalert(details)
+        return _format_as_ms_teams_canaryalert(details)
     elif webhook_type == WebhookType.GENERIC:
         return TokenAlertDetailGeneric(**details.dict())
     else:
@@ -130,9 +129,7 @@ def _format_exposed_details_for_webhook(
     elif webhook_type == WebhookType.DISCORD:
         return _format_as_discord_token_exposed(details)
     elif webhook_type == WebhookType.MS_TEAMS:
-        raise NotImplementedError(
-            f"_format_exposed_details_for_webhook not implemented for webhook type: {webhook_type}"
-        )
+        return _format_as_ms_teams_token_exposed(details)
     elif webhook_type == WebhookType.GENERIC:
         return TokenExposedDetailGeneric(**details.dict())
     else:
@@ -176,8 +173,11 @@ def generate_webhook_test_payload(webhook_type: WebhookType, token_type: TokenTy
         )
         return TokenAlertDetailsDiscord(embeds=[embeds])
     elif webhook_type == WebhookType.MS_TEAMS:
-        raise NotImplementedError(
-            "generate_webhook_test_payload not implemented for MS_TEAMS"
+        section = MsTeamsTitleSection(
+            activityTitle="<b>Validating new Canarytokens webhook</b>"
+        )
+        return TokenAlertDetailsMsTeams(
+            summary="Validating new Canarytokens webhook", sections=[section]
         )
     elif webhook_type == WebhookType.GENERIC:
         return TokenAlertDetails(
@@ -758,6 +758,120 @@ class TokenAlertDetailsDiscord(BaseModel):
     embeds: list[DiscordEmbeds]
 
     def json_safe_dict(self) -> dict[str, str]:
+        return json_safe_dict(self)
+
+
+def _format_as_ms_teams_canaryalert(
+    details: TokenAlertDetails,
+) -> TokenAlertDetailsMsTeams:
+    facts = [
+        MsTeamsFact(name="Canarytoken", value=details.token),
+        MsTeamsFact(name="Token Reminder", value=details.memo),
+    ]
+
+    if details.src_data:
+        facts.extend(_data_to_ms_teams_facts(details.src_data))
+    if details.additional_data:
+        facts.extend(_data_to_ms_teams_facts(details.additional_data))
+
+    sections = [
+        MsTeamsTitleSection(activityTitle="<b>Canarytoken Triggered</b>"),
+        MsTeamsDetailsSection(facts=facts),
+    ]
+
+    return TokenAlertDetailsMsTeams(
+        summary="Canarytoken Triggered",
+        themeColor=HexColor.ERROR.value_without_hash,
+        sections=sections,
+        potentialAction=[
+            MsTeamsPotentialAction(name="Manage token", target=[details.manage_url])
+        ],
+    )
+
+
+def _format_as_ms_teams_token_exposed(
+    details: TokenExposedDetails,
+) -> TokenAlertDetailsMsTeams:
+    facts = [
+        MsTeamsFact(name="Key ID", value=details.key_id),
+        MsTeamsFact(name="Token Reminder", value=details.memo),
+        MsTeamsFact(
+            name="Key exposed at",
+            value=details.exposed_time.strftime("%Y-%m-%d %H:%M:%S (UTC)"),
+        ),
+        MsTeamsFact(name="Key exposed here", value=details.public_location),
+    ]
+
+    sections = [
+        MsTeamsTitleSection(activityTitle="<b>Canarytoken Exposed</b>"),
+        MsTeamsDetailsSection(
+            facts=facts, text=_get_exposed_token_description(details.token_type)
+        ),
+    ]
+
+    return TokenAlertDetailsMsTeams(
+        summary="Canarytoken Exposed",
+        themeColor=HexColor.WARNING.value_without_hash,
+        sections=sections,
+        potentialAction=[
+            MsTeamsPotentialAction(name="Manage token", target=[details.manage_url])
+        ],
+    )
+
+
+def _data_to_ms_teams_facts(data: dict[str, Union[str, dict]]) -> list[MsTeamsFact]:
+    facts: list[MsTeamsFact] = []
+
+    for label, value in data.items():
+        if not label or not value:
+            continue
+
+        message_text = dict_to_csv(value) if isinstance(value, dict) else value
+        facts.append(MsTeamsFact(name=prettify_snake_case(label), value=message_text))
+
+    return facts
+
+
+class MsTeamsFact(BaseModel):
+    name: str
+    value: str
+
+
+class MsTeamsDetailsSection(BaseModel):
+    facts: list[MsTeamsFact]
+    text: Optional[str] = None
+
+
+class MsTeamsTitleSection(BaseModel):
+    activityTitle: str
+    activityImage = CANARY_LOGO_ROUND_PUBLIC_URL
+
+
+class MsTeamsPotentialAction(BaseModel):
+    name: str
+    target: List[HttpUrl]
+    type: str = "ViewAction"
+    context: str = "http://schema.org"
+
+    def dict(self, *args, **kwargs):
+        d = super().dict(*args, **kwargs)
+
+        d["@type"] = d.pop("type")
+        d["@context"] = d.pop("context")
+
+        return d
+
+
+class TokenAlertDetailsMsTeams(BaseModel):
+    """Details that are sent to MS Teams webhooks."""
+
+    summary: str
+    themeColor: str = HexColor.CANARY_GREEN.value
+    sections: Optional[List[Union[MsTeamsTitleSection, MsTeamsDetailsSection]]] = None
+    potentialAction: Optional[List[MsTeamsPotentialAction]] = None
+    text: Optional[str] = None
+
+    def json_safe_dict(self) -> Dict[str, str]:
         return json_safe_dict(self)
 
 

--- a/tests/units/test_channel_output_webhook.py
+++ b/tests/units/test_channel_output_webhook.py
@@ -4,13 +4,9 @@ import pytest
 from twisted.logger import capturedLogs
 
 from canarytokens.canarydrop import Canarydrop
-from canarytokens.channel import (
-    format_as_ms_teams_canaryalert,
-)
 from canarytokens.channel_dns import ChannelDNS
 from canarytokens.channel_output_webhook import WebhookOutputChannel
 from canarytokens.models import (
-    TokenAlertDetailsMsTeams,
     TokenTypes,
 )
 from canarytokens.settings import FrontendSettings, SwitchboardSettings
@@ -22,6 +18,7 @@ from canarytokens.webhook_formatting import (
     format_details_for_webhook,
     get_webhook_type,
     TokenAlertDetailsGoogleChat,
+    TokenAlertDetailsMsTeams,
 )
 
 
@@ -277,23 +274,23 @@ def test_ms_teams_webhook_format(
         protocol=input_channel.switchboard_scheme,
         host=settings.PUBLIC_DOMAIN,
     )
-    webhook_payload = format_as_ms_teams_canaryalert(details=details)
+    webhook_payload = format_details_for_webhook(WebhookType.MS_TEAMS, details)
     payload = webhook_payload.json_safe_dict()
 
-    assert payload["summary"] == "Canarytoken triggered"
-    assert payload["themeColor"] == "ff0000"
+    assert payload["summary"] == "Canarytoken Triggered"
+    assert payload["themeColor"] == "d32f2f"
     assert payload["potentialAction"] == [
         {
             "@context": "http://schema.org",
             "@type": "ViewAction",
-            "name": "Manage",
+            "name": "Manage token",
             "target": [details.manage_url],
         }
     ]
     assert len(payload["sections"]) == 2
 
     assert payload["sections"][0] == {
-        "activityTitle": "<b>Canarytoken triggered</b>",
+        "activityTitle": "<b>Canarytoken Triggered</b>",
         "activityImage": CANARY_IMAGE_URL,
     }
 

--- a/tests/units/test_webhook_formatting.py
+++ b/tests/units/test_webhook_formatting.py
@@ -10,6 +10,7 @@ from canarytokens.webhook_formatting import (
     TokenAlertDetailGeneric,
     TokenAlertDetailsGoogleChat,
     TokenAlertDetailsDiscord,
+    TokenAlertDetailsMsTeams,
     TokenExposedDetailGeneric,
 )
 
@@ -51,6 +52,8 @@ def test_get_webhook_type(url: str, expected_type: WebhookType):
         ("exposed", WebhookType.GOOGLE_CHAT, TokenAlertDetailsGoogleChat),
         ("alert", WebhookType.DISCORD, TokenAlertDetailsDiscord),
         ("exposed", WebhookType.DISCORD, TokenAlertDetailsDiscord),
+        ("alert", WebhookType.MS_TEAMS, TokenAlertDetailsMsTeams),
+        ("exposed", WebhookType.MS_TEAMS, TokenAlertDetailsMsTeams),
     ],
 )
 def test_format_details_for_webhook_alert_type(


### PR DESCRIPTION
## Proposed changes

Add MS Teams webhook support for exposed API key alerts. While we're in the area also do some refactoring and general improvements for the MS Teams webhook.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

I tested the changes to the MS Teams webhook by creating a new AWS API key token, triggering it normally and manually creating an exposed key alert with CURL (with 25 Dec as the exposed time) and checked that all three MS Teams messages displayed correctly.

![CleanShot 2024-11-13 at 13 28 21@2x](https://github.com/user-attachments/assets/f1839c11-fb2e-43e6-bc36-92e36775e073)


An example of the current (before this change) MS Teams message format is shown below.

![CleanShot 2024-11-07 at 15 58 15@2x](https://github.com/user-attachments/assets/e7aa6304-a7a6-4c40-a05c-41faa96a48cb)
