### PR TITLE
Display query parameters in alert history

### DIFF
--- a/frontend_vue/src/utils/incidentAlertService.ts
+++ b/frontend_vue/src/utils/incidentAlertService.ts
@@ -170,6 +170,7 @@ export function buildIncidentDetails(
           (hitAlert.location &&
             locationValue(hitAlert.token_type, hitAlert.location)) ||
           null,
+        request_args: hitAlert?.request_args || null,
       },
       time_of_hit: convertUnixTimeStampToDate(hitAlert.time_of_hit),
       src_ip: hitAlert.src_ip,


### PR DESCRIPTION
## Proposed changes

Enable visibility of query parameters in alert history by adding request_args field.

![image](https://github.com/user-attachments/assets/490f6341-1784-43b8-8602-529975f8e141)
