### PR TITLE
Fix terraform poll + disable Save Plan button on loading

### DIFF
--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
@@ -31,8 +31,10 @@
       <BaseMessageBox
         variant="success"
         class="mb-24"
-        >We analyzed your AWS account. Below are the recommended decoys that have been generated to match your environment for each asset.
-        You can review or edit anything before we generate your canarytoken.</BaseMessageBox
+        >We analyzed your AWS account. Below are the recommended decoys that
+        have been generated to match your environment for each asset. You can
+        review or edit anything before we generate your
+        canarytoken.</BaseMessageBox
       >
       <BaseMessageBox
         v-if="isErrorMessage"
@@ -64,6 +66,7 @@
     <div class="flex flex-col items-center mt-32">
       <BaseButton
         :loading="isSavingPlan"
+        :disabled="getAnyLoadingAssetData()"
         @click="handleSubmit(proposed_plan)"
         >{{ isSavingPlan ? 'Saving...' : 'Save configuration' }}</BaseButton
       >
@@ -176,6 +179,10 @@ const assetWithMissingPermissionText = computed(() => {
 
 function getIsLoadingAssetData(assetType: AssetTypesEnum): boolean {
   return isLoadingAssetCard.value[assetType] || false;
+}
+
+function getAnyLoadingAssetData(): boolean {
+  return Object.values(isLoadingAssetCard.value).some((loading) => loading);
 }
 
 function handleDeleteAsset(assetType: AssetTypesEnum, index: number) {
@@ -301,8 +308,10 @@ async function handleSavePlan(formValues: { assets: AssetData[] | null }) {
     emits('updateStep');
   } catch (err: any) {
     isSaveError.value = true;
-    isSaveErrorMessage.value = err.response?.data?.message ||
-      err.message || 'We couldn`t save the plan. Please, try again';
+    isSaveErrorMessage.value =
+      err.response?.data?.message ||
+      err.message ||
+      'We couldn`t save the plan. Please, try again';
     isSaveSuccess.value = false;
   } finally {
     isSavingPlan.value = false;

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateTerraformSnippet.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateTerraformSnippet.vue
@@ -276,23 +276,16 @@ async function handleRequestTerraformSnippet() {
             'An error occurred while generating your Terraform Snippet. Try again';
           return;
         }
-        console.log(
-          `Retrying requesting the Terraform Snippet (${retryAttempts}/${MAX_RETRIES})`
-        );
 
-        stateStatus.value = StepStateEnum.ERROR;
-        errorMessage.value =
-          err.response?.data?.message ||
-          err.message ||
-          'An error occurred while generating your Terraform Snippet. Try again';
-        return;
+        setTimeout(() => {
+          console.log(
+            `Retrying requesting the Terraform Snippet (${retryAttempts}/${MAX_RETRIES})`
+          );
+          retryAttempts++;
+          pollTerraformSnippet();
+        }, POLL_INTERVAL);
       }
     };
-
-    setTimeout(() => {
-      retryAttempts++;
-      pollTerraformSnippet();
-    }, POLL_INTERVAL);
 
     await pollTerraformSnippet();
   } catch (err: any) {


### PR DESCRIPTION
## Proposed changes

- Refactor the poll mechanism for the Terraform snippet, aligning it to the /check-role and inventory
- Disable "Save Configuration" when the Plan is still loading ( Trying to proceed would cause an error )

# Test
Create a new token
The button should be disabled on Plan Loading (step 2)
The last step should display the Terraform module as before, as expected