### PR TITLE
Fix AWS Internal ip info exception

### DIFF
--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -423,7 +423,7 @@ def set_ip_info_api_key(ip_info_api_key):
 
 def get_geoinfo(ip: str):
     if ip.lower() == "aws internal":
-        return "AWS Internal"
+        return models.GeoIPBogonInfo(ip="AWS Internal", bogon=False).dict()
 
     if is_ip_cached(ip):
         return get_geoinfo_from_cache(ip)

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -422,6 +422,9 @@ def set_ip_info_api_key(ip_info_api_key):
 
 
 def get_geoinfo(ip: str):
+    if ip.lower() == "aws internal":
+        return "AWS Internal"
+
     if is_ip_cached(ip):
         return get_geoinfo_from_cache(ip)
     else:

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -423,7 +423,7 @@ def set_ip_info_api_key(ip_info_api_key):
 
 def get_geoinfo(ip: str):
     if ip.lower() == "aws internal":
-        return models.GeoIPBogonInfo(ip="AWS Internal", bogon=False).dict()
+        return None
 
     if is_ip_cached(ip):
         return get_geoinfo_from_cache(ip)

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -350,7 +350,7 @@ def test_get_geoinfo_503_response_code_handling(monkeypatch):
 def test_get_geoinfo_aws_internal():
     ip = "AWS Internal"
     info = queries.get_geoinfo(ip)
-    assert info == "AWS Internal"
+    assert info is None
 
 
 def test_mail_queue(setup_db):

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -347,6 +347,12 @@ def test_get_geoinfo_503_response_code_handling(monkeypatch):
     assert captured[0]["log_level"] == LogLevel.info
 
 
+def test_get_geoinfo_aws_internal():
+    ip = "AWS Internal"
+    info = queries.get_geoinfo(ip)
+    assert info == "AWS Internal"
+
+
 def test_mail_queue(setup_db):
     details = make_token_alert_detail()
     mail_key = "some_unique_key"


### PR DESCRIPTION
## Proposed changes

Fix the exception created when attempting to do an IPInfo lookup for 'AWS Internal'. The fix returns None, which is inline withe the model of a TokenHit accepting the None `geo_info: Union[GeoIPInfo, GeoIPBogonInfo, None, Literal[""]]` in models.py

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

![CleanShot 2025-06-10 at 12 00 11@2x](https://github.com/user-attachments/assets/3539ee7d-8bda-4b3d-9ee5-861f1c9b488c)
