### PR TITLE
Drop non-existent WireGuard device log line to `INFO`

### DIFF
--- a/canarytokens/channel_input_wireguard.py
+++ b/canarytokens/channel_input_wireguard.py
@@ -97,7 +97,7 @@ class WireGuardProtocol(DatagramProtocol):
                 )
             )
         except StopIteration:
-            log.error(
+            log.info(
                 f"Could not find matching public key for message from {src}: {data!r}"
             )
             return


### PR DESCRIPTION
## Proposed changes
This PR drops the log line for non-existent WireGuard devices from `ERROR` to `INFO` to reduce noise.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)


## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
