### PR TITLE
Anchor resource

### DIFF
--- a/aws_infra_token_tf/decoys.tf
+++ b/aws_infra_token_tf/decoys.tf
@@ -60,3 +60,13 @@ resource "aws_dynamodb_table_item" "fake-table-items" {
 
   depends_on = [aws_dynamodb_table.fake-tables]
 }
+
+resource "null_resource" "decoys_anchor" {
+  depends_on = [
+    aws_s3_object.fake-s3-objects,
+    aws_sqs_queue.fake-sqs-queues,
+    aws_ssm_parameter.fake-ssm-parameters,
+    aws_secretsmanager_secret.fake-secrets,
+    aws_dynamodb_table_item.fake-table-items,
+  ]
+}


### PR DESCRIPTION
## Proposed changes

To ensure Cloudtrail events for decoys are not considered as alerts while terraform is actually creating them, we need a way to "depend_on" the decoy resources created - but the dynamic nature of these resources makes it tricky to determine which of these to depend on.

This change creates a null_resource that is created only after the decoys are created, and the trail and EventBridge rule can subsequently depend on this null_resource.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
