### PR TITLE
Fix credit card instructions typo

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,11 +36,11 @@ repos:
         - id: terraform_fmt
         # - id: terraform_tfsec install is suboptimal
 
--   repo: local
-    hooks:
-    -   id: typescript-check
-        name: Typescript Checker
-        entry: npm run --prefix frontend_vue type-check
-        types_or: [javascript, jsx, ts, tsx, vue]
-        language: system
-        pass_filenames: false
+# -   repo: local
+#     hooks:
+#     -   id: typescript-check
+#         name: Typescript Checker
+#         entry: npm run --prefix frontend_vue type-check
+#         types_or: [javascript, jsx, ts, tsx, vue]
+#         language: system
+#         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,11 +36,11 @@ repos:
         - id: terraform_fmt
         # - id: terraform_tfsec install is suboptimal
 
-# -   repo: local
-#     hooks:
-#     -   id: typescript-check
-#         name: Typescript Checker
-#         entry: npm run --prefix frontend_vue type-check
-#         types_or: [javascript, jsx, ts, tsx, vue]
-#         language: system
-#         pass_filenames: false
+-   repo: local
+    hooks:
+    -   id: typescript-check
+        name: Typescript Checker
+        entry: npm run --prefix frontend_vue type-check
+        types_or: [javascript, jsx, ts, tsx, vue]
+        language: system
+        pass_filenames: false

--- a/frontend_vue/src/utils/tokenServices.ts
+++ b/frontend_vue/src/utils/tokenServices.ts
@@ -49,7 +49,7 @@ export const tokenServices: TokenServicesType = {
     description: 'Get an alert when an attacker attempt to use your credit card.',
     documentationLink: 'https://docs.canarytokens.org/guide/qr-code-token.html',
     icon: `${TOKENS_TYPE.CREDIT_CARD_V2}.png`,
-    instruction: 'Place it on your computer and get notified when your\'e breached:',
+    instruction: 'Place it on your computer and get notified when you\'re breached:',
     howItWorksInstructions: [
       'We give you unique Credit Card details',
       'You place it somewhere.',


### PR DESCRIPTION
Small change to fix typo in the credit card instructions -> `your'e changes to you're`.