### PR TITLE
Handle webhook ChunkedEncodingError gracefully

### DIFF
--- a/canarytokens/channel_output_webhook.py
+++ b/canarytokens/channel_output_webhook.py
@@ -111,4 +111,8 @@ class WebhookOutputChannel(OutputChannel):
             log.debug(
                 f"Failed connecting to webhook {alert_webhook_url}.",
             )
+        except requests.exceptions.ChunkedEncodingError:
+            log.debug(
+                f"Broken connection when sending to webhook {alert_webhook_url}.",
+            )
         return False


### PR DESCRIPTION
## Proposed changes

This is a small change to handle `requests.exceptions.ChunkedEncodingError` being thrown during webhook sending.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
