### PR TITLE
Add randomness to S3 buckets and role names

### DIFF
--- a/aws-token-infra/.gitignore
+++ b/aws-token-infra/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+.terraform.lock.hcl


### PR DESCRIPTION
## Proposed changes

Using predictable names allows testing if an AWS Account associated with an API Key is part of canarytokens.org by checking for existence of S3 buckets and roles. This change is part of ensuring the names are unpredictable.

## Types of changes

What types of changes does your code introduce to this repository?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
