### PR TITLE
Expire inventoried assets

### DIFF
--- a/canarytokens/aws_infra/db_queries.py
+++ b/canarytokens/aws_infra/db_queries.py
@@ -1,0 +1,40 @@
+from canarytokens.canarydrop import Canarydrop
+from canarytokens.redismanager import DB
+from datetime import timedelta
+
+import json
+
+INVENTORY_EXPIRY = timedelta(hours=3).seconds  # 3 hours
+
+
+def _inventory_key(canarydrop: Canarydrop):
+    return f"{canarydrop.canarytoken.value()}_aws_inventoried_assets"
+
+
+def get_current_assets(canarydrop: Canarydrop) -> dict:
+    """
+    Retrieve the current assets inventoried for a given canarydrop.
+    Returns an empty dict if no assets are found.
+    :param canarydrop: The canarydrop instance for which to retrieve assets.
+    """
+    with DB.get_db() as r:
+        return json.loads(r.get(_inventory_key(canarydrop))) or {}
+
+
+def save_current_assets(canarydrop: Canarydrop, assets: dict) -> None:
+    """
+    Save the current assets inventoried for a given canarydrop.
+    :param canarydrop: The canarydrop instance for which to save assets.
+    :param assets: The inventoried assets to save.
+    """
+    with DB.get_db() as r:
+        r.set(_inventory_key(canarydrop), json.dumps(assets), ex=INVENTORY_EXPIRY)
+
+
+def delete_current_assets(canarydrop: Canarydrop) -> None:
+    """
+    Delete the current assets inventoried for a given canarydrop.
+    :param canarydrop: The canarydrop instance for which to delete assets.
+    """
+    with DB.get_db() as r:
+        r.delete(_inventory_key(canarydrop))

--- a/canarytokens/aws_infra/operations.py
+++ b/canarytokens/aws_infra/operations.py
@@ -28,6 +28,8 @@ from canarytokens.models import (
 from canarytokens.settings import FrontendSettings
 from canarytokens.tokens import Canarytoken
 
+from canarytokens.aws_infra.db_queries import delete_current_assets, save_current_assets
+
 settings = FrontendSettings()
 
 AWS_INFRA_AWS_ACCOUNT = settings.AWS_INFRA_AWS_ACCOUNT
@@ -238,15 +240,12 @@ def save_plan(canarydrop: Canarydrop, plan: str):
         }
     )
     queries.save_canarydrop(canarydrop)
+    # Clear inventory
+    delete_current_assets(canarydrop)
     variables = generate_tf_variables(canarydrop, plan)
     upload_tf_module(
         canarydrop.canarytoken.value(), canarydrop.aws_tf_module_prefix, variables
     )
-
-
-def save_current_assets(canarydrop: Canarydrop, assets: dict):
-    canarydrop.aws_inventoried_assets = json.dumps(assets)
-    queries.save_canarydrop(canarydrop)
 
 
 def get_canarydrop_from_handle(handle_id: str):

--- a/canarytokens/aws_infra/plan_generation.py
+++ b/canarytokens/aws_infra/plan_generation.py
@@ -2,6 +2,7 @@ import json
 import random
 import string
 
+from canarytokens.aws_infra.db_queries import get_current_assets
 from canarytokens.aws_infra.state_management import is_ingesting
 from canarytokens.canarydrop import Canarydrop
 from canarytokens.models import AWSInfraAssetType
@@ -290,7 +291,7 @@ def generate_proposed_plan(canarydrop: Canarydrop):
     """
 
     aws_deployed_assets = json.loads(canarydrop.aws_deployed_assets or "{}")
-    aws_inventoried_assets = json.loads(canarydrop.aws_inventoried_assets or "{}")
+    aws_inventoried_assets = get_current_assets(canarydrop)
     current_plan = json.loads(canarydrop.aws_saved_plan or "{}")
     proposed_plan = {
         "assets": {asset_type.value: [] for asset_type in AWSInfraAssetType}

--- a/canarytokens/canarydrop.py
+++ b/canarytokens/canarydrop.py
@@ -136,7 +136,6 @@ class Canarydrop(BaseModel):
     # AWS  infra specific stuff
     aws_customer_iam_access_external_id: Optional[str]
     aws_deployed_assets: Optional[str]
-    aws_inventoried_assets: Optional[str]
     aws_saved_plan: Optional[str]
     aws_tf_module_prefix: Optional[str]
     aws_infra_ingestion_bus_name: Optional[str]


### PR DESCRIPTION
## Proposed changes
We needn't store a customer AWS account's inventory permanently, this change automatically expires them after 3 hours and also deletes the inventory after a generated plan is saved.


## Types of changes
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
