### PR TITLE
Force HTTPS for IdP App tokens

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -848,7 +848,10 @@ async def api_generate(  # noqa: C901  # gen is large
         page=page,
         use_path_elements=(token_request_details.token_type != TokenTypes.IDP_APP),
     )
-    if token_request_details.token_type == TokenTypes.PWA:
+    if token_request_details.token_type in [
+        TokenTypes.IDP_APP,
+        TokenTypes.PWA,
+    ]:
         canarydrop.generated_url = canarydrop.generated_url.replace(
             "http://", "https://"
         )


### PR DESCRIPTION
## Proposed changes

Like PWA tokens, IdP App tokens require HTTPS to be effective. This PR applies the same approach to IdP App tokens as has been used for PWA tokens, overriding the default URL generation behaviour to always use HTTPS.

Tested by deploying with a `switchboard.env` which does not have the `CANARY_FORCE_HTTPS` flag.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
