### PR TITLE
Ignore irregular activity tickets in AWS exposed key checker

### DIFF
--- a/aws-exposed-key-checker-infra/lambda_source/exposed_key_checker/exposed_keys.py
+++ b/aws-exposed-key-checker-infra/lambda_source/exposed_key_checker/exposed_keys.py
@@ -50,6 +50,7 @@ def _should_ignore_ticket_parse_failure(ticket: TicketData) -> bool:
         "we have not heard back from you",
         "duplicate of case",
         "case has been resolved",
+        "observed anomalous activity in your aws account",
     ]
 
     text = ticket.description.lower()

--- a/aws-exposed-key-checker-infra/lambda_source/exposed_key_checker/lambda_handler.py
+++ b/aws-exposed-key-checker-infra/lambda_source/exposed_key_checker/lambda_handler.py
@@ -106,6 +106,7 @@ def gather_data(
         if age > timedelta(days=MAX_PROCESS_AGE_DAYS):
             # Only check the last week's data
             break
+    print(f"Got {len(ignorable_tickets)} ignorable tickets from {num_tickets} tickets.")
     print(f"Got {len(data)} exposed keys from {num_tickets} tickets.")
 
     return data, ignorable_ids, error_ids

--- a/aws-exposed-key-checker-infra/lambda_source/exposed_key_checker/ticket_manager.py
+++ b/aws-exposed-key-checker-infra/lambda_source/exposed_key_checker/ticket_manager.py
@@ -5,6 +5,9 @@ import os
 import requests
 
 ZENDESK_EXPOSED_TICKET_TAG = os.environ["ZENDESK_EXPOSED_TICKET_TAG"]
+ZENDESK_IRREGULAR_ACTIVITY_TICKET_TAG = os.environ[
+    "ZENDESK_IRREGULAR_ACTIVITY_TICKET_TAG"
+]
 ZENDESK_CLOSED_TICKET_TAG = os.environ["ZENDESK_CLOSED_TICKET_TAG"]
 ZENDESK_ASSIGNEE = os.environ["ZENDESK_ASSIGNEE"]
 
@@ -35,7 +38,7 @@ class ZendeskTicketManager:
             url or f"{self._api_base_url}/api/v2/search.json",
             auth=self._auth,
             data={
-                "query": f'tags:"{ZENDESK_EXPOSED_TICKET_TAG}"',
+                "query": f'tags:"{ZENDESK_EXPOSED_TICKET_TAG}" OR tags:"{ZENDESK_IRREGULAR_ACTIVITY_TICKET_TAG}"',
                 "sort_by": "created_at",
                 "sort_order": "desc",
             },

--- a/aws-exposed-key-checker-infra/main.tf
+++ b/aws-exposed-key-checker-infra/main.tf
@@ -73,14 +73,15 @@ resource "aws_lambda_function" "key_checker_lambda" {
   environment {
     variables = merge(
       {
-        TICKET_SERVICE_URL         = "${var.ticket_service_url}"
-        TICKET_SERVICE_RECIPIENT   = "${var.ticket_service_recipient}"
-        WIKI_REFERENCE             = "${var.wiki_reference}"
-        ZENDESK_EXPOSED_TICKET_TAG = "${var.zendesk_exposed_ticket_tag}"
-        ZENDESK_CLOSED_TICKET_TAG  = "${var.zendesk_closed_ticket_tag}"
-        ZENDESK_ASSIGNEE           = "${var.zendesk_assignee}"
-        ZENDESK_AUTH_SECRET_ID     = "${var.zendesk_auth_secret_id}"
-        TOKENS_SERVERS_ALLOW_LIST  = "${var.tokens_servers_allow_list}"
+        TICKET_SERVICE_URL                    = "${var.ticket_service_url}"
+        TICKET_SERVICE_RECIPIENT              = "${var.ticket_service_recipient}"
+        WIKI_REFERENCE                        = "${var.wiki_reference}"
+        ZENDESK_EXPOSED_TICKET_TAG            = "${var.zendesk_exposed_ticket_tag}"
+        ZENDESK_IRREGULAR_ACTIVITY_TICKET_TAG = "${var.zendesk_irregular_activity_ticket_tag}"
+        ZENDESK_CLOSED_TICKET_TAG             = "${var.zendesk_closed_ticket_tag}"
+        ZENDESK_ASSIGNEE                      = "${var.zendesk_assignee}"
+        ZENDESK_AUTH_SECRET_ID                = "${var.zendesk_auth_secret_id}"
+        TOKENS_SERVERS_ALLOW_LIST             = "${var.tokens_servers_allow_list}"
       },
       var.tokens_post_url_override != null ? { TOKENS_POST_URL_OVERRIDE = var.tokens_post_url_override } : {}
     )

--- a/aws-exposed-key-checker-infra/variables.tf
+++ b/aws-exposed-key-checker-infra/variables.tf
@@ -14,6 +14,10 @@ variable "zendesk_exposed_ticket_tag" {
   type = string
 }
 
+variable "zendesk_irregular_activity_ticket_tag" {
+  type = string
+}
+
 variable "zendesk_closed_ticket_tag" {
   type = string
 }


### PR DESCRIPTION
## Proposed changes

We should be ignoring the "Irregular Activity Detected for Your AWS Access Key" tickets in Zendesk as we already process this information - these are duplicates. This change adds a string to catch the ignores, and includes tickets with the irregular activity tag.

## Types of changes

What types of changes does your code introduce to this repository?
- [x] New feature (non-breaking change which adds functionality)

## Testing
Pushed terraform to AWS, ran lambda manually, and confirmed the relevant tickets for irregular activity are collected and closed