### PR TITLE
Allow nested paths in fake fs

### DIFF
--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -530,7 +530,7 @@ class WindowsFakeFSTokenRequest(TokenRequest):
     @validator("windows_fake_fs_root")
     def check_process_name(value: str):
         _value = value.strip()
-        invalid_chars = r'[<>:"/\\|?*]'
+        invalid_chars = r'[<>:"/|?*[\]]'
         drive_pattern = r"^[A-Za-z]:[\\/]"
 
         if not re.match(drive_pattern, _value):

--- a/tests/integration/test_windows_fake_fs_token.py
+++ b/tests/integration/test_windows_fake_fs_token.py
@@ -95,17 +95,16 @@ def test_windows_fake_fs_token_fires(
     [
         (
             [
-                r"C:\Testing["
-                r"C:\Testing<"
-                r"C:\Testing>"
-                r"C:\Testing:"
-                r'C:\Testing"'
-                r"C:\Testing/"
-                r"C:\Testing\\"
-                r"C:\Testing|"
-                r"C:\Testing?"
-                r"C:\Testing*"
-                r"C:\Testing]"
+                r"C:\Testing[",
+                r"C:\Testing<",
+                r"C:\Testing>",
+                r"C:\Testing:",
+                r'C:\Testing"',
+                r"C:\Testing/",
+                r"C:\Testing|",
+                r"C:\Testing?",
+                r"C:\Testing*",
+                r"C:\Testing]",
             ],
             "windows_fake_fs_root contains invalid Windows Path Characters.",
         ),
@@ -126,7 +125,6 @@ def test_windows_fake_fs_token_validator(
     """
     memo = "Testing"
     file_structure = "testing"
-
     for root_dir in directories:
         with pytest.raises(ValueError, match=expected_error_message):
             WindowsFakeFSTokenRequest(


### PR DESCRIPTION
## Proposed changes

Our check for the Windows Fake FS path was too strict and didn't allow for nested paths. This change simply reduces the check to allow for nested paths to be used.

Additionally, fixed the associated integration tests to correctly test each case.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] Lint and unit tests pass locally with my changes (if applicable)
- [X] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
