### PR TITLE
Fix unicode error on smtp data received

### DIFF
--- a/canarytokens/channel_input_smtp.py
+++ b/canarytokens/channel_input_smtp.py
@@ -36,22 +36,18 @@ original_lookup_method = smtp.ESMTP.lookupMethod
 
 def patched_lookupMethod(self, command):
     """
-    Patched version of lookupMethod that handles non-ASCII characters by ignoring them.
+    Patched version of lookupMethod that handles non-ASCII characters by closing the connection.
     """
     try:
         return original_lookup_method(self, command)
     except UnicodeDecodeError:
-        # Log the issue but continue processing
+        # Log the issue and close the connection
         log.warn(
             f"Received command with non-ASCII characters from {self.transport.getPeer().host}: {command!r}"
         )
-        # Try to decode with replacement character
-        try:
-            cleaned_command = command.decode("ascii", errors="replace").encode("ascii")
-            return original_lookup_method(self, cleaned_command)
-        except Exception as e:
-            log.error(f"Failed to process command after cleaning: {e}")
-            return None
+        self.sendLine(b"500 Syntax error, command unrecognized")
+        self.transport.loseConnection()
+        return None
 
 
 # Apply the patch to the ESMTP class


### PR DESCRIPTION
## Proposed changes

Fix a case where the smtp server is receiving invalid characters, we now catch the exception and close the connection.

Exception before the fix:
```
builtins.UnicodeDecodeError: 'ascii' codec can't decode byte 0x80 in position 1: ordinal not in range(128)
```

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

Since the token is not longer officially supported a manual test was conducted using netcat

```
echo -ne 'X\x80X\r\n' | nc -v canarytokens.org 25
Connection to canarytokens.org port 25 [tcp/smtp] succeeded!
220 Hello there
500 Syntax error, command unrecognized
500 Command not implemented
```