### PR TITLE
Add email exposed key handling

### DIFF
--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -381,53 +381,39 @@ class EmailOutputChannel(OutputChannel):
         return minify_html.minify(rendered_html)
 
     @staticmethod
-    def format_report_text(details: TokenAlertDetails, body_length: int = 999999999):
+    def format_report_text(details: TokenAlertDetails):
         """Returns a string containing an incident report in text,
         suitable for emailing"""
 
-        if body_length <= 140:
-            body = """Canarydrop@{time} via {channel_name}: """.format(
-                channel_name=details.channel, time=details.time
-            )
-            capacity = 140 - len(body)
-            body += details.memo[:capacity]
-        else:
-            additional_data = "\n" + "\n".join(
-                f"{k}: {v}" for k, v in details.additional_data.items()
-            )
-            body = textwrap.dedent(
-                f"""
-                One of your canarydrops was triggered.
-                Channel: {details.channel}
-                Time   : {details.time}
-                Memo   : {details.memo}{additional_data}
-                Manage your settings for this Canarydrop:
-                {details.manage_url}
-                """
-            ).strip()
+        additional_data = "\n" + "\n".join(
+            f"{k}: {v}" for k, v in details.additional_data.items()
+        )
+        body = textwrap.dedent(
+            f"""
+            One of your canarydrops was triggered.
+            Channel: {details.channel}
+            Time   : {details.time}
+            Memo   : {details.memo}{additional_data}
+            Manage your settings for this Canarydrop:
+            {details.manage_url}
+            """
+        ).strip()
         return body
 
     @staticmethod
-    def format_token_exposed_text(
-        details: TokenExposedDetails, body_length: int = 999999999
-    ):
+    def format_token_exposed_text(details: TokenExposedDetails):
         """Returns a string containing an incident report in text,
         suitable for emailing"""
-        if body_length <= 140:
-            body = f"Canarytoken exposed on the internet @ {details.exposed_time}: "
-            capacity = 140 - len(body)
-            body += details.memo[:capacity]
-        else:
-            body = textwrap.dedent(
-                f"""
-                One of your Canarytokens was exposed on the internet.
-                Location: {details.public_location or "unknown"}
-                Time    : {details.exposed_time}
-                Memo    : {details.memo}
-                Manage your settings for this Canarydrop:
-                {details.manage_url}
-                """
-            ).strip()
+        body = textwrap.dedent(
+            f"""
+            One of your Canarytokens was exposed on the internet.
+            Location: {details.public_location or "unknown"}
+            Time    : {details.exposed_time}
+            Memo    : {details.memo}
+            Manage your settings for this Canarydrop:
+            {details.manage_url}
+            """
+        ).strip()
         return body
 
     @staticmethod

--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -27,8 +27,11 @@ from canarytokens.constants import OUTPUT_CHANNEL_EMAIL, MAILGUN_IGNORE_ERRORS
 from canarytokens.models import (
     AnyTokenHit,
     AnyTokenExposedHit,
+    Memo,
+    TokenExposedHit,
     readable_token_type_names,
     TokenAlertDetails,
+    TokenExposedDetails,
     token_types_with_article_an,
     TokenTypes,
 )
@@ -71,7 +74,7 @@ class EmailResponse(object):
         status: EmailResponseStatuses,
         canarydrop: Canarydrop,
         message_id: str,
-        alert_details: TokenAlertDetails,
+        alert_details: Union[TokenAlertDetails, TokenExposedDetails],
         max_alert_failures: int,
     ):
         self.status = status
@@ -92,9 +95,14 @@ class EmailResponse(object):
         self.canarydrop.disable_alert_email()
 
     def handle_sent(self):
+        time = (
+            self.alert_details.time
+            if isinstance(self.alert_details, TokenAlertDetails)
+            else self.alert_details.exposed_time
+        )
         queries.remove_mail_from_to_send_status(
             token=self.alert_details.token,
-            time=self.alert_details.time,
+            time=time,
         )
         queries.put_mail_on_sent_queue(
             mail_key=self.message_id,
@@ -284,6 +292,29 @@ class EmailOutputChannel(OutputChannel):
         )
 
     @staticmethod
+    def format_token_exposed_html(
+        details: TokenExposedDetails,
+        template_path: Path,
+    ):
+        """Returns a string containing an incident report in HTML,
+        suitable for emailing"""
+        readable_type = readable_token_type_names[details.token_type]
+        BasicDetails = details.dict()
+        BasicDetails["readable_type"] = readable_type
+        BasicDetails["token_type"] = details.token_type.value
+        BasicDetails["memo"] = details.memo
+        BasicDetails["key_id"] = details.key_id
+        BasicDetails["time_ymd"] = details.time_ymd
+        BasicDetails["time_hm"] = details.time_hm
+
+        rendered_html = Template(template_path.read_text()).render(
+            BasicDetails=BasicDetails,
+            ManageLink=details.manage_url,
+            HistoryLink=details.history_url,
+        )
+        return minify_html.minify(rendered_html)
+
+    @staticmethod
     def format_report_html(
         details: TokenAlertDetails,
         template_path: Path,
@@ -377,6 +408,38 @@ class EmailOutputChannel(OutputChannel):
         return body
 
     @staticmethod
+    def format_token_exposed_text(
+        details: TokenExposedDetails, body_length: int = 999999999
+    ):
+        """Returns a string containing an incident report in text,
+        suitable for emailing"""
+        if body_length <= 140:
+            body = f"Canarytoken exposed on the internet @ {details.exposed_time}: "
+            capacity = 140 - len(body)
+            body += details.memo[:capacity]
+        else:
+            body = textwrap.dedent(
+                f"""
+                One of your Canarytokens was exposed on the internet.
+                Location: {details.public_location or "unknown"}
+                Time    : {details.exposed_time}
+                Memo    : {details.memo}
+                Manage your settings for this Canarydrop:
+                {details.manage_url}
+                """
+            ).strip()
+        return body
+
+    @staticmethod
+    def format_token_exposed_intro(details: TokenExposedDetails):
+        article = "An" if details.token_type in token_types_with_article_an else "A"
+        readable_type = readable_token_type_names[details.token_type]
+        intro = (
+            f"{article} {readable_type} Canarytoken has been exposed on the internet."
+        )
+        return intro
+
+    @staticmethod
     def format_report_intro(details: TokenAlertDetails):
         details.channel
         details.token_type
@@ -421,28 +484,56 @@ class EmailOutputChannel(OutputChannel):
         canarydrop: Canarydrop,
         token_hit: Union[AnyTokenHit, AnyTokenExposedHit],
     ):
-        alert_details = input_channel.gather_alert_details(
-            canarydrop=canarydrop,
-            host=self.switchboard_settings.PUBLIC_DOMAIN,
-            protocol=self.switchboard_scheme,
-        )
-        #
+        if isinstance(token_hit, TokenExposedHit):
+            details = TokenExposedDetails(
+                token_type=token_hit.token_type,
+                token=canarydrop.canarytoken.value(),
+                key_id=canarydrop.aws_access_key_id,
+                memo=Memo(canarydrop.memo),
+                public_location=token_hit.public_location,
+                exposed_time=token_hit.time_of_hit,
+                manage_url=canarydrop.build_manage_url(
+                    self.switchboard_scheme, self.hostname
+                ),
+                public_domain=self.hostname,
+            )
+        else:
+            details = input_channel.gather_alert_details(
+                canarydrop=canarydrop,
+                host=self.switchboard_settings.PUBLIC_DOMAIN,
+                protocol=self.switchboard_scheme,
+            )
+
         queries.add_mail_to_send_status(
             recipient=canarydrop.alert_email_recipient,
-            details=alert_details,
+            details=details,
         )
-        email_content_html = EmailOutputChannel.format_report_html(
-            alert_details,
-            Path(
-                f"{self.switchboard_settings.TEMPLATES_PATH}/emails/notification.html"
-            ),
-        )
+
+        if isinstance(details, TokenExposedDetails):
+            email_content_html = EmailOutputChannel.format_token_exposed_html(
+                details,
+                Path(
+                    f"{self.switchboard_settings.TEMPLATES_PATH}/emails/notification_token_exposed.html"
+                ),
+            )
+            email_content_text = EmailOutputChannel.format_token_exposed_text(details)
+            email_subject = "Canarytoken Exposed"
+        else:
+            email_content_html = EmailOutputChannel.format_report_html(
+                details,
+                Path(
+                    f"{self.switchboard_settings.TEMPLATES_PATH}/emails/notification.html"
+                ),
+            )
+            email_content_text = EmailOutputChannel.format_report_text(details)
+            email_subject = self.email_subject
+
         if self.switchboard_settings.MAILGUN_API_KEY:
             email_response_status, message_id = mailgun_send(
                 email_address=canarydrop.alert_email_recipient,
-                email_subject=self.email_subject,
+                email_subject=email_subject,
                 email_content_html=email_content_html,
-                email_content_text=EmailOutputChannel.format_report_text(alert_details),
+                email_content_text=email_content_text,
                 from_email=EmailStr(self.from_email),
                 from_display=self.from_display,
                 api_key=self.switchboard_settings.MAILGUN_API_KEY,
@@ -455,7 +546,7 @@ class EmailOutputChannel(OutputChannel):
                 email_address=canarydrop.alert_email_recipient,
                 email_content_html=email_content_html,
                 from_email=EmailStr(self.from_email),
-                email_subject=self.email_subject,
+                email_subject=email_subject,
                 from_display=self.from_display,
                 sandbox_mode=False,
             )
@@ -463,8 +554,8 @@ class EmailOutputChannel(OutputChannel):
             email_response_status, message_id = smtp_send(
                 email_address=canarydrop.alert_email_recipient,
                 email_content_html=email_content_html,
-                email_content_text=EmailOutputChannel.format_report_text(alert_details),
-                email_subject=self.email_subject,
+                email_content_text=email_content_text,
+                email_subject=email_subject,
                 from_email=EmailStr(self.from_email),
                 from_display=self.from_display,
                 smtp_password=self.switchboard_settings.SMTP_PASSWORD,
@@ -480,11 +571,11 @@ class EmailOutputChannel(OutputChannel):
                 status=email_response_status,
                 canarydrop=canarydrop,
                 message_id=message_id,
-                alert_details=alert_details,
+                alert_details=details,
                 max_alert_failures=self.switchboard_settings.MAX_ALERT_FAILURES,
             )
         )
-        return alert_details
+        return details
 
     def handle_email_response(self, email_response: EmailResponse):
         return email_response.handle()
