### PR TITLE
Fix nxdomain not being cleared on startup

### DIFF
--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -138,6 +138,10 @@ def remove_canary_domain():
     return DB.get_db().delete(KEY_CANARY_DOMAINS)
 
 
+def remove_canary_nxdomain():
+    return DB.get_db().delete(KEY_CANARY_NXDOMAINS)
+
+
 def add_canary_nxdomain(domain: str) -> int:
     return DB.get_db().sadd(KEY_CANARY_NXDOMAINS, domain)
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -162,6 +162,7 @@ from canarytokens.queries import (
     is_email_blocked,
     is_valid_email,
     remove_canary_domain,
+    remove_canary_nxdomain,
     save_canarydrop,
     validate_webhook,
     WebhookTooLongError,
@@ -342,7 +343,7 @@ def startup_event():
         hostname=switchboard_settings.REDIS_HOST, port=switchboard_settings.REDIS_PORT
     )
     remove_canary_domain()
-    remove_canary_domain()
+    remove_canary_nxdomain()
 
     add_canary_domain(domain=frontend_settings.DOMAINS[0])
     if frontend_settings.GOOGLE_API_KEY:


### PR DESCRIPTION
## Proposed changes

Fix canary nxdomains not being cleared out of Redis on startup.

Fixes #618.

Ran [tests](https://github.com/thinkst/canarytokens/actions/runs/11954515349).

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] Linked to the relevant github issue or github discussion