### PR TITLE
Fix marker drawing when no geo info is available

### DIFF
--- a/frontend_vue/src/components/ui/CustomMap.vue
+++ b/frontend_vue/src/components/ui/CustomMap.vue
@@ -67,7 +67,7 @@ import getImageUrl from '@/utils/getImageUrl';
 
 type MarkerType = {
   id: number;
-  ip: string;
+  ip?: string;
   hostname?: string;
   city?: string;
   country?: string;
@@ -92,21 +92,10 @@ function parseGeoInfoLocation(info: string) {
   };
 }
 
-onMounted(() => {
-  if (props.hitsList.length === 0) {
-    return;
-  }
-  if (props.hitsList.length > 1) {
-    return fitMarkerBounds();
-  } else if (props.hitsList.length === 1) {
-    center.value = parseGeoInfoLocation(
-      props.hitsList[0].geo_info.loc as string
-    );
-  }
-});
-
 const markers: ComputedRef<MarkerType[]> = computed(() => {
-  return props.hitsList.map((marker) => {
+  return props.hitsList.filter(function(marker) {
+    return (marker.geo_info != null);
+  }).map((marker) => {
     return {
       id: marker.time_of_hit,
       ip: marker.geo_info.ip,
@@ -119,6 +108,17 @@ const markers: ComputedRef<MarkerType[]> = computed(() => {
         : undefined,
     };
   });
+});
+
+onMounted(() => {
+  if (markers.value.length === 0) {
+    return;
+  }
+  if (markers.value.length > 1) {
+    return fitMarkerBounds();
+  } else if (markers.value.length === 1) {
+    if (markers.value[0].position != null) center.value = markers.value[0].position
+  }
 });
 
 function handleOpenMarker(id: number | null) {

--- a/frontend_vue/src/components/ui/CustomMap.vue
+++ b/frontend_vue/src/components/ui/CustomMap.vue
@@ -82,7 +82,7 @@ const props = defineProps<{
 const isLoading = ref(true);
 const openedMarkerID = ref();
 const mapRef = ref();
-const center = ref({ lat: 0, lng: 0 });
+const center = ref({ lat: -33.9221, lng: 18.4231 }); // Default to Cape Town
 
 function parseGeoInfoLocation(info: string) {
   const locationArray = info.split(',');


### PR DESCRIPTION
## Proposed changes

Some alerts like the AWS safetynet alert does not have IP and geo info.
This fix addresses this so that the map and markers still work.

The incident without geo info will be ignored and all the other alerts that do have the info will be used to draw the markers.

If none of the alerts have geo info the map will default to the Cape Town location like the place holder image does when the map is loading.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
