### PR TITLE
Ensure the aws provider uses the correct region

### DIFF
--- a/aws_infra_token_tf/main.tf
+++ b/aws_infra_token_tf/main.tf
@@ -31,7 +31,11 @@ resource "null_resource" "region_validator" {
   lifecycle {
     precondition {
       condition     = data.aws_region.current.name == local.expected_region
-      error_message = "AWS region validation failed. Expected: ${local.expected_region}, Got: ${data.aws_region.current.name}"
+      error_message = "You're trying to create decoys in ${data.aws_region.current.name}, but this Terraform targets ${local.expected_region} specifically. You can set the AWS_REGION variable to switch your region: export AWS_REGION=${local.expected_region}, then run 'terraform apply' again."
     }
   }
+}
+
+provider "aws" {
+  region = local.expected_region
 }


### PR DESCRIPTION
## Proposed changes

Although the terraform module checks for the expected region, it's worthwhile to add a provider which explicitly uses the region in the module itself.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update
