### PR TITLE
Return an error response for invalid plans

### DIFF
--- a/canarytokens/aws_infra/plan_generation.py
+++ b/canarytokens/aws_infra/plan_generation.py
@@ -305,9 +305,8 @@ async def generate_child_assets(
 
 def save_plan(canarydrop: Canarydrop, plan: dict[str, list[dict]]) -> None:
     """
-    Save an AWS Infra plan and upload it to the tf modules S3 bucket.
+    Save an AWS Infra plan
     """
-    canarydrop.aws_saved_plan = json.dumps(plan)
     try:
         canarydrop.aws_deployed_assets = json.dumps(
             {
@@ -339,3 +338,4 @@ def save_plan(canarydrop: Canarydrop, plan: dict[str, list[dict]]) -> None:
         raise ValueError(
             "Invalid plan structure. Ensure all required fields are present in the plan."
         )
+    canarydrop.aws_saved_plan = json.dumps(plan)

--- a/canarytokens/aws_infra/plan_generation.py
+++ b/canarytokens/aws_infra/plan_generation.py
@@ -308,29 +308,34 @@ def save_plan(canarydrop: Canarydrop, plan: dict[str, list[dict]]) -> None:
     Save an AWS Infra plan and upload it to the tf modules S3 bucket.
     """
     canarydrop.aws_saved_plan = json.dumps(plan)
-    canarydrop.aws_deployed_assets = json.dumps(
-        {
-            AWSInfraAssetType.S3_BUCKET.value: [
-                bucket[AWSInfraAssetField.BUCKET_NAME]
-                for bucket in plan.get(AWSInfraAssetType.S3_BUCKET.value, [])
-            ],
-            AWSInfraAssetType.DYNAMO_DB_TABLE.value: [
-                table[AWSInfraAssetField.TABLE_NAME]
-                for table in plan.get(AWSInfraAssetType.DYNAMO_DB_TABLE.value, [])
-            ],
-            AWSInfraAssetType.SQS_QUEUE.value: [
-                queue[AWSInfraAssetField.SQS_QUEUE_NAME]
-                for queue in plan.get(AWSInfraAssetType.SQS_QUEUE.value, [])
-            ],
-            AWSInfraAssetType.SSM_PARAMETER.value: [
-                param[AWSInfraAssetField.SSM_PARAMETER_NAME]
-                for param in plan.get(AWSInfraAssetType.SSM_PARAMETER.value, [])
-            ],
-            AWSInfraAssetType.SECRETS_MANAGER_SECRET.value: [
-                secret[AWSInfraAssetField.SECRET_NAME]
-                for secret in plan.get(
-                    AWSInfraAssetType.SECRETS_MANAGER_SECRET.value, []
-                )
-            ],
-        }
-    )
+    try:
+        canarydrop.aws_deployed_assets = json.dumps(
+            {
+                AWSInfraAssetType.S3_BUCKET.value: [
+                    bucket[AWSInfraAssetField.BUCKET_NAME]
+                    for bucket in plan.get(AWSInfraAssetType.S3_BUCKET.value, [])
+                ],
+                AWSInfraAssetType.DYNAMO_DB_TABLE.value: [
+                    table[AWSInfraAssetField.TABLE_NAME]
+                    for table in plan.get(AWSInfraAssetType.DYNAMO_DB_TABLE.value, [])
+                ],
+                AWSInfraAssetType.SQS_QUEUE.value: [
+                    queue[AWSInfraAssetField.SQS_QUEUE_NAME]
+                    for queue in plan.get(AWSInfraAssetType.SQS_QUEUE.value, [])
+                ],
+                AWSInfraAssetType.SSM_PARAMETER.value: [
+                    param[AWSInfraAssetField.SSM_PARAMETER_NAME]
+                    for param in plan.get(AWSInfraAssetType.SSM_PARAMETER.value, [])
+                ],
+                AWSInfraAssetType.SECRETS_MANAGER_SECRET.value: [
+                    secret[AWSInfraAssetField.SECRET_NAME]
+                    for secret in plan.get(
+                        AWSInfraAssetType.SECRETS_MANAGER_SECRET.value, []
+                    )
+                ],
+            }
+        )
+    except KeyError:
+        raise ValueError(
+            "Invalid plan structure. Ensure all required fields are present in the plan."
+        )

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1336,7 +1336,7 @@ async def api_awsinfra_save_plan(
         aws_infra.mark_succeeded(canarydrop)
         queries.save_canarydrop(canarydrop)
 
-    except AWSInfraOperationNotAllowed as e:
+    except (AWSInfraOperationNotAllowed, ValueError) as e:
         response.status_code = status.HTTP_400_BAD_REQUEST
         return DefaultResponse(result=False, message=str(e))
 


### PR DESCRIPTION
If during the parsing of the plan received when save-plan is called, there is a KeyError, return an error response indicating that the plan structure is invalid.