### PR TITLE
Allow mail to be sent without starttls() and login creds if desired

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,6 @@ When configuring outgoing SMTP please consider the following:
 
 Restrictions:
 * no other provider like Mailgun or Sendgrid must be configured for this to work
-* only supports StartTLS right now (you have to use the corresponding port)
-* no anonymous SMTP is supported right now (you have to use a username/password to authenticate)
 * For AWS SES `CANARY_ALERT_EMAIL_FROM_DISPLAY` should be in the format: `CANARY_ALERT_EMAIL_FROM_DISPLAY=CanaryAlert <canaryalert@my-email-domain.here>`
 
 The following settings have to be configured in `switchboard.env` for SMTP to work:

--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -263,8 +263,9 @@ def smtp_send(
         smtpmsg.attach(part2)
 
         with smtplib.SMTP(smtp_server, smtp_port) as server:
-            server.starttls()
-            server.login(smtp_username, smtp_password)
+            if smtp_username is not None and smtp_password is not None:
+                server.starttls()
+                server.login(smtp_username, smtp_password)
             server.sendmail(fromaddr, toaddr, smtpmsg.as_string())
     except smtplib.SMTPException as e:
         log.error("A smtp error occurred: %s - %s" % (e.__class__, e))


### PR DESCRIPTION
## Proposed changes

Addresses some of the limitations outlined in the README for the SMTP output.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation Update

## Checklist

- [X] Lint and unit tests pass locally with my changes (if applicable)
- [X] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
