### PR TITLE
Add max assets + fix plan loading state + fix plan grid layout

### DIFF
--- a/frontend_vue/src/components/base/BaseButton.vue
+++ b/frontend_vue/src/components/base/BaseButton.vue
@@ -72,9 +72,9 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-    border: {
+  border: {
     type: Boolean,
-    default: true
+    default: true,
   },
 });
 
@@ -116,6 +116,10 @@ const spinnerVariant = computed(() => {
 <style scoped>
 .base-button {
   @apply w-fit relative font-semibold rounded-full px-16 py-8 disabled:pointer-events-none transition duration-100;
+}
+
+.base-button[disabled] {
+  @apply cursor-not-allowed opacity-70;
 }
 
 .primary {

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetFormArray.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/AssetFormArray.vue
@@ -17,6 +17,7 @@
       variant="text"
       icon="plus"
       :loading="isLoading"
+      :disabled="isMaxItemsReached"
       @click="handleAddItem"
     >
       Add Decoy
@@ -26,6 +27,13 @@
     v-if="isErrorMessage"
     variant="danger"
     >{{ errorMessageMapper(isErrorMessage) }}
+  </BaseMessageBox>
+  <BaseMessageBox
+    v-if="isMaxItemsReached"
+    variant="warning"
+    class="mb-16"
+    >You have reached the maximum of {{ MAX_ITEMS }}
+    {{ getFieldLabel(props.assetType, props.assetKey) }}.
   </BaseMessageBox>
   <AssetFormPagination :fields="props.fields">
     <div
@@ -51,7 +59,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 import { AssetTypesEnum } from '@/components/tokens/aws_infra/constants.ts';
 import getImageUrl from '@/utils/getImageUrl';
 import type { AssetData } from '../types';
@@ -60,6 +68,8 @@ import { useGenerateAssetName } from '@/components/tokens/aws_infra/plan_generat
 import AssetFormPagination from '@/components/tokens/aws_infra/plan_generator/AssetFormPagination.vue';
 import AssetTextField from '@/components/tokens/aws_infra/plan_generator/AssetTextField.vue';
 import { errorMessageMapper } from '@/utils/errorMessageMapper.ts';
+
+const MAX_ITEMS = 20;
 
 const props = defineProps<{
   assetType: AssetTypesEnum;
@@ -76,6 +86,10 @@ const isErrorMessage = ref('');
 function iconURL() {
   return getImageUrl(`aws_infra_icons/${props.assetKey}.svg`);
 }
+
+const isMaxItemsReached = computed(
+  () => Array.isArray(props.fields) && props.fields.length >= MAX_ITEMS
+);
 
 async function handleAddItem() {
   if (isLoading.value) return;

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
@@ -125,7 +125,7 @@ import ModalAssetContentItem from './ModalAssetContentItem.vue';
 import { errorMessageMapper } from '@/utils/errorMessageMapper.ts';
 import { setTempAssetsFields } from '@/components/tokens/aws_infra/plan_generator/planTempService.ts';
 
-const MAX_DECOY_ASSETS = 10;
+const MAX_DECOY_ASSETS = 5;
 
 const props = defineProps<{
   assetType: AssetTypesEnum;

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
@@ -30,6 +30,7 @@
       <BaseButton
         v-if="!showAssetDetails"
         :loading="isLoading"
+        :disabled="isMaxAssetsReached"
         class="self-end"
         variant="text"
         icon="plus"
@@ -39,6 +40,13 @@
       </BaseButton>
     </div>
     <!-- Asset List -->
+    <BaseMessageBox
+      v-if="isMaxAssetsReached && !showAssetDetails"
+      variant="warning"
+      class="mb-16"
+      >You have reached the maximum of {{ MAX_DECOY_ASSETS }} decoys for
+      {{ assetLabel }}.
+    </BaseMessageBox>
     <BaseMessageBox
       v-if="isErrorMessage"
       variant="danger"
@@ -117,6 +125,8 @@ import ModalAssetContentItem from './ModalAssetContentItem.vue';
 import { errorMessageMapper } from '@/utils/errorMessageMapper.ts';
 import { setTempAssetsFields } from '@/components/tokens/aws_infra/plan_generator/planTempService.ts';
 
+const MAX_DECOY_ASSETS = 10;
+
 const props = defineProps<{
   assetType: AssetTypesEnum;
   assetData: ComputedRef<AssetData[] | [] | null>;
@@ -148,6 +158,12 @@ const currentAssetData = computed(() => {
 const isEmptyAssetData = computed(
   () =>
     Array.isArray(currentAssetData.value) && currentAssetData.value.length === 0
+);
+
+const isMaxAssetsReached = computed(
+  () =>
+    Array.isArray(currentAssetData.value) &&
+    currentAssetData.value.length >= MAX_DECOY_ASSETS
 );
 
 const assetLabel = computed(() => getAssetLabel(props.assetType));

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GeneratePlan.vue
@@ -30,6 +30,12 @@
       </div>
     </div>
   </div>
+  <BaseSkeletonLoader
+    v-if="getAnyLoadingAssetData() || isLoadingUI"
+    class="mb-24"
+    type="rectangle"
+    style="height: 100px; width: 100%"
+  />
   <div
     v-if="isLoadingUI"
     class="mt-[20px] grid gap-16 grid-cols-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-5 auto-rows-fr"
@@ -53,25 +59,26 @@
       {{ isAiGenerateErrorMessage }}
     </BaseMessageBox>
     <div>
-      <div class="flex justify-between mb-24"></div>
-      <BaseMessageBox
-        v-if="totalAiQuota > 0 && availableAiQuota > 0"
-        variant="success"
-        class="mb-24"
-        >We analyzed your AWS account. Below are the recommended decoys that
-        have been generated to match your environment for each asset. You can
-        review or edit anything before we generate your
-        Canarytoken.</BaseMessageBox
-      >
-      <BaseMessageBox
-        v-else
-        variant="success"
-        class="mb-24"
-        >We analyzed your AWS account. It's not possible to generate decoys for
-        your AWS account because you've run out of credits. However, you can
-        still manually set up the decoys and then generate your
-        Canarytoken.</BaseMessageBox
-      >
+      <div v-if="!getAnyLoadingAssetData()">
+        <BaseMessageBox
+          v-if="totalAiQuota > 0 && availableAiQuota > 0"
+          variant="success"
+          class="mb-24"
+          >We analyzed your AWS account. Below are the recommended decoys that
+          have been generated to match your environment for each asset. You can
+          review or edit anything before we generate your
+          Canarytoken.</BaseMessageBox
+        >
+        <BaseMessageBox
+          v-else
+          variant="success"
+          class="mb-24"
+          >We analyzed your AWS account. It's not possible to generate decoys
+          for your AWS account because you've run out of credits. However, you
+          can still manually set up the decoys and then generate your
+          Canarytoken.</BaseMessageBox
+        >
+      </div>
       <BaseMessageBox
         v-if="isErrorMessage"
         variant="danger"
@@ -79,7 +86,7 @@
         >{{ isErrorMessage }}</BaseMessageBox
       >
       <ul
-        class="grid gap-16 grid-cols-1 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-5 auto-rows-fr"
+        class="grid gap-16 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 auto-rows-fr"
       >
         <AssetCategoryCard
           v-for="(assetValues, assetKey, index) in availableAssets"
@@ -93,7 +100,7 @@
       <BaseMessageBox
         v-if="assetsWithMissingPermissions.length > 0"
         variant="warning"
-        class="mt-16"
+        class="mt-16 mb-16"
       >
         {{ assetWithMissingPermissionText }}
       </BaseMessageBox>


### PR DESCRIPTION
## Proposed changes

Add a limit of 10 max assets per type
Add a limit of 20 max items per single asset type where supported (S3 buckets, DynamoDB tables)

+ fix plan UI on loading ( adds skeleton when waiting for AI available credits )
+ fix grid layout