### PR TITLE
Frontend update api update polling

### DIFF
--- a/frontend_vue/src/components/tokens/aws_infra/history/IncidentList.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/history/IncidentList.vue
@@ -55,7 +55,7 @@ import type {
   AdditionalInfoType,
 } from '@/components/tokens/types.ts';
 import { AssetTypesEnum } from '@/components/tokens/aws_infra/constants.ts';
-import { getAssetLabel } from '@/components/tokens/aws_infra/assetService.ts';
+import { getAssetLabel } from '@/components/tokens/aws_infra/plan_generator/assetService.ts';
 import { convertUnixTimeStampToDate } from '@/utils/utils';
 import IncidentCardAsset from '@/components/tokens/aws_infra/history/IncidentCardAsset.vue';
 import CardIncident from '@/components/ui/CardIncident.vue';

--- a/frontend_vue/src/components/tokens/aws_infra/history/SelectIncidentType.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/history/SelectIncidentType.vue
@@ -53,7 +53,7 @@
 import { ref, computed, onMounted } from 'vue';
 import getImageUrl from '@/utils/getImageUrl';
 import type { HitsType } from '@/components/tokens/types.ts';
-import { getAssetLabel } from '@/components/tokens/aws_infra/assetService.ts';
+import { getAssetLabel } from '@/components/tokens/aws_infra/plan_generator/assetService.ts';
 import {
   AssetTypesEnum,
 } from '@/components/tokens/aws_infra/constants.ts';


### PR DESCRIPTION
## Proposed changes

The previous code used set-interval to retry the API calls every 2 seconds for check-role and inventory, regardless of the response.
These changes fix the code so that we wait for the response and retry after a set interval if an error occurs.
The set interval should give time for the server to provide the correct data.

## How to test
Generate a new token
Run the AWS cli snippet
Click 'proceed'
You should see max 5 call attempts for /check-role or /inventory