### PR TITLE
Include install instructions on manage page for sensitive command tokens

### DIFF
--- a/frontend_vue/src/components/tokens/cmd/ActivatedToken.vue
+++ b/frontend_vue/src/components/tokens/cmd/ActivatedToken.vue
@@ -1,27 +1,5 @@
 <template>
-  <TokenDisplay :token-data="tokenData" />
-  <base-message-box
-    class="mt-24"
-    variant="info"
-    message="Once installed (with admin permissions) you'll get an alert whenever someone
-  (or someone's code) runs your sensitive process."
-  />
-  <p class="mt-24 text-sm">
-    It will automatically provide the command used, computer the command ran on,
-    and the user invoking the command.
-  </p>
-  <p class="mt-16 text-sm"></p>
-  <base-message-box
-    class="mt-24"
-    variant="warning"
-    message="In order to ensure that the token fires for both 32-bit and 64-bit
-    executables, we suggest installing by running the following commands:"
-  />
-  <BaseCodeSnippet
-    class="mt-16"
-    lang="bash"
-    :code="recommendedReg"
-  ></BaseCodeSnippet>
+  <TokenDisplay :token-data="tokenData" :displayInfoBox="true"/>
 </template>
 
 <script setup lang="ts">
@@ -37,8 +15,4 @@ const tokenData = ref({
   token: props.tokenData.token || '',
   auth: props.tokenData.auth_token || '',
 });
-
-const recommendedReg = ref(
-  'reg import FILENAME /reg:64  \nreg import FILENAME /reg:32'
-);
 </script>

--- a/frontend_vue/src/components/tokens/cmd/ManageToken.vue
+++ b/frontend_vue/src/components/tokens/cmd/ManageToken.vue
@@ -1,12 +1,8 @@
 <template>
-  <div v-if="!tokenData">Error loading</div>
-  <TokenDisplay
-    v-else
-    :token-data="tokenData"
-  />
+  <TokenDisplay :token-data="tokenData" :displayInfoBox="false"/>
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { ref } from 'vue';
 import TokenDisplay from './TokenDisplay.vue';
 import type { ManageTokenBackendType } from '@/components/tokens/types.ts';

--- a/frontend_vue/src/components/tokens/cmd/TokenDisplay.vue
+++ b/frontend_vue/src/components/tokens/cmd/TokenDisplay.vue
@@ -6,9 +6,34 @@
       >Download your MS registry file</base-button
     >
   </div>
+  <div v-if="displayInfoBox">
+    <base-message-box
+      class="mt-24"
+      variant="info"
+      message="Once installed (with admin permissions) you'll get an alert whenever someone
+    (or someone's code) runs your sensitive process."
+    />
+    <p class="mt-24 text-sm">
+      It will automatically provide the command used, computer the command ran on,
+      and the user invoking the command.
+    </p>
+    <p class="mt-16 text-sm"></p>
+  </div>
+  <base-message-box
+    class="mt-24"
+    variant="warning"
+    message="In order to ensure that the token fires for both 32-bit and 64-bit
+    executables, we suggest installing by running the following commands:"
+  />
+  <BaseCodeSnippet
+    class="mt-16"
+    lang="bash"
+    :code="recommendedReg"
+  ></BaseCodeSnippet>
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { downloadAsset } from '@/api/main';
 
 type CMDDataType = {
@@ -18,6 +43,7 @@ type CMDDataType = {
 
 const props = defineProps<{
   tokenData: CMDDataType;
+  displayInfoBox: boolean;
 }>();
 
 async function handleDownloadMSregistryFile() {
@@ -35,4 +61,9 @@ async function handleDownloadMSregistryFile() {
     console.log('Download ready');
   }
 }
+
+const recommendedReg = ref(
+  'reg import FILENAME /reg:64  \nreg import FILENAME /reg:32'
+);
+
 </script>


### PR DESCRIPTION
## Proposed changes

The manage page for sensitive command tokens only has a download button but does not remind users how to install the token. This PR includes the install instructions in the token display so they are always shown:
<img width="400" alt="Screenshot 2024-12-13 at 11 33 47" src="https://github.com/user-attachments/assets/b1174d06-5d0f-4d64-8eea-1ef6e36f8e3d" /><img width="400" alt="Screenshot 2024-12-13 at 11 33 51" src="https://github.com/user-attachments/assets/cbb5f3eb-2659-44b2-a4b5-348b8e119f0c" />


## Types of changes
- [x] Documentation Update

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
