### PR TITLE
Convert the base32 string to uppercase before decoding

### DIFF
--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -272,10 +272,10 @@ class Canarytoken(object):
             return b32_data
 
         if file_name and file_name != "f":
-            b32_data = correct_base32_padding(file_name[0:])
+            b32_data = correct_base32_padding(file_name[0:].upper())
             data["windows_fake_fs_file_name"] = base64.b32decode(b32_data).decode()
         if process_name and process_name != "i":
-            b32_data = correct_base32_padding(process_name[0:])
+            b32_data = correct_base32_padding(process_name[0:].upper())
             data["windows_fake_fs_process_name"] = base64.b32decode(b32_data).decode()
 
         return {"src_data": data}
@@ -570,8 +570,8 @@ class Canarytoken(object):
         hit_time = datetime.utcnow().strftime("%s.%f")
         hit_info = {
             "additional_info": WebDavAdditionalInfo(
-                 file_path=request.getHeader("X-Alert-Path"),
-                 useragent=http_general_info["useragent"],
+                file_path=request.getHeader("X-Alert-Path"),
+                useragent=http_general_info["useragent"],
             ),
             "geo_info": queries.get_geoinfo(ip=client_ip),
             "input_channel": INPUT_CHANNEL_HTTP,

--- a/tests/units/test_tokens.py
+++ b/tests/units/test_tokens.py
@@ -100,6 +100,13 @@ def test_cmd_process_pattern(
             "explorer.exe",
         ),
         (
+            # ensure lowercase also works
+            "u7595.fmrxwgidcfzsg6y3y.imv4ha3dpojsxeltfpbsq.someid.sometoken.com",
+            "7595",
+            "doc b.docx",
+            "explorer.exe",
+        ),
+        (
             "u7595.f.iMV4HA3DPOJSXELTFPBSQ.someid.sometoken.com",
             "7595",
             "(not obtained)",


### PR DESCRIPTION
## Proposed changes

Fixes and issue that would cause the fake file system extra data to fail decoding if there was lowercase characters present.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
