### PR TITLE
Update Ubuntu version from 20.04 to 22.04 for docker image build action

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build-and-commit-frontend-dist:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       NODE_VERSION: '18'
     permissions:
@@ -93,7 +93,7 @@ jobs:
 
   build:
     needs: build-and-commit-frontend-dist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COPYFILE_DISABLE: 1
 


### PR DESCRIPTION
## Proposed changes

Updates our GH action to move away from `ubuntu-20.04` which is GH will stop supporting from 15 April.

The action runs successfully: https://github.com/thinkst/canarytokens/actions/runs/14401050978