### PR TITLE
Support both referer and referrer on frontend

### DIFF
--- a/frontend_vue/src/components/tokens/types.ts
+++ b/frontend_vue/src/components/tokens/types.ts
@@ -249,6 +249,7 @@ export type HitsType = {
   merchant?: string | null;
   mail?: string | null;
   referer?: string | null;
+  referrer?: string | null;
   location?: string | GeolocationPosition | CoordsType | null;
 };
 

--- a/frontend_vue/src/utils/incidentAlertService.ts
+++ b/frontend_vue/src/utils/incidentAlertService.ts
@@ -166,7 +166,7 @@ export function buildIncidentDetails(
         amount: hitAlert.amount || null,
         merchant: hitAlert.merchant || null,
         mail: hitAlert.mail || null,
-        referer: hitAlert.referer || null,
+        referer: hitAlert.referer || hitAlert.referrer || null,
         location:
           (hitAlert.location &&
             locationValue(hitAlert.token_type, hitAlert.location)) ||


### PR DESCRIPTION
## Proposed changes

There are two possible spellings for referer: referer and referrer. CSS tokens use the latter and as such the referrer is not displayed on the frontend. This PR supports both spellings on the frontend and fixes #648 

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [x] Linked to the relevant github issue or github discussion

## Further comments

Since CSS tokens don't fire on the dev infrastructure we can't test this before landing. I have confirmed that on the production infrastructure the referrer field is present.

After manually generating a hit the following details are shown in the network tools when loading the alert history of the token:

```
{
    "canarydrop": {
        "generate": null,
        "canarytoken": {
            "_value": "..."
        },
        "triggered_details": {
            "hits": [
                {
                    "time_of_hit": 1740552350.306394,
                    ...
                    "token_type": "cssclonedsite",
                    "referrer": "https://google.com"
                }
            ],
            "token_type": "cssclonedsite"
        },
        "memo": "test",
        ...
}
```