### PR TITLE
Only allow valid base32 characters for fake file system token source data

### DIFF
--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -60,7 +60,7 @@ cmd_process_pattern = re.compile(
     re.IGNORECASE,
 )
 windows_fake_fs_pattern = re.compile(
-    r"u([0-9]*)\.f([A-Z2-7]*=*)\.i([A-Z2-7]*=*)\.", re.IGNORECASE
+    r"u([0-9]*)\.f([A-Z2-7]*)\.i([A-Z2-7]*)\.", re.IGNORECASE
 )
 
 # to validate decoded sql username, not a data extractor:
@@ -263,7 +263,7 @@ class Canarytoken(object):
             "windows_fake_fs_process_name": "(not obtained)",
         }
         if invocation_id:
-            data["windows_fake_fs_invocation_id"] = invocation_id[0:]
+            data["windows_fake_fs_invocation_id"] = invocation_id
 
         def correct_base32_padding(b32_data):
             padding_count = len(b32_data) % 8
@@ -272,10 +272,10 @@ class Canarytoken(object):
             return b32_data
 
         if file_name and file_name != "f":
-            b32_data = correct_base32_padding(file_name[0:].upper())
+            b32_data = correct_base32_padding(file_name.upper())
             data["windows_fake_fs_file_name"] = base64.b32decode(b32_data).decode()
         if process_name and process_name != "i":
-            b32_data = correct_base32_padding(process_name[0:].upper())
+            b32_data = correct_base32_padding(process_name.upper())
             data["windows_fake_fs_process_name"] = base64.b32decode(b32_data).decode()
 
         return {"src_data": data}

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -60,7 +60,7 @@ cmd_process_pattern = re.compile(
     re.IGNORECASE,
 )
 windows_fake_fs_pattern = re.compile(
-    r"u([0-9]*)\.f([A-Za-z0-9]*)\.i([A-Za-z0-9]*)\.", re.IGNORECASE
+    r"u([0-9]*)\.f([A-Z2-7]*=*)\.i([A-Z2-7]*=*)\.", re.IGNORECASE
 )
 
 # to validate decoded sql username, not a data extractor:

--- a/tests/units/test_tokens.py
+++ b/tests/units/test_tokens.py
@@ -90,48 +90,114 @@ def test_cmd_process_pattern(
     assert data["src_data"].get("cmd_invocation_id") == cmd_invocation_id
 
 
+ALL_BASE_32_CHARS_BYTES = bytes([i for i in range(32)])
+ALL_BASE_32_CHARS_STRING = base64.b32encode(ALL_BASE_32_CHARS_BYTES).decode()
+
+
 @pytest.mark.parametrize(
-    "query, invocation_id, file_name, process_name, ",
+    "query, invocation_id, file_name, process_name, pass_regex",
     [
-        (
+        pytest.param(
             "u7595.fMRXWGIDCFZSG6Y3Y.iMV4HA3DPOJSXELTFPBSQ.someid.sometoken.com",
             "7595",
             "doc b.docx",
             "explorer.exe",
+            True,
+            id="Valid Token",
         ),
-        (
+        pytest.param(
             # ensure lowercase also works
             "u7595.fmrxwgidcfzsg6y3y.imv4ha3dpojsxeltfpbsq.someid.sometoken.com",
             "7595",
             "doc b.docx",
             "explorer.exe",
+            True,
+            id="Valid Token Lowercase",
         ),
-        (
+        pytest.param(
             "u7595.f.iMV4HA3DPOJSXELTFPBSQ.someid.sometoken.com",
             "7595",
             "(not obtained)",
             "explorer.exe",
+            True,
+            id="Valid Token No File",
         ),
-        (
+        pytest.param(
             "u7595.fMRXWGIDCFZSG6Y3Y.i.someid.sometoken.com",
             "7595",
             "doc b.docx",
             "(not obtained)",
+            True,
+            id="Valid Token No Process",
         ),
-        (
+        pytest.param(
             "u7595.f.i.someid.sometoken.com",
             "7595",
             "(not obtained)",
             "(not obtained)",
+            True,
+            id="Valid Token No File or Process",
+        ),
+        pytest.param(
+            # Test invalid base32 char 0 is ignored
+            "u.f0.i.someid.sometoken.com",
+            None,
+            None,
+            None,
+            False,
+            id="Invalid Base32 Char 0",
+        ),
+        pytest.param(
+            # Test invalid base32 char 1 is ignored
+            "u.f1.i.someid.sometoken.com",
+            None,
+            None,
+            None,
+            False,
+            id="Invalid Base32 Char 1",
+        ),
+        pytest.param(
+            # Test invalid base32 char 8 is ignored
+            "u.f8.i.someid.sometoken.com",
+            None,
+            None,
+            None,
+            False,
+            id="Invalid Base32 Char 8",
+        ),
+        pytest.param(
+            # Test invalid base32 char 9 is ignored
+            "u.f9.i.someid.sometoken.com",
+            None,
+            None,
+            None,
+            False,
+            id="Invalid Base32 Char 9",
+        ),
+        pytest.param(
+            # Test all the valid base32 chars
+            f"u1.f{ALL_BASE_32_CHARS_STRING}.i{ALL_BASE_32_CHARS_STRING}.someid.sometoken.com",
+            "1",
+            ALL_BASE_32_CHARS_BYTES.decode(),
+            ALL_BASE_32_CHARS_BYTES.decode(),
+            True,
+            id="All valid Base32 Chars",
         ),
     ],
 )
-def test_windows_fake_fs_pattern(query, invocation_id, file_name, process_name):
-    m = t.windows_fake_fs_pattern.match(query)
-    data = t.Canarytoken._windows_fake_fs(m)
-    assert data["src_data"]["windows_fake_fs_invocation_id"] == invocation_id.lower()
-    assert data["src_data"]["windows_fake_fs_file_name"] == file_name.lower()
-    assert data["src_data"]["windows_fake_fs_process_name"] == process_name.lower()
+def test_windows_fake_fs_pattern(
+    query, invocation_id, file_name, process_name, pass_regex
+):
+    matches = t.windows_fake_fs_pattern.match(query)
+    assert (matches is not None) == pass_regex
+
+    if pass_regex:
+        data = t.Canarytoken._windows_fake_fs(matches)
+        assert (
+            data["src_data"]["windows_fake_fs_invocation_id"] == invocation_id.lower()
+        )
+        assert data["src_data"]["windows_fake_fs_file_name"] == file_name.lower()
+        assert data["src_data"]["windows_fake_fs_process_name"] == process_name.lower()
 
 
 def test_windows_fake_fs_base32_padding():

--- a/tests/units/test_tokens.py
+++ b/tests/units/test_tokens.py
@@ -90,7 +90,8 @@ def test_cmd_process_pattern(
     assert data["src_data"].get("cmd_invocation_id") == cmd_invocation_id
 
 
-ALL_BASE_32_CHARS_BYTES = bytes([i for i in range(32)])
+# string was chosen so it would use each of the 32 characters used by base 32
+ALL_BASE_32_CHARS_BYTES = b"WP*BHy@Sa9`M:6'F?u0G':~?\\7<7o`[mQ~?"
 ALL_BASE_32_CHARS_STRING = base64.b32encode(ALL_BASE_32_CHARS_BYTES).decode()
 
 
@@ -193,11 +194,9 @@ def test_windows_fake_fs_pattern(
 
     if pass_regex:
         data = t.Canarytoken._windows_fake_fs(matches)
-        assert (
-            data["src_data"]["windows_fake_fs_invocation_id"] == invocation_id.lower()
-        )
-        assert data["src_data"]["windows_fake_fs_file_name"] == file_name.lower()
-        assert data["src_data"]["windows_fake_fs_process_name"] == process_name.lower()
+        assert data["src_data"]["windows_fake_fs_invocation_id"] == invocation_id
+        assert data["src_data"]["windows_fake_fs_file_name"] == file_name
+        assert data["src_data"]["windows_fake_fs_process_name"] == process_name
 
 
 def test_windows_fake_fs_base32_padding():


### PR DESCRIPTION
## Proposed changes

We recently improve the decoding of the fake file system DNS queries to allow lowercase letters as some DNS queries come in as lower case or mixed case.
This is a continuation of this to improve our fake file system token so we ignore invalid base32 characters as specified in [RFC4648](https://datatracker.ietf.org/doc/html/rfc4648)

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
