### PR TITLE
Add CORP header to CF Function output

### DIFF
--- a/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
+++ b/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
@@ -15,7 +15,8 @@ const matching_ref_response = {
     statusDescription: 'OK',
     headers: {
         'content-type': { value: 'image/gif' },
-        'cache-control': { value: 'no-store' }
+        'cache-control': { value: 'no-store' },
+        'cross-origin-resource-policy': { value: 'cross-origin' }
     },
     body: "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff"
     + "\xff\xff\xff\x21\xf9\x04\x01\x0a\x00\x01\x00\x2c\x00\x00\x00\x00"


### PR DESCRIPTION
## Proposed changes

Add the `cross-origin-resource-policy` header to the output of the CF Function to explicitly tell importing origins we're ok with them referencing the function. Implicitly, every HTTP request without this header is assumed to be `cross-origin`, but some origins specify the `cross-origin-embedder-policy: require-corp` header which while technically not breaking due to the lack of the CORP header, throws ugly warnings into the browser console. This header simply makes it explicit that we're expecting to be loaded cross-origin.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
