### PR TITLE
Generate full output URL for canarytokens service

### DIFF
--- a/aws-token-infra/awsid.tf
+++ b/aws-token-infra/awsid.tf
@@ -194,8 +194,8 @@ resource "aws_lambda_permission" "create_user_api_tokens" {
 }
 
 
-output "base_url" {
-  value = aws_api_gateway_deployment.create_user_api_tokens.invoke_url
+output "aws_api_key_creation_url" {
+  value = "https://${aws_api_gateway_rest_api.create_user_api_tokens.id}.execute-api.us-east-2.amazonaws.com/${aws_api_gateway_deployment.create_user_api_tokens.stage_name}/${aws_api_gateway_resource.create_user_api_tokens.path_part}"
 }
 
 


### PR DESCRIPTION
## Proposed changes

Previously the URL generated could be given directly to the Canarytokens service, it had the final part of the path missing.

When updating this, also removed the deprecated invoke_url attribute.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
