### PR TITLE
Ignore referers from fbapp on CloudFront

### DIFF
--- a/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
+++ b/aws-css-token-infra/CSSClonedSiteCFFunc/index.js
@@ -41,6 +41,10 @@ async function handler(event) {
     if ('referer' in event.request.headers) {
         referer = event.request.headers.referer.value;
         if (referer.indexOf('//') >= 0) {
+            if (referer.startsWith('fbapp://')) {
+                // Global ignore any FB app schemes
+                return matching_ref_response;
+            }
             const pathArray = referer.split( '/' );
             referer_origin = pathArray[2];
         } else {


### PR DESCRIPTION
## Proposed changes

This change ignores (i.e. returns a HTTP 200) any hits to the CloudFront function from the `fbapp://` scheme. There are some (tough to reproduce) instances where spurious alerts are coming from the FB app, which are impossible to act on, and often false positives.

I have run all the tests in the CloudFront function repo, and a new one to verify that any referer prefaced with `fbapp://` are not alerted on.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
