### PR TITLE
Add AI generated name count tracker

### DIFF
--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetForm.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetForm.vue
@@ -31,6 +31,11 @@
           :label="getFieldLabel(props.assetType, key)"
           :field-type="key"
           :asset-type="props.assetType"
+          @update-ai-available-names-count="
+            (count) => {
+              emit('updateAiAvailableNamesCount', count);
+            }
+          "
         />
       </template>
     </div>
@@ -43,9 +48,7 @@ import type { Ref } from 'vue';
 import { Form, FieldArray } from 'vee-validate';
 import type { GenericObject } from 'vee-validate';
 import type { AssetData } from '../types';
-import {
-  AssetTypesEnum,
-} from '@/components/tokens/aws_infra/constants.ts';
+import { AssetTypesEnum } from '@/components/tokens/aws_infra/constants.ts';
 import AssetTextField from '@/components/tokens/aws_infra/plan_generator/AssetTextField.vue';
 import { getFieldLabel } from '@/components/tokens/aws_infra/plan_generator/assetService.ts';
 import AssetFormArray from '@/components/tokens/aws_infra/plan_generator/AssetFormArray.vue';
@@ -58,7 +61,11 @@ const props = defineProps<{
   triggerCancel: boolean;
 }>();
 
-const emits = defineEmits(['update-asset', 'invalid-submit']);
+const emit = defineEmits([
+  'update-asset',
+  'invalid-submit',
+  'updateAiAvailableNamesCount',
+]);
 const initialValues = ref({});
 const formAssetRef: Ref<HTMLFormElement | null> = ref(null);
 const tempFields: Ref<AssetData | []> = ref([]);
@@ -70,11 +77,11 @@ onMounted(() => {
 });
 
 function onSubmit(values: GenericObject) {
-  emits('update-asset', values);
+  emit('update-asset', values);
 }
 
 function onInvalidSubmit(values: any) {
-  emits('invalid-submit', values);
+  emit('invalid-submit', values);
 }
 
 function handleProgramaticSubmit() {
@@ -84,7 +91,7 @@ function handleProgramaticSubmit() {
 }
 
 function handleRestoreFields() {
-  emits('update-asset', tempFields);
+  emit('update-asset', tempFields);
 }
 
 watch(

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetFormArray.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetFormArray.vue
@@ -51,15 +51,15 @@
 
 <script setup lang="ts">
 import { ref } from 'vue';
-import {
-  AssetTypesEnum,
-} from '@/components/tokens/aws_infra/constants.ts';
+import { AssetTypesEnum } from '@/components/tokens/aws_infra/constants.ts';
 import getImageUrl from '@/utils/getImageUrl';
 import type { AssetData } from '../types';
 import { getFieldLabel } from '@/components/tokens/aws_infra/plan_generator/assetService.ts';
 import { useGenerateAssetName } from '@/components/tokens/aws_infra/plan_generator/useGenerateAssetName.ts';
 import AssetFormPagination from '@/components/tokens/aws_infra/plan_generator/AssetFormPagination.vue';
 import AssetTextField from '@/components/tokens/aws_infra/plan_generator/AssetTextField.vue';
+
+const emit = defineEmits(['updateAiAvailableNamesCount']);
 
 const props = defineProps<{
   assetType: AssetTypesEnum;
@@ -84,7 +84,9 @@ async function handleAddItem() {
     isGenerateNameError,
     isGenerateNameLoading,
     generatedName,
-  } = useGenerateAssetName(props.assetType, props.assetKey);
+  } = useGenerateAssetName(props.assetType, props.assetKey, (count: number) => {
+    emit('updateAiAvailableNamesCount', count);
+  });
 
   isLoading.value = isGenerateNameLoading.value;
   await handleGenerateName();

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetTextField.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetTextField.vue
@@ -120,6 +120,7 @@ const emit = defineEmits([
   'update:modelValue',
   'handleRemoveInstance',
   'handleRegenerateInstance',
+  'updateAiAvailableNamesCount',
 ]);
 const id = toRef(props, 'id');
 const { value, handleChange, errorMessage, resetField } = useField(
@@ -143,7 +144,13 @@ async function handleGenerateValue() {
     isGenerateNameError,
     isGenerateNameLoading,
     generatedName,
-  } = useGenerateAssetName(props.assetType, props.fieldType);
+  } = useGenerateAssetName(
+    props.assetType,
+    props.fieldType,
+    (count: number) => {
+      emit('updateAiAvailableNamesCount', count);
+    }
+  );
 
   isGenerateValueLoading.value = isGenerateNameLoading.value;
   await handleGenerateName();

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
@@ -70,6 +70,11 @@
           handleUpdateAsset(values);
         }
       "
+      @update-ai-available-names-count="
+        (count) => {
+          emit('update-ai-available-names-count', count);
+        }
+      "
     />
     <template #footer>
       <BaseButton
@@ -99,14 +104,13 @@
 
 <script setup lang="ts">
 import { ref, nextTick, computed } from 'vue';
-import {
-  AssetTypesEnum,
-} from '@/components/tokens/aws_infra/constants.ts';
+import { AssetTypesEnum } from '@/components/tokens/aws_infra/constants.ts';
 import type { ComputedRef } from 'vue';
-import type {
-  AssetData,
-} from '../types';
-import { getAssetLabel, getAssetDefaultValues } from '@/components/tokens/aws_infra/plan_generator/assetService.ts';
+import type { AssetData } from '../types';
+import {
+  getAssetLabel,
+  getAssetDefaultValues,
+} from '@/components/tokens/aws_infra/plan_generator/assetService.ts';
 import { useGenerateAssetName } from '@/components/tokens/aws_infra/plan_generator/useGenerateAssetName.ts';
 import ModalAssetContentList from './ModalAssetContentList.vue';
 import ModalAssetContentItem from './ModalAssetContentItem.vue';
@@ -117,7 +121,12 @@ const props = defineProps<{
   closeModal: () => void;
 }>();
 
-const emit = defineEmits(['update-asset', 'delete-asset', 'add-asset']);
+const emit = defineEmits([
+  'update-asset',
+  'delete-asset',
+  'add-asset',
+  'update-ai-available-names-count',
+]);
 const showAssetDetails = ref(false);
 const selectedAssetDetails = ref({
   assetType: '',
@@ -135,7 +144,9 @@ const currentAssetData = computed(() => {
 });
 
 const isEmptyAssetData = computed(() => {
-  return Array.isArray(currentAssetData.value) && currentAssetData.value.length === 0;
+  return (
+    Array.isArray(currentAssetData.value) && currentAssetData.value.length === 0
+  );
 });
 
 const assetLabel = computed(() => getAssetLabel(props.assetType));
@@ -145,7 +156,6 @@ const subtitle = computed(() => {
     ? `We generated names for your ${assetLabel.value} is based on your current deployment.`
     : `You can add new decoys to your ${assetLabel.value} list.`;
 });
-
 
 function handleShowAssetDetails(selectedItem: AssetData, index: number) {
   isErrorMessage.value = '';
@@ -170,7 +180,7 @@ function handleUpdateAsset(values: any) {
 }
 
 async function handleAddNewAsset() {
-  const newAssetFields = () => getAssetDefaultValues(props.assetType)
+  const newAssetFields = () => getAssetDefaultValues(props.assetType);
 
   const newAssetValues: Record<string, any> = { ...newAssetFields() };
 
@@ -189,7 +199,9 @@ async function handleAddNewAsset() {
             isGenerateNameError,
             isGenerateNameLoading,
             generatedName,
-          } = useGenerateAssetName(props.assetType, key);
+          } = useGenerateAssetName(props.assetType, key, (count: number) => {
+            emit('update-ai-available-names-count', count);
+          });
 
           isLoading.value = isGenerateNameLoading.value;
           await handleGenerateName();

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAssetContentItem.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAssetContentItem.vue
@@ -10,6 +10,11 @@
       :trigger-cancel="props.triggerCancel"
       @update-asset="handleUpdateAsset"
       @invalid-submit="handleInvalidSubmit"
+      @update-ai-available-names-count="
+        (count) => {
+          emit('update-ai-available-names-count', count);
+        }
+      "
     />
   </div>
 </template>
@@ -35,10 +40,10 @@ const props = defineProps<{
   triggerCancel: boolean;
 }>();
 
-const emits = defineEmits(['update-asset']);
+const emit = defineEmits(['update-asset', 'update-ai-available-names-count']);
 
 function handleUpdateAsset(values: any) {
-  emits('update-asset', values);
+  emit('update-asset', values);
 }
 
 function handleInvalidSubmit() {

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
@@ -6,7 +6,7 @@
       <div
         class="flex flex-row items-center md:justify-end gap-16 justify-center"
       >
-        <p>AI Generated Names</p>
+        <p>Name generation requests left</p>
         <BaseSkeletonLoader
           v-if="getAnyLoadingAssetData()"
           class="w-[2.5rem] h-[2.5rem]"
@@ -23,9 +23,9 @@
           role="progressbar"
           :aria-valuemax="aiNameCountState.total"
           aria-valuemin="0"
-          :aria-valuenow="aiNameCountState.current"
+          :aria-valuenow="aiNameCountState.available"
         >
-          <span>{{ aiNameCountState.total - aiNameCountState.current }} </span>
+          <span>{{ aiNameCountState.available }} </span>
         </div>
       </div>
     </div>
@@ -156,8 +156,8 @@ const isLoadingAssetCard = ref<Record<AssetTypesEnum, boolean>>({
 });
 const isAiGenerateErrorMessage = ref('');
 const aiNameCountState = ref({
-  total: NaN,
-  current: 0,
+  total: 0,
+  available: 0,
 });
 
 const assetsData = ref<ProposedAWSInfraTokenPlanData>({
@@ -177,7 +177,7 @@ onMounted(() => {
     isLoadingUI.value = false;
     aiNameCountState.value = props.currentStepData?.ai_name_state || {
       total: NaN,
-      current: 0,
+      available: 0,
     };
     return;
   }
@@ -192,26 +192,33 @@ onMounted(() => {
 
 const styleAiNameCountProgressBar = computed(() => {
   const total = aiNameCountState.value.total;
-  const current = aiNameCountState.value.current;
+  const available = aiNameCountState.value.available;
   const progress =
-    total && !isNaN(total)
-      ? Math.min(((total - current) / total) * 100, 100)
-      : 0;
+    total && !isNaN(total) ? Math.min((available / total) * 100, 100) : 0;
+  // if (progress > 70) {
+  //   // Red state
+  //   return `--bar-color: #ef4444; --progress: ${progress}%;`;
+  // } else if (progress > 50) {
+  //   // Warning state
+  //   return `--bar-color: #eab308; --progress: ${progress}%;`;
+  // }
+  // // Green state
+  // return ` --bar-color: #22c55e; --progress: ${progress}%;`;
 
   if (progress > 70) {
-    // Red state
-    return `--bar-color: #ef4444; --progress: ${progress}%;`;
+    // Red state (should be green)
+    return `--bar-color: #22c55e; --progress: ${progress}%;`;
   } else if (progress > 50) {
     // Warning state
     return `--bar-color: #eab308; --progress: ${progress}%;`;
   }
-  // Green state
-  return ` --bar-color: #22c55e; --progress: ${progress}%;`;
+  // Green state (should be red)
+  return `--bar-color: #ef4444; --progress: ${progress}%;`;
 });
 
 const aiCurrentAvailableNamesCountTootlip = computed(() => {
-  return aiNameCountState.value.current > 0
-    ? `We generate decoy names with AI. You have ${aiNameCountState.value.current} names available out of ${aiNameCountState.value.total}.`
+  return aiNameCountState.value.available > 0
+    ? `We generate decoy names with AI. You have ${aiNameCountState.value.available} names available out of ${aiNameCountState.value.total}.`
     : 'You have reached your limit for generated names. You can continue with manual setup.';
 });
 
@@ -251,11 +258,11 @@ function getAnyLoadingAssetData(): boolean {
 }
 
 function updateAiCurrentAvailableNamesCount(count: number) {
-  if (isNaN(aiNameCountState.value.total)) {
-    aiNameCountState.value.current = count;
+  if (aiNameCountState.value.total === 0) {
+    aiNameCountState.value.available = Math.floor(count) || 0;
     return;
   }
-  aiNameCountState.value.current = Math.floor(count) || 0;
+  aiNameCountState.value.available = Math.floor(count) || 0;
 }
 
 function handleDeleteAsset(assetType: AssetTypesEnum, index: number) {

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
@@ -193,26 +193,12 @@ onMounted(() => {
 const styleAiNameCountProgressBar = computed(() => {
   const total = aiNameCountState.value.total;
   const available = aiNameCountState.value.available;
-  const progress =
-    total && !isNaN(total) ? Math.min((available / total) * 100, 100) : 0;
-  // if (progress > 70) {
-  //   // Red state
-  //   return `--bar-color: #ef4444; --progress: ${progress}%;`;
-  // } else if (progress > 50) {
-  //   // Warning state
-  //   return `--bar-color: #eab308; --progress: ${progress}%;`;
-  // }
-  // // Green state
-  // return ` --bar-color: #22c55e; --progress: ${progress}%;`;
-
+  const progress = total ? Math.min((available / total) * 100, 100) : 0;
   if (progress > 70) {
-    // Red state (should be green)
     return `--bar-color: #22c55e; --progress: ${progress}%;`;
-  } else if (progress > 50) {
-    // Warning state
+  } else if (progress > 40) {
     return `--bar-color: #eab308; --progress: ${progress}%;`;
   }
-  // Green state (should be red)
   return `--bar-color: #ef4444; --progress: ${progress}%;`;
 });
 

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
@@ -176,7 +176,7 @@ onMounted(() => {
       .proposed_plan as ProposedAWSInfraTokenPlanData;
     isLoadingUI.value = false;
     aiNameCountState.value = props.currentStepData?.ai_name_state || {
-      total: NaN,
+      total: 0,
       available: 0,
     };
     return;

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
@@ -136,8 +136,6 @@ const props = defineProps<{
 const {
   token,
   auth_token,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  code_snippet_command,
   proposed_plan,
 } = props.initialStepData;
 

--- a/frontend_vue/src/components/tokens/aws_infra/types.ts
+++ b/frontend_vue/src/components/tokens/aws_infra/types.ts
@@ -53,7 +53,7 @@ type TokenSetupData = {
   aws_account_number?: string;
   ai_name_state?: {
     total: number;
-    current: number;
+    available: number;
   };
 };
 

--- a/frontend_vue/src/components/tokens/aws_infra/types.ts
+++ b/frontend_vue/src/components/tokens/aws_infra/types.ts
@@ -51,6 +51,10 @@ type TokenSetupData = {
   external_id?: string;
   aws_account?: string;
   aws_account_number?: string;
+  ai_name_state?: {
+    total: number;
+    current: number;
+  };
 };
 
 export type {

--- a/frontend_vue/src/views/PlanPreview.vue
+++ b/frontend_vue/src/views/PlanPreview.vue
@@ -53,3 +53,15 @@ function handleSelectOption(value) {
   selectedPlanKey.value++;
 }
 </script>
+
+<style>
+.infra-token__title-wrapper {
+  margin-top: 1rem;
+  margin-bottom: 1.5rem;
+
+  h2 {
+    font-size: 2rem;
+    text-align: center;
+  }
+}
+</style>


### PR DESCRIPTION
## Proposed changes

This update introduces a new UI element to track a user's AI asset generation quota. The UI element is displayed when a user first loads their plan and will be updated dynamically as they generate new asset names.

The UI element has three distinct states to provide clear feedback to the user:
- ok ( less than 70% quota used )
- warning ( more than 40 % )
- alert ( less than 40 %) 

<img width="459" height="93" alt="Screenshot 2025-07-31 at 18 04 57" src="https://github.com/user-attachments/assets/00cdf9fa-cd60-4c47-8d37-7e00a5bcdeaa" />
<img width="402" height="97" alt="Screenshot 2025-07-31 at 18 05 40" src="https://github.com/user-attachments/assets/dc9ac319-c75b-4162-a2ce-43d894bd4e02" />
<img width="395" height="93" alt="Screenshot 2025-07-31 at 18 05 50" src="https://github.com/user-attachments/assets/194af761-08ed-44db-8398-6dd5c096bd93" />


## How to test
Generate a new token
Once on step 2 to generate a plan, you should see the counter decreasing every time a new asset is generated