### PR TITLE
Aws infra ignored failed teardown

### DIFF
--- a/canarytokens/aws_infra/operations.py
+++ b/canarytokens/aws_infra/operations.py
@@ -45,7 +45,7 @@ HANDLE_RESPONSE_TIMEOUT = 300  # seconds
 SERVICE_ERROR_MESSAGE_MAP = {
     AWSInfraServiceError.FAILURE_CHECK_ROLE: "Could not assume the role in the account. Please make sure the role exists and that the external ID is correct.",
     AWSInfraServiceError.FAILURE_INGESTION_SETUP: "Could not setup alerting. Please make sure that you do not already have a Canarytoken in the same AWS region for this account.",
-    AWSInfraServiceError.FAILURE_INGESTION_TEARDOWN: "Something went wrong while trying to delete the Canarytoken.",
+    AWSInfraServiceError.FAILURE_INGESTION_TEARDOWN: "",
     AWSInfraServiceError.FAILURE_INVENTORY: "Could not retrieve the inventory of the account. Please make sure the policy is attached to the inventory role.",
     AWSInfraServiceError.REQ_HANDLE_INVALID: "The handle ID provided is invalid.",
     AWSInfraServiceError.REQ_HANDLE_TIMEOUT: "Handle response timed out.",

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1388,7 +1388,8 @@ async def api_awsinfra_teardown(
         return handle_response
     if (
         handle_response.error
-        and handle_response.error != AWSInfraServiceError.FAILURE_INGESTION_TEARDOWN
+        and handle_response.error
+        != AWSInfraServiceError.FAILURE_INGESTION_TEARDOWN.value
     ):
         response.status_code = status.HTTP_400_BAD_REQUEST
     return handle_response

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -72,6 +72,7 @@ from canarytokens.models import (
     AWSInfraManagementResponseRequest,
     AWSInfraOperationType,
     AWSInfraSavePlanRequest,
+    AWSInfraServiceError,
     AWSInfraSetupIngestionReceivedResponse,
     AWSInfraState,
     AWSInfraTeardownReceivedResponse,
@@ -1385,7 +1386,10 @@ async def api_awsinfra_teardown(
     except NoCanarydropFound:
         response.status_code = status.HTTP_404_NOT_FOUND
         return handle_response
-    if handle_response.error:
+    if (
+        handle_response.error
+        and handle_response.error != AWSInfraServiceError.FAILURE_INGESTION_TEARDOWN
+    ):
         response.status_code = status.HTTP_400_BAD_REQUEST
     return handle_response
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1393,7 +1393,7 @@ async def api_awsinfra_teardown(
         != AWSInfraServiceError.FAILURE_INGESTION_TEARDOWN.value
     ):
         response.status_code = status.HTTP_400_BAD_REQUEST
-    if not isinstance(handle_response, AWSInfraHandleResponse):
+    elif not isinstance(handle_response, AWSInfraHandleResponse):
         queries.delete_canarydrop(canarydrop)
     return handle_response
 

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1381,6 +1381,7 @@ async def api_awsinfra_teardown(
     handle_response = await aws_infra.get_handle_response(
         request.handle, AWSInfraOperationType.TEARDOWN
     )
+
     try:
         canarydrop = aws_infra.get_canarydrop_from_handle(request.handle)
     except NoCanarydropFound:
@@ -1392,6 +1393,8 @@ async def api_awsinfra_teardown(
         != AWSInfraServiceError.FAILURE_INGESTION_TEARDOWN.value
     ):
         response.status_code = status.HTTP_400_BAD_REQUEST
+    if not isinstance(handle_response, AWSInfraHandleResponse):
+        queries.delete_canarydrop(canarydrop)
     return handle_response
 
 

--- a/frontend_vue/src/components/tokens/aws_infra/DeleteTokenModal.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/DeleteTokenModal.vue
@@ -114,16 +114,8 @@ async function deleteTokenFnc() {
           isLoading.value = false;
           isError.value = true;
           isErrorMessage.value =
-            resWithHandle.data.error ||
+            resWithHandle.data.message ||
             'Error on requesting to delete the token. Try again';
-          clearInterval(pollingDeleteTokenInterval);
-          return;
-        }
-
-        if (resWithHandle.data.message) {
-          isLoading.value = false;
-          isError.value = true;
-          isErrorMessage.value = resWithHandle.data.message;
           clearInterval(pollingDeleteTokenInterval);
           return;
         }

--- a/frontend_vue/src/components/tokens/aws_infra/DeleteTokenModal.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/DeleteTokenModal.vue
@@ -120,6 +120,14 @@ async function deleteTokenFnc() {
           return;
         }
 
+        if (resWithHandle.data.message) {
+          isLoading.value = false;
+          isError.value = true;
+          isErrorMessage.value = resWithHandle.data.message;
+          clearInterval(pollingDeleteTokenInterval);
+          return;
+        }
+
         // timeout
         if (Date.now() - startTime >= timeout) {
           isLoading.value = false;


### PR DESCRIPTION
- Do not return an error code or error message if teardown fails
-  Teardown also deletes the token from redis