### PR TITLE
Temporary fix for waiting account to be set

### DIFF
--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateAwsSnippet.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateAwsSnippet.vue
@@ -125,12 +125,14 @@
           </BaseMessageBox>
           <BaseButton
             v-if="!showWarningSnipeptCheck"
+            :loading="isWaitingForSetup"
             @click="handleGoToNextStep"
           >
             Continue
           </BaseButton>
           <BaseButton
             v-if="showWarningSnipeptCheck"
+            :loading="isWaitingForSetup"
             @click="handleGoToNextStep"
           >
             I Ran the Command, Continue
@@ -199,6 +201,8 @@ const { token, auth_token, aws_region, aws_account_number } =
 
 const stateStatus = ref<StepStateEnum>(StepStateEnum.LOADING);
 const errorMessage = ref('');
+// TODO: Remove when the lambda is fixed to handle the poll correctly
+const isWaitingForSetup = ref(false);
 
 const { isLoading, isError } = useStepState(stateStatus);
 const {
@@ -310,7 +314,13 @@ async function handleGoToNextStep() {
     isSnippedChecked.value = true;
   } else {
     showWarningSnipeptCheck.value = false;
-    await handleFetchUserAccount();
+    isWaitingForSetup.value = true;
+    // TODO: Remove when the lambda is fixed to handle the poll correctly
+    // Forces waiting time expected for the AWS account to be ready
+    setTimeout(async () => {
+      isWaitingForSetup.value = false;
+      await handleFetchUserAccount();
+    }, 3500);
   }
 }
 

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateAwsSnippet.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateAwsSnippet.vue
@@ -201,7 +201,7 @@ const { token, auth_token, aws_region, aws_account_number } =
 
 const stateStatus = ref<StepStateEnum>(StepStateEnum.LOADING);
 const errorMessage = ref('');
-// TODO: Remove when the lambda is fixed to handle the poll correctly
+// TODO: Remove when we clarify why the polling is not working correctly
 const isWaitingForSetup = ref(false);
 
 const { isLoading, isError } = useStepState(stateStatus);
@@ -315,7 +315,7 @@ async function handleGoToNextStep() {
   } else {
     showWarningSnipeptCheck.value = false;
     isWaitingForSetup.value = true;
-    // TODO: Remove when the lambda is fixed to handle the poll correctly
+    // TODO: Remove when we clarify why the polling is not working correctly
     // Forces waiting time expected for the AWS account to be ready
     setTimeout(async () => {
       isWaitingForSetup.value = false;


### PR DESCRIPTION
## Proposed changes

This update addresses a bug where the /check-role operation fails if a user clicks 'Continue' immediately after running the AWS CLI snippet.

Previously, if a user clicked 'Proceed' immediately after running the provided snippet, the check would fail. We are still debugging the issue.
To fix this for now, we've added a 3.5-second delay before the system checks the user's role. 
A more permanent solution will be implemented later on the backend, and this code will be removed. The current polling mechanism will be hopefully sufficient to cover this case.

# Test
Pull the branch
Run the snippet on your AWS CLI
Immediately hit 'Continue'
The first call should succeed