### PR TITLE
Do not parse the geodata if there is none

### DIFF
--- a/frontend_vue/src/utils/incidentAlertService.ts
+++ b/frontend_vue/src/utils/incidentAlertService.ts
@@ -133,6 +133,7 @@ function locationValue(
 }
 
 function parseGeoInfo(hitAlert: Record<string, any>) {
+  if (hitAlert.geo_info == null) return null;
   if (isCreditCardtoken(hitAlert.token_type)) return null;
 
   if (!hitAlert.geo_info.bogon) {


### PR DESCRIPTION
## Proposed changes

Some of the alerts like the AWS safetynet does not have geo data. This fix checks if the geo data is blank before attempting to parse it

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