@@ -503,72 +594,3 @@ class EmailOutputChannel(OutputChannel):
             bool: returns True if mail was processed. False otherwise.
         """
         return
-        # sg = sendgrid.SendGridAPIClient(api_key=api_key)
-        # mail_key, alert_details = queries.pop_mail_off_sent_queue()
-        # # Check using: resp = sg.client.messages._(mail_key).get()
-        # if False:
-        #     # delivery was not made.
-        #     queries.put_mail_on_sent_queue(mail_key=mail_key, details=alert_details)
-        # return mail_key is not None
-
-    # def get_basic_details(self,):
-
-    #     vars = { 'Description' : self.data['description'],
-    #              'Channel'     : self.data['channel'],
-    #              'Time'        : self.data['time'],
-    #              'Canarytoken' : self.data['canarytoken']
-    #             }
-
-    #     if 'src_ip' in self.data:
-    #         vars['src_ip'] = self.data['src_ip']
-    #         vars['SourceIP'] = self.data['src_ip']
-
-    #     if 'useragent' in self.data:
-    #         vars['User-Agent'] = self.data['useragent']
-
-    #     if 'tokentype' in self.data:
-    #         vars['TokenType'] = self.data['tokentype']
-
-    #     if 'referer' in self.data:
-    #         vars['Referer'] = self.data['referer']
-
-    #     if 'location' in self.data:
-    #         try:
-    #             vars['Location'] = self.data['location'].decode('utf-8')
-    #         except Exception:
-    #             vars['Location'] = self.data['location']
-
-    #     if 'log4_shell_computer_name' in self.data:
-    #         vars['Log4JComputerName'] = self.data['log4_shell_computer_name']
-
-    #     return vars
-
-    # def mandrill_send(self, msg=None, canarydrop=None):
-    #     try:
-    #         mandrill_client = mandrill.Mandrill(settings.MANDRILL_API_KEY)
-    #         message = {
-    #          'auto_html': None,
-    #          'auto_text': None,
-    #          'from_email': msg['from_address'],
-    #          'from_name': msg['from_display'],
-    #          'text': msg['body'],
-    #          'html':self.format_report_html(),
-    #          'subject': msg['subject'],
-    #          'to': [{'email': canarydrop['alert_email_recipient'],
-    #                  'name': '',
-    #                  'type': 'to'}],
-    #         }
-    #         if settings.DEBUG:
-    #             pprint.pprint(message)
-    #         else:
-    #             result = mandrill_client.messages.send(message=message,
-    #                                                async=False,
-    #                                                ip_pool='Main Pool')
-    #         log.info('Sent alert to {recipient} for token {token}'\
-    #                     .format(recipient=canarydrop['alert_email_recipient'],
-    #                             token=canarydrop.canarytoken.value()))
-
-    #     except mandrill.Error, e:
-    #         # Mandrill errors are thrown as exceptions
-    #         log.error('A mandrill error occurred: %s - %s' % (e.__class__, e))
-    #         # A mandrill error occurred: <class 'mandrill.UnknownSubaccountError'> - No subaccount exists with the id 'customer-123'....

--- a/templates/emails/notification_token_exposed.html
+++ b/templates/emails/notification_token_exposed.html
@@ -1,0 +1,618 @@
+<!doctype html>
+<html lang="und" dir="auto" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+
+<head>
+  <title>Canarytoken exposed!</title>
+  <!--[if !mso]><!-->
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <!--<![endif]-->
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style type="text/css">
+    #outlook a {
+      padding: 0;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+      -webkit-text-size-adjust: 100%;
+      -ms-text-size-adjust: 100%;
+    }
+
+    table,
+    td {
+      border-collapse: collapse;
+      mso-table-lspace: 0pt;
+      mso-table-rspace: 0pt;
+    }
+
+    img {
+      border: 0;
+      height: auto;
+      line-height: 100%;
+      outline: none;
+      text-decoration: none;
+      -ms-interpolation-mode: bicubic;
+    }
+
+    p {
+      display: block;
+      margin: 13px 0;
+    }
+
+  </style>
+  <!--[if mso]>
+    <noscript>
+    <xml>
+    <o:OfficeDocumentSettings>
+      <o:AllowPNG/>
+      <o:PixelsPerInch>96</o:PixelsPerInch>
+    </o:OfficeDocumentSettings>
+    </xml>
+    </noscript>
+    <![endif]-->
+  <!--[if lte mso 11]>
+    <style type="text/css">
+      .mj-outlook-group-fix { width:100% !important; }
+    </style>
+    <![endif]-->
+  <style type="text/css">
+    @media only screen and (min-width:480px) {
+      .mj-column-per-100 {
+        width: 100% !important;
+        max-width: 100%;
+      }
+
+      .mj-column-per-40 {
+        width: 40% !important;
+        max-width: 40%;
+      }
+    }
+
+  </style>
+  <style media="screen and (min-width:480px)">
+    .moz-text-html .mj-column-per-100 {
+      width: 100% !important;
+      max-width: 100%;
+    }
+
+    .moz-text-html .mj-column-per-40 {
+      width: 40% !important;
+      max-width: 40%;
+    }
+
+  </style>
+  <style type="text/css">
+    @media only screen and (max-width:479px) {
+      table.mj-full-width-mobile {
+        width: 100% !important;
+      }
+
+      td.mj-full-width-mobile {
+        width: auto !important;
+      }
+    }
+
+  </style>
+</head>
+
+<body style="word-spacing:normal;background-color:#F6F7FA;">
+  <div style="background-color:#F6F7FA;" lang="und" dir="auto">
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:10px 0 20px 0;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
+              <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tbody>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+    <!-- Red bar top -->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#ec4f41" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#ec4f41;background-color:#ec4f41;margin:0px auto;border-radius:30px 30px 0 0;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#ec4f41;background-color:#ec4f41;width:100%;border-radius:30px 30px 0 0;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:10px 0 0px 0px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><![endif]-->
+              <!-- Logo -->
+              <!--[if mso | IE]><td class="" style="vertical-align:top;width:240px;" ><![endif]-->
+              <div class="mj-column-per-40 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                  <tbody>
+                    <tr>
+                      <td align="center" style="font-size:0px;padding:0px;word-break:break-word;">
+                        <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                          <tbody>
+                            <tr>
+                              <td style="width:240px;">
+                                <img alt="Canarytokens" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/token_logo.png" style="border:none;display:block;outline:none;text-decoration:none;height:70px;width:100%;font-size:13px;" width="240" height="70">
+                              </td>
+                            </tr>
+                          </tbody>
+                        </table>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:30px 30px 20px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><![endif]-->
+              <!-- Alert icon --><!-- Alert Top details -->
+              <!--[if mso | IE]><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" bgcolor="#F6F7FA" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="background:#F6F7FA;background-color:#F6F7FA;margin:0px auto;border-radius:16px 16px;max-width:540px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F7FA;background-color:#F6F7FA;width:100%;border-radius:16px 16px;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0px 0px;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="background-color:#f6f8fb;border-radius:0 0 16px 16px;vertical-align:top;padding-bottom:30px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" style="font-size:0px;padding:0px;word-break:break-word;">
+                                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:collapse;border-spacing:0px;">
+                                            <tbody>
+                                              <tr>
+                                                <td style="width:70px;">
+                                                  <img alt="Canarytokens" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/canarytoken-icons/{{BasicDetails['token_type']}}.png" style="border:none;display:block;outline:none;text-decoration:none;height:70px;width:100%;font-size:13px;" width="70" height="70">
+                                                </td>
+                                              </tr>
+                                            </tbody>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                          <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:24px;font-weight:bold;line-height:24px;text-align:center;color:#060606;">Your Canarytoken was exposed publicly</div>
+                                        </td>
+                                      </tr>
+                                      <tr>
+                                        <td align="center" style="font-size:0px;padding:0px 20px;word-break:break-word;">
+                                          <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:center;color:#818a8e;">One of your <span style="color:#060606;font-weight:600">{{BasicDetails['readable_type']}}</span> Canarytokens has been found on the {% if BasicDetails['public_location'] %} <a href="{{ BasicDetails['public_location'] }}" style="text-decoration:none;color:#33c480" target="_blank">internet</a>. {% else %} internet. {% endif %} A publicly exposed token will provide very low quality alerts. We recommend that you disable and replace this token on private infrastructure.</div>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+    <!-- Reminder -->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" bgcolor="#f6f8fb" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="background:#f6f8fb;background-color:#f6f8fb;margin:0px auto;border-radius:16px 16px;max-width:540px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#f6f8fb;background-color:#f6f8fb;width:100%;border-radius:16px 16px;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="vertical-align:top;padding:0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                                    <tbody>
+                                      <tr>
+                                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                          <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+                                              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                                                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/reminder.png" width="40px">
+                                              </td>
+                                              <td>
+                                                <p style="font-weight:600;display:block;line-height:1;margin:0;">Reminder</p>
+                                                <p style="font-weight:400;color:#060606;margin:0;">{{BasicDetails['memo'] | e}}</p>
+                                              </td>
+                                            </tr>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+    <!-- Key exposed location -->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" bgcolor="#f6f8fb" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="background:#f6f8fb;background-color:#f6f8fb;margin:0px auto;border-radius:16px 16px;max-width:540px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#f6f8fb;background-color:#f6f8fb;width:100%;border-radius:16px 16px;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="vertical-align:top;padding:0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                                    <tbody>
+                                      <tr>
+                                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                          <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+                                              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                                                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px">
+                                              </td>
+                                              <td>
+                                                <p style="font-weight:600;display:block;line-height:1;margin:0;">Key found here</p>
+                                                <p style="font-weight:400;color:#060606;margin:0;">
+                                                  <a href="{{ BasicDetails['public_location'] }}" style="text-decoration:none;color:#33c480" target="_blank">{{ BasicDetails['public_location'] }}</a>
+                                                </p>
+                                              </td>
+                                            </tr>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+    <!-- Key ID -->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" bgcolor="#f6f8fb" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="background:#f6f8fb;background-color:#f6f8fb;margin:0px auto;border-radius:16px 16px;max-width:540px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#f6f8fb;background-color:#f6f8fb;width:100%;border-radius:16px 16px;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="vertical-align:top;padding:0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                                    <tbody>
+                                      <tr>
+                                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                          <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+                                              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                                                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px">
+                                              </td>
+                                              <td>
+                                                <p style="font-weight:600;display:block;line-height:1;margin:0;">Key ID</p>
+                                                <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['key_id'] | e}}</p>
+                                              </td>
+                                            </tr>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+    <!-- Day & Time -->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" bgcolor="#f6f8fb" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="background:#f6f8fb;background-color:#f6f8fb;margin:0px auto;border-radius:16px 16px;max-width:540px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#f6f8fb;background-color:#f6f8fb;width:100%;border-radius:16px 16px;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="vertical-align:top;padding:0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                                    <tbody>
+                                      <tr>
+                                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                          <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+                                              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                                                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/daytime.png" width="40px">
+                                              </td>
+                                              <td style="vertical-align: top;">
+                                                <p style="font-weight:600;display:block;line-height:1;margin:0;">Date</p>
+                                                <p style="font-weight:400;color:#060606;margin:0;">{{BasicDetails['time_ymd']}}</p>
+                                              </td>
+                                              <td style="vertical-align: top;">
+                                                <p style="font-weight:600;display:block;line-height:1;margin:0;">Time</p>
+                                                <p style="font-weight:400;color:#060606;margin:0;">{{BasicDetails['time_hm']}} UTC</p>
+                                              </td>
+                                            </tr>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+    <!-- CTA -->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 0px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:540px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:0px 0 20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 20px;word-break:break-word;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="border-collapse:separate;width:100%;line-height:100%;">
+                                    <tbody>
+                                      <tr>
+                                        <td align="center" bgcolor="#33c480" role="presentation" style="border:none;border-radius:24px;cursor:auto;mso-padding-alt:10px 25px;background:#33c480;" valign="middle">
+                                          <a href="{{ ManageLink }}" style="display:inline-block;background:#33c480;color:#FFFFFF;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:bold;line-height:160%;margin:0;text-decoration:none;text-transform:none;padding:10px 25px;mso-padding-alt:0px;border-radius:24px;" target="_blank"> Manage Alert </a>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+    <!-- More info -->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 0px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:540px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:0px 0 20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:center;color:#4D4D4D;">More info on this Canarytoken? <a href="https://docs.canarytokens.org/guide/" style="text-decoration:none;color:#33c480">Click here</a></div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+    <!-- Banner ad -->
+    <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;border-radius:0 0 60px 60px;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;border-radius:0 0 60px 60px;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F7FA" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#F6F7FA;background-color:#F6F7FA;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F7FA;background-color:#F6F7FA;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#38d07e" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#38d07e;background-color:#38d07e;margin:0px auto;border-radius:30px;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#38d07e;background-color:#38d07e;width:100%;border-radius:30px;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:10px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="margin:0px auto;max-width:540px;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+                  <tbody>
+                    <tr>
+                      <td style="direction:ltr;font-size:0px;padding:20px 0 10px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+                            <tbody>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 30px;word-break:break-word;">
+                                  <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:24px;font-weight:400;line-height:1.4;text-align:center;color:white;">Some of the <span style="font-weight:600">best security teams</span> in the world run <span style="font-weight:600">Thinkst Canary</span>.</div>
+                                </td>
+                              </tr>
+                              <tr>
+                                <td align="center" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                  <div style="font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:16px;font-weight:400;line-height:24px;text-align:center;color:white;"><a href="https://canary.tools/" style="color:white">Find out why</a></div>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#F6F7FA" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#F6F7FA;background-color:#F6F7FA;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F6F7FA;background-color:#F6F7FA;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <!--[if mso | IE]></td></tr></table><![endif]-->
+  </div>
+</body>
+
+</html>

--- a/templates/emails/notification_token_exposed.mjml
+++ b/templates/emails/notification_token_exposed.mjml
@@ -1,0 +1,211 @@
+<!--
+  This is an MJML file. MJML (Mailjet Markup Language) is a markup language designed to reduce the pain of coding responsive email templates.
+  It abstracts away the complexity of responsive email design, allowing developers to write simpler and more readable code.
+
+  There are many ways you can use MJML. The easier one that requires less setup is:
+  1. Add a mjml plugin to your code editor. This will allow you to write MJML code and see the rendered email template in real-time.
+    For VScode https://marketplace.visualstudio.com/items?itemName=attilabuti.vscode-mjml
+    ( If you face troubles with the official plugin, try one of the forked projects )
+  2. Use the MJML online editor to convert mjml code to html: https://mjml.io/try-it-live
+
+  Or install MJML globally and compile your MJML files into HTML files:
+  1. Install MJML: `npm install -g mjml`.
+  2. Create an MJML file: Write your email template using MJML tags.
+  3. Compile the MJML file: Use the command `mjml input.mjml -o output.html` to compile your MJML file into an HTML file.
+  4. Use the generated HTML: The output HTML file can be used in your email campaigns.
+
+
+  For more information, and more visit the official MJML documentation: https://mjml.io/documentation
+
+  NOTE: When exporting to html, the conditions {% if BasicDetails['something'] %} living outside a <mj-text> are not supported and will be removed from the final html file.
+  If you need to use conditions, remeber to check the output html file and add them manually if needed.
+-->
+<mjml>
+  <mj-head>
+    <mj-title>Canarytoken exposed!</mj-title>
+    <mj-attributes>
+      <mj-all font-family="'Helvetica Neue', Helvetica, Arial, sans-serif"></mj-all>
+      <mj-text font-weight="400" font-size="16px" color="#4D4D4D" line-height="24px" font-family="'Helvetica Neue', Helvetica, Arial, sans-serif"></mj-text>
+    </mj-attributes>
+    <mj-style inline="inline">
+      .center-image {
+        display: block;
+        margin: 0 auto;
+      }
+    </mj-style>
+  </mj-head>
+
+  <mj-body background-color="#F6F7FA" width="600px">
+    <mj-section padding="10px 0 20px 0">
+      <mj-column>
+      </mj-column>
+    </mj-section>
+
+    <!-- Red bar top -->
+    <mj-section padding="10px 0 0px 0px" border-radius="30px 30px 0 0" background-color="#ec4f41">
+      <!--Logo -->
+      <mj-column width="40%">
+        <mj-image src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/token_logo.png" alt="Canarytokens" align="center" border="none" padding="0px" height="70px" />
+      </mj-column>
+    </mj-section>
+
+
+    <mj-wrapper padding="30px 30px 20px" background-color="#FFF">
+      <!--Alert icon -->
+
+      <!--Alert Top details -->
+      <mj-section padding="20px 0px 0px" border-radius="16px 16px" background-color="#F6F7FA">
+        <mj-column background-color="#f6f8fb" padding-bottom="30px" border-radius="0 0 16px 16px">
+          <mj-image src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/canarytoken-icons/{{BasicDetails['token_type']}}.png" alt="Canarytokens" align="center" border="none" padding="0px" width="70px" height="70px" />
+          <mj-text color="#060606" font-weight="bold" align="center" font-size="24px">
+            Your Canarytoken was exposed publicly</mj-text>
+          <mj-text color="#818a8e" padding="0px 20px" align="center">
+            One of your <span style="color:#060606;font-weight:600">{{BasicDetails['readable_type']}}</span>
+            Canarytokens has been found on the
+            {% if BasicDetails['public_location'] %}
+            <a href="{{ BasicDetails['public_location'] }}" style="text-decoration:none;color:#33c480" target="_blank">internet</a>.
+            {% else %}
+            internet.
+            {% endif %}
+            A publicly exposed token will provide very low quality alerts. We recommend that you disable and replace this token on private infrastructure.
+          </mj-text>
+        </mj-column>
+      </mj-section>
+
+    </mj-wrapper>
+
+    <!--Reminder -->
+    <mj-wrapper padding="0px 30px 30px" background-color="#FFF">
+      <mj-section background-color="#f6f8fb" border-radius="16px 16px">
+        <mj-column width="100%" padding="0px">
+          <mj-table>
+
+            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/reminder.png" width="40px" />
+              </td>
+              <td>
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">Reminder</p>
+                <p style="font-weight:400;color:#060606;margin:0;">{{BasicDetails['memo'] | e}}</p>
+              </td>
+            </tr>
+
+          </mj-table>
+        </mj-column>
+      </mj-section>
+
+    </mj-wrapper>
+
+    <!-- Key exposed location -->
+    <mj-wrapper padding="0px 30px 30px" background-color="#FFF">
+      <mj-section background-color="#f6f8fb" border-radius="16px 16px">
+        <mj-column width="100%" padding="0px">
+          <mj-table>
+
+            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px" />
+              </td>
+              <td>
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">Key found here</p>
+                <p style="font-weight:400;color:#060606;margin:0;">
+                  <a href="{{ BasicDetails['public_location'] }}" style="text-decoration:none;color:#33c480" target="_blank">{{ BasicDetails['public_location'] }}</a>
+                </p>
+              </td>
+            </tr>
+
+          </mj-table>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+
+    <!-- Key ID -->
+    <mj-wrapper padding="0px 30px 30px" background-color="#FFF">
+      <mj-section background-color="#f6f8fb" border-radius="16px 16px">
+        <mj-column width="100%" padding="0px">
+          <mj-table>
+
+            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px" />
+              </td>
+              <td>
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">Key ID</p>
+                <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['key_id'] | e}}</p>
+              </td>
+            </tr>
+
+          </mj-table>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+
+    <!-- Day & Time -->
+    <mj-wrapper padding="0px 30px 30px" background-color="#FFF">
+      <mj-section background-color="#f6f8fb" border-radius="16px 16px">
+        <mj-column width="100%" padding="0px">
+          <mj-table>
+
+            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/daytime.png" width="40px" />
+              </td>
+              <td style="vertical-align: top;">
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">Date</p>
+                <p style="font-weight:400;color:#060606;margin:0;">{{BasicDetails['time_ymd']}}</p>
+              </td>
+              <td style="vertical-align: top;">
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">Time</p>
+                <p style="font-weight:400;color:#060606;margin:0;">{{BasicDetails['time_hm']}} UTC</p>
+              </td>
+            </tr>
+
+          </mj-table>
+        </mj-column>
+      </mj-section>
+
+    </mj-wrapper>
+
+    <!-- CTA -->
+    <mj-wrapper padding="0px 30px 0px" background-color="#FFF">
+      <mj-section padding="0px 0 20px 0">
+        <mj-column>
+          <mj-button line-height="160%" background-color="#33c480" color="#FFF" font-size="16px" font-weight="bold" padding="10px 20px" border-radius="24px" align="center" href="{{ ManageLink }}" width="100%">
+            Manage Alert
+          </mj-button>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+
+    <!-- More info -->
+    <mj-wrapper padding="0px 30px 0px" background-color="#FFF">
+      <mj-section padding="0px 0 20px 0">
+        <mj-column>
+          <mj-text align="center">More info on this Canarytoken? <a href="https://docs.canarytokens.org/guide/" style="text-decoration:none;color:#33c480">Click here</a></mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+
+
+    <!-- Banner ad -->
+    <mj-wrapper padding="0px 30px 30px" background-color="#FFF" border-radius="0 0 60px 60px"></mj-wrapper>
+    <mj-wrapper padding="0px 30px 30px" background-color="#F6F7FA"></mj-wrapper>
+
+    <mj-wrapper padding="10px 30px" background-color="#38d07e" border-radius="30px">
+      <mj-section padding="20px 0 10px 0">
+        <mj-column>
+          <mj-text align="center" color="white" font-size="24px" line-height="1.4" padding="10px 30px">
+            Some of the <span style="font-weight:600">best security teams</span> in the world run <span style="font-weight:600">Thinkst Canary</span>.
+          </mj-text>
+          <mj-text align="center" color="white">
+            <a href="https://canary.tools/" style="color:white">Find out why</a>
+          </mj-text>
+        </mj-column>
+      </mj-section>
+    </mj-wrapper>
+
+    <mj-wrapper padding="0px 30px 30px" background-color="#F6F7FA"></mj-wrapper>
+
+
+  </mj-body>
+</mjml>


### PR DESCRIPTION
## Proposed changes

Add email support for exposed API key alerts.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

I tested the changes to the email handling by creating a new AWS API key token, triggering it normally and manually creating an exposed key alert with CURL (with 25 Dec as the exposed time) and checked that the normal alert email and the exposed key alert email were both correct.

![CleanShot 2024-11-13 at 13 59 53@2x](https://github.com/user-attachments/assets/a17bfeba-6ba6-40bb-9afa-2a6d895e6642)

![CleanShot 2024-11-13 at 13 58 46@2x](https://github.com/user-attachments/assets/07d3dfd5-2f4a-4524-94a6-b8669ea171b4)
