### PR TITLE
Frontend update api manage endpoint

### DIFF
--- a/frontend_vue/src/api/awsInfra.ts
+++ b/frontend_vue/src/api/awsInfra.ts
@@ -39,8 +39,8 @@ export function requestAWSInfraRoleCheck({
   const params = {
     canarytoken,
     auth_token,
-    handle: handle || '',
-    external_id: external_id || '',
+    handle,
+    external_id,
   };
   return axios.post(url, { ...params }).then((response) => response);
 }

--- a/frontend_vue/src/api/awsInfra.ts
+++ b/frontend_vue/src/api/awsInfra.ts
@@ -5,6 +5,7 @@ type AWSInfraRequestPayload = {
   canarytoken?: string;
   auth_token?: string;
   handle?: string;
+  external_id?: string;
 };
 
 export function requestAWSInfraRoleSetupCommands(
@@ -18,16 +19,28 @@ export function requestAWSInfraRoleSetupCommands(
     .then((response) => response);
 }
 
+export function requestAWSInfraExternalIdSnippet({
+  canarytoken,
+  auth_token,
+}: AWSInfraRequestPayload) {
+  const url = '/d3aece8093b71007b5ccfedad91ebb11/awsinfra/management-response';
+  return axios
+    .post(url, { canarytoken, auth_token })
+    .then((response) => response);
+}
+
 export function requestAWSInfraRoleCheck({
   canarytoken,
   auth_token,
   handle,
+  external_id,
 }: AWSInfraRequestPayload) {
   const url = '/d3aece8093b71007b5ccfedad91ebb11/awsinfra/check-role';
   const params = {
     canarytoken,
     auth_token,
-    handle,
+    handle: handle || '',
+    external_id: external_id || '',
   };
   return axios.post(url, { ...params }).then((response) => response);
 }

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/ModalSetupRolePolicySnippet.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/ModalSetupRolePolicySnippet.vue
@@ -6,24 +6,6 @@
   >
     <template #default>
       <h2 class="mb-24 text-center">Run the AWS CLI command below</h2>
-      <!-- <template v-if="props.externalId">
-        <BaseLabelArrow
-          id="aws-snippet"
-          label="Copy AWS CLI snippet"
-          arrow-word-position="last"
-          arrow-variant="two"
-          class="z-10 text-right"
-        />
-        <BaseCodeSnippet
-          v-if="setupSnippetCommands"
-          id="aws-snippet"
-          lang="bash"
-          :code="setupSnippetCommands"
-          custom-height="120px"
-          class="wrap-code max-w-[100%]"
-        />
-      </template> -->
-
       <div class="place-self-center w-full">
         <Form
           class="flex flex-col justify-center items-center mb-24"
@@ -66,24 +48,24 @@
               class="wrap-code max-w-[100%]"
             />
           </template>
+          <div class="text-center flex mt-24 gap-8 items-center justify-center">
+            <p>What's this snippet doing?</p>
+            <button
+              v-tooltip="{
+                content: 'Check details',
+                triggers: ['hover'],
+              }"
+              class="w-24 h-24 text-sm duration-150 bg-transparent border border-solid rounded-full hover:text-white hover:bg-green-600 hover:border-green-300"
+              aria-label="What's this snippet doing?"
+              @click="handleShowModalInfoSnippet"
+            >
+              <font-awesome-icon
+                icon="question"
+                aria-hidden="true"
+              />
+            </button>
+          </div>
         </template>
-      </div>
-      <div class="text-center flex mt-24 gap-8 items-center justify-center">
-        <p>What's this snippet doing?</p>
-        <button
-          v-tooltip="{
-            content: 'Check details',
-            triggers: ['hover'],
-          }"
-          class="w-24 h-24 text-sm duration-150 bg-transparent border border-solid rounded-full hover:text-white hover:bg-green-600 hover:border-green-300"
-          aria-label="What's this snippet doing?"
-          @click="handleShowModalInfoSnippet"
-        >
-          <font-awesome-icon
-            icon="question"
-            aria-hidden="true"
-          />
-        </button>
       </div>
     </template>
     <template #footer>

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/ModalSetupRolePolicySnippet.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/ModalSetupRolePolicySnippet.vue
@@ -1,0 +1,166 @@
+<template>
+  <BaseModal
+    title="Restore Canarytoken IAM role and policy"
+    :has-close-button="true"
+    :content-class="`items-stretch`"
+  >
+    <template #default>
+      <h2 class="mb-24 text-center">Run the AWS CLI command below</h2>
+      <!-- <template v-if="props.externalId">
+        <BaseLabelArrow
+          id="aws-snippet"
+          label="Copy AWS CLI snippet"
+          arrow-word-position="last"
+          arrow-variant="two"
+          class="z-10 text-right"
+        />
+        <BaseCodeSnippet
+          v-if="setupSnippetCommands"
+          id="aws-snippet"
+          lang="bash"
+          :code="setupSnippetCommands"
+          custom-height="120px"
+          class="wrap-code max-w-[100%]"
+        />
+      </template> -->
+
+      <div class="place-self-center w-full">
+        <Form
+          class="flex flex-col justify-center items-center mb-24"
+          :validation-schema="schema"
+          :initial-values="initialValues"
+          @submit="handleGenerateSnippet"
+        >
+          <BaseFormTextField
+            id="external_id"
+            label="Add here your External ID"
+            placeholder="e.g. abCd7Lb6cEZrMCEm3OAoj"
+            required
+            :has-arrow="true"
+            arrow-variant="one"
+            :arrow-word-position="2"
+            class="flex-grow min-w-[300px]"
+          />
+          <BaseButton type="submit">Generate Snippet</BaseButton>
+        </Form>
+        <template v-if="showSnippet">
+          <BaseSkeletonLoader
+            v-if="isLoading"
+            class="mt-24 h-[10svh] w-full"
+          />
+          <template v-else>
+            <div class="text-right">
+              <BaseLabelArrow
+                id="aws-snippet"
+                label="Copy AWS CLI snippet"
+                arrow-word-position="last"
+                arrow-variant="two"
+                class="z-10"
+              />
+            </div>
+            <BaseCodeSnippet
+              id="aws-snippet"
+              lang="bash"
+              :code="setupSnippetCommands"
+              custom-height="120px"
+              class="wrap-code max-w-[100%]"
+            />
+          </template>
+        </template>
+      </div>
+      <div class="text-center flex mt-24 gap-8 items-center justify-center">
+        <p>What's this snippet doing?</p>
+        <button
+          v-tooltip="{
+            content: 'Check details',
+            triggers: ['hover'],
+          }"
+          class="w-24 h-24 text-sm duration-150 bg-transparent border border-solid rounded-full hover:text-white hover:bg-green-600 hover:border-green-300"
+          aria-label="What's this snippet doing?"
+          @click="handleShowModalInfoSnippet"
+        >
+          <font-awesome-icon
+            icon="question"
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+    </template>
+    <template #footer>
+      <BaseButton
+        variant="secondary"
+        @click="closeModal"
+        >Done</BaseButton
+      >
+    </template>
+  </BaseModal>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref, defineAsyncComponent } from 'vue';
+import * as Yup from 'yup';
+import { Form } from 'vee-validate';
+import type { GenericObject } from 'vee-validate';
+import { useModal } from 'vue-final-modal';
+import { policyDocument } from '@/components/tokens/aws_infra/constants.ts';
+
+const ModalInfoSnippet = defineAsyncComponent(
+  () => import('./ModalInfoSnippet.vue')
+);
+
+const props = defineProps<{
+  closeModal: () => void;
+  roleName: string;
+  externalId: string;
+  managementAwsAccount: string;
+  accountNumber: string;
+}>();
+
+const emits = defineEmits(['updateExternalId']);
+
+const newExternalId = ref('');
+const showSnippet = ref(false);
+const isLoading = ref(false);
+
+const initialValues = {
+  external_id: props.externalId || '',
+};
+
+const setupSnippetCommands = computed(() => {
+  const externalIdSnippet = props.externalId || newExternalId.value;
+
+  return `aws iam create-role --no-cli-pager --role-name ${props.roleName} --assume-role-policy-document \'{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": {"AWS": "arn:aws:sts::${props.managementAwsAccount}:assumed-role/InventoryManagerRole/${externalIdSnippet}"}, "Action": "sts:AssumeRole", "Condition": {"StringEquals": {"sts:ExternalId": "${externalIdSnippet}"}}}]}\'
+
+aws iam create-policy --no-cli-pager --policy-name Canarytokens-Inventory-ReadOnly-Policy --policy-document \'${policyDocument}\'
+
+aws iam attach-role-policy --role-name ${props.roleName} --policy-arn arn:aws:iam::${props.accountNumber}:policy/Canarytokens-Inventory-ReadOnly-Policy
+`;
+});
+
+const schema = Yup.object().shape({
+  external_id: Yup.string().required('The external ID is required'),
+});
+
+function handleGenerateSnippet(values: GenericObject) {
+  newExternalId.value = values.external_id;
+
+  if (newExternalId.value) {
+    showSnippet.value = true;
+    isLoading.value = true;
+    emits('updateExternalId', newExternalId.value);
+    setTimeout(() => {
+      isLoading.value = false;
+    }, 2000);
+  }
+}
+
+function handleShowModalInfoSnippet() {
+  const { open, close } = useModal({
+    component: ModalInfoSnippet,
+    attrs: {
+      closeModal: () => close(),
+    },
+  });
+  open();
+}
+</script>

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/useFetchUserAccount.ts
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/useFetchUserAccount.ts
@@ -39,6 +39,7 @@ export function useFetchUserAccount(
       if (res.status !== 200) {
         stateStatus.value = StepStateEnum.ERROR;
         errorMessage.value = res.data.message;
+        return;
       }
 
       const handle = res.data.handle;
@@ -48,17 +49,20 @@ export function useFetchUserAccount(
 
       const pollInfraRoleCheck = async () => {
         try {
-          const resWithHandle = await requestAWSInfraRoleCheck({ handle });
+          const resWithHandle = await requestAWSInfraRoleCheck({
+            handle,
+            external_id: externalId.value,
+          });
 
           if (resWithHandle.data.error && retryAttempts < MAX_RETRIES) {
             retryAttempts++;
             console.log(
               `Retrying AWS Infra Role Check (${retryAttempts}/${MAX_RETRIES})`
             );
-            setTimeout(() => {
-              clearInterval(pollingRoleInterval);
-              pollInfraRoleCheck();
-            }, POLL_INTERVAL);
+            // setTimeout(() => {
+            //   clearInterval(pollingRoleInterval);
+            //   pollInfraRoleCheck();
+            // }, POLL_INTERVAL);
             return;
           }
 
@@ -123,6 +127,7 @@ export function useFetchUserAccount(
       if (res.status !== 200) {
         stateStatus.value = StepStateEnum.ERROR;
         errorMessage.value = res.data.error_message;
+        return;
       }
 
       const handle = res.data.handle;

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/useFetchUserAccount.ts
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/useFetchUserAccount.ts
@@ -1,14 +1,20 @@
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
+import type { Ref } from 'vue';
 import {
   requestAWSInfraRoleCheck,
   requestInventoryCustomerAccount,
 } from '@/api/awsInfra.ts';
 import { StepStateEnum } from '@/components/tokens/aws_infra/useStepState.ts';
 
-export function useFetchUserAccount(canarytoken: string, auth_token: string) {
+export function useFetchUserAccount(
+  canarytoken: string,
+  auth_token: string,
+  external_id?: Ref<string>
+) {
   const errorMessage = ref('');
   const stateStatus = ref<StepStateEnum>();
   const proposedPlan = ref<any>(null);
+  const externalId = ref(external_id || '');
 
   const POLL_INTERVAL = 2000;
   // If the first attempts fails, it could depend on the AWS account still being set up
@@ -28,6 +34,7 @@ export function useFetchUserAccount(canarytoken: string, auth_token: string) {
       const res = await requestAWSInfraRoleCheck({
         canarytoken,
         auth_token,
+        external_id: externalId.value || '',
       });
       if (res.status !== 200) {
         stateStatus.value = StepStateEnum.ERROR;
@@ -177,6 +184,13 @@ export function useFetchUserAccount(canarytoken: string, auth_token: string) {
       errorMessage.value = err.message;
     }
   }
+
+  watch(
+    () => external_id,
+    (newValue) => {
+      externalId.value = newValue || '';
+    }
+  );
 
   return {
     errorMessage,

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/useFetchUserAccount.ts
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/useFetchUserAccount.ts
@@ -51,7 +51,7 @@ export function useFetchUserAccount(
         try {
           const resWithHandle = await requestAWSInfraRoleCheck({
             handle,
-            external_id: externalId.value,
+            // external_id: externalId.value,
           });
 
           if (resWithHandle.data.error && retryAttempts < MAX_RETRIES) {

--- a/frontend_vue/src/components/tokens/aws_infra/types.ts
+++ b/frontend_vue/src/components/tokens/aws_infra/types.ts
@@ -55,6 +55,8 @@ type TokenSetupData = {
   code_snippet_command?: string;
   role_name?: string;
   external_id?: string;
+  aws_account?: string;
+  aws_account_number?: string;
 };
 
 export type {

--- a/frontend_vue/src/components/tokens/aws_infra/types.ts
+++ b/frontend_vue/src/components/tokens/aws_infra/types.ts
@@ -44,8 +44,7 @@ type AssetData =
   | SecretsManagerSecretData
   | SSMParameterData
   | SQSQueueData
-  | S3BucketData
-
+  | S3BucketData;
 
 type TokenSetupData = {
   token: string;
@@ -54,8 +53,9 @@ type TokenSetupData = {
     assets: ProposedAWSInfraTokenPlanData;
   };
   code_snippet_command?: string;
+  role_name?: string;
+  external_id?: string;
 };
-
 
 export type {
   AssetData,
@@ -66,5 +66,5 @@ export type {
   SecretsManagerSecretData,
   DynamoDBTableData,
   TokenSetupData,
-  ProposedAWSInfraTokenPlanData
+  ProposedAWSInfraTokenPlanData,
 };


### PR DESCRIPTION
## Proposed changes

Update the /manage wizard first step.
Unlike the token creation, this page requires the user to add an external ID related to their account in order to proceed.

Fix the Check Permission page
Add a modal to generate a new Role and Policy snippet, in case the user removed them

## How to test
Check on slack discussion