### PR TITLE
Check parent asset name for AI name generation on child element

### DIFF
--- a/frontend_vue/src/api/awsInfra.ts
+++ b/frontend_vue/src/api/awsInfra.ts
@@ -77,7 +77,8 @@ export function generateDataChoice(
   canarytoken: string,
   auth_token: string,
   asset_type: string,
-  asset_field: string
+  asset_field: string,
+  parent_asset_name: string = ''
 ) {
   const url =
     '/d3aece8093b71007b5ccfedad91ebb11/awsinfra/generate-data-choices';
@@ -86,6 +87,7 @@ export function generateDataChoice(
     auth_token,
     asset_type,
     asset_field,
+    parent_asset_name,
   };
   return axios.post(url, { ...params }).then((response) => response);
 }

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetForm.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetForm.vue
@@ -19,6 +19,7 @@
             :asset-type="props.assetType"
             :asset-key="key"
             :fields="fields"
+            :parent-asset-name="parentAssetName"
             :prepend="prepend"
             :remove="remove"
           />
@@ -38,7 +39,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, onMounted } from 'vue';
+import { ref, watch, onMounted, computed } from 'vue';
 import type { Ref } from 'vue';
 import { Form, FieldArray } from 'vee-validate';
 import type { GenericObject } from 'vee-validate';
@@ -47,7 +48,7 @@ import {
   AssetTypesEnum,
 } from '@/components/tokens/aws_infra/constants.ts';
 import AssetTextField from '@/components/tokens/aws_infra/plan_generator/AssetTextField.vue';
-import { getFieldLabel } from '@/components/tokens/aws_infra/plan_generator/assetService.ts';
+import { getFieldLabel, getAssetNameKey } from '@/components/tokens/aws_infra/plan_generator/assetService.ts';
 import AssetFormArray from '@/components/tokens/aws_infra/plan_generator/AssetFormArray.vue';
 
 const props = defineProps<{
@@ -68,6 +69,11 @@ onMounted(() => {
   const firstInput = formAssetRef.value?.$el.getElementsByTagName('input')[0];
   firstInput.focus();
 });
+
+const parentAssetName = computed(():string => {
+  const assetNameKey = getAssetNameKey(props.assetType) as keyof AssetData;
+  return String(props.assetData[assetNameKey]) || '';
+})
 
 function onSubmit(values: GenericObject) {
   emits('update-asset', values);

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetFormArray.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetFormArray.vue
@@ -65,6 +65,7 @@ const props = defineProps<{
   assetType: AssetTypesEnum;
   assetKey: keyof AssetData;
   fields: any;
+  parentAssetName: string;
   prepend: (value: any) => void;
   remove: (value: number) => void;
 }>();
@@ -75,6 +76,7 @@ const isErrorMessage = ref('');
 function iconURL() {
   return getImageUrl(`aws_infra_icons/${props.assetKey}.svg`);
 }
+
 async function handleAddItem() {
   isLoading.value = true;
   isErrorMessage.value = '';
@@ -87,7 +89,7 @@ async function handleAddItem() {
   } = useGenerateAssetName(props.assetType, props.assetKey);
 
   isLoading.value = isGenerateNameLoading.value;
-  await handleGenerateName();
+  await handleGenerateName(props.parentAssetName);
   isErrorMessage.value = isGenerateNameError.value;
   if (isErrorMessage.value) {
     isLoading.value = false;

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/useGenerateAssetName.ts
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/useGenerateAssetName.ts
@@ -27,7 +27,7 @@ export function useGenerateAssetName(
 
   const isPreviewMode = window.location.pathname.includes('/nest/plan-preview');
 
-  async function handleGenerateName() {
+  async function handleGenerateName(parentAssetName: string = '') {
     if (isPreviewMode) {
       const res = await generateDataChoiceTest()
       //@ts-ignore
@@ -40,7 +40,8 @@ export function useGenerateAssetName(
         tokenId.value,
         authId.value,
         assetType,
-        fieldType
+        fieldType,
+        parentAssetName
       );
       if (!res.data.result) {
         isGenerateNameError.value = res.data.message;


### PR DESCRIPTION
## Proposed changes

When generating a name for a child asset ( as table_items and object ), send the parent name in the request to generate a meaningful AI answer

# Test
Pull the branch
When you are in step 2 ( generate plan ), add new table items for the DynamoDB and objects for the S3bucekts.
The names of the new instances should be related to the asset's main name.
i.e. Bucket names "Finance-something-something" should expect object values as "Stock-market-something" or "Income-something"
