### PR TITLE
Fix plaintext mail template and rendering

### DIFF
--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -437,17 +437,19 @@ class EmailOutputChannel(OutputChannel):
 
         if details.channel == "DNS":  # TODO: make channel an enum.
             intro = dedent(
-                f"""{intro}
-                    Please note that the source IP refers to a DNS server, rather than the host that triggered the token.
-                    """
-            )
+                f"""
+                {intro}
+                Please note that the source IP refers to a DNS server, rather than the host that triggered the token.
+                """
+            ).strip()
 
         if (details.channel == "DNS") and (details.token_type == TokenTypes.MY_SQL):
             intro = dedent(
-                f"""{intro}
-                    Your MySQL token was tripped, but the attackers machine was unable to connect to the server directly. Instead, we can tell that it happened, and merely report on their DNS server. Source IP therefore refers to the DNS server used by the attacker.
-                    """
-            )
+                f"""
+                {intro}
+                Your MySQL token was tripped, but the attackers machine was unable to connect to the server directly. Instead, we can tell that it happened, and merely report on their DNS server. Source IP therefore refers to the DNS server used by the attacker.
+                """
+            ).strip()
 
         if (
             (details.token_type == TokenTypes.AWS_KEYS)
@@ -456,10 +458,11 @@ class EmailOutputChannel(OutputChannel):
             and (details.additional_data["aws_key_log_data"]["safety_net"])
         ):
             intro = dedent(
-                f"""{intro}
-                    This AWS activity was caught using our safetynet feature so it may contain limited information.
-                    """
-            )
+                f"""
+                {intro}
+                This AWS activity was caught using our safetynet feature so it may contain limited information.
+                """
+            ).strip()
 
         return intro
 

--- a/templates/emails/notification.txt
+++ b/templates/emails/notification.txt
@@ -1,22 +1,107 @@
-======================================================================
-                                ALERT
-======================================================================
+Your Canarytoken was triggered!
+-------------------------------
 
 {{Intro}}
 
-Basic Information:
-  Incident: {{Description}}
-  Time    : {{Timestamp}}
-{%if SourceIP %}
-  Source  : {{SourceIP}}
-{%endif%}
-  Target  : {{CanaryIP}} ({{CanaryName}}, id {{CanaryID}})
+Reminder:
+  {{BasicDetails['memo']}}
+{% if BasicDetails['src_ip'] %}
+Source IP:
+  {{BasicDetails['src_ip']}}
+{% endif %}
+Date:
+  {{BasicDetails['time_ymd']}}
 
-{% if AdditionalDetails %}
-Additional Details:
-  {% for add_det in AdditionalDetails %}
-  {{add_det[0]}}: {{add_det[1]}}
-  {% endfor %}
-{%endif%}
+Time:
+  {{BasicDetails['time_hm']}} UTC
+{% if BasicDetails['identity'] %}
+Identity:
+  {{BasicDetails['identity']}}
+{% endif %}{% if BasicDetails['useragent'] %}
+User agent:
+  {{BasicDetails['useragent']}}
+{% endif %}{% if BasicDetails['pwa_location'] %}
+Location:
+  Latitude: {{BasicDetails['pwa_location']['coords'].get('latitude', '-')}}
+  Longitude: {{BasicDetails['pwa_location']['coords'].get('longitude', '-')}}
+  Accuracy (m): {{BasicDetails['pwa_location']['coords'].get('accuracy', '-')}}{% if BasicDetails['pwa_location'].get('google_maps_link') %}
+  Google Maps link: {{ BasicDetails['pwa_location']['google_maps_link'] }}
+  Apple Maps link: {{ BasicDetails['pwa_location']['apple_maps_link'] }}{% endif %}
+{% endif %}{% if BasicDetails['location'] %}
+Location:
+  {{BasicDetails.get('location', None)}}
+{% endif %}{% if BasicDetails['log4_shell_computer_name'] %}
+Log4Shell hostname:
+  {{BasicDetails['log4_shell_computer_name']}}
+{% endif %}{% if BasicDetails['sql_username'] %}
+SQL Server username:
+  {{BasicDetails['sql_username']}}
+{% endif %}{% if BasicDetails['aws_key_log_data'] and BasicDetails['aws_key_log_data']['service_used'] %}
+Service Used:
+  {{ BasicDetails['aws_key_log_data']['service_used'][0].upper()}}
+{% endif %}{% if BasicDetails['cmd_process'] or BasicDetails['cmd_computer_name'] or BasicDetails['cmd_user_name']%}
+{% if BasicDetails['cmd_process'] %}
+Sensitive command:
+  {{BasicDetails['cmd_process']}}
+{% endif %}{% if BasicDetails['cmd_computer_name'] %}
+Executed on:
+  {{BasicDetails['cmd_computer_name']}}
+{% endif %}{% if BasicDetails['cmd_user_name'] %}
+Run by:
+  {{BasicDetails['cmd_user_name']}}{% endif %}
+{% endif %}{% if BasicDetails['windows_fake_fs_file_name'] or BasicDetails['windows_fake_fs_process_name']%}
+{% if BasicDetails['windows_fake_fs_file_name'] %}
+File opened:
+  {{BasicDetails['windows_fake_fs_file_name']}}
+{% endif %}{% if BasicDetails['windows_fake_fs_process_name'] %}
+Opened by:
+  {{BasicDetails['windows_fake_fs_process_name']}}{% endif %}
+{% endif %}{% if BasicDetails['merchant'] or BasicDetails['amount']%}
+{% if BasicDetails['merchant'] %}
+Authorizing merchant:
+  {{BasicDetails['merchant']}}
+{% endif %}{% if BasicDetails['amount'] %}
+Transaction amount:
+  {{BasicDetails['amount']}}{% endif %}
+{% endif %}{% if BasicDetails['token_type'] == 'credit_card_v2' %}
+{% if BasicDetails['additional_info']['merchant'] %}
+Authorizing merchant:
+  {{BasicDetails['additional_info']['merchant']}}
+{% endif %}{% if BasicDetails['additional_info']['transaction_amount'] %}
+Transaction amount:
+  {{BasicDetails['additional_info']['transaction_amount']}} {{BasicDetails['additional_info']['transaction_currency']}}{% endif %}
+{% endif %}{% if BasicDetails['token_type'] == 'webdav' %}
+{% if BasicDetails['additional_info']['file_path'] %}
+File Path:
+  {{BasicDetails['additional_info']['file_path']}}
+{% endif %}{% if BasicDetails['additional_info']['useragent'] %}
+WebDAV Client User-Agent:
+  {{BasicDetails['additional_info']['useragent']}}
+{% endif %}
+{% endif %}{% if BasicDetails['generic_data'] %}
+Generic data:
+  {{ BasicDetails['generic_data']}}
+{% endif %}{% if BasicDetails['referer'] %}
+Referer:
+  {{ BasicDetails['referer']}}
+{% endif %}{% if BasicDetails['referrer'] %}
+Referer:
+  {{ BasicDetails['referrer']}}
+{% endif %}{% if BasicDetails['request_args'] %}
+Request arguments:
+  {{ BasicDetails['request_args']}}
+{% endif %}{% if BasicDetails['token'] %}
+Canarytoken ID:
+  {{ BasicDetails['token']}}
+{% endif %}
+Alert History:
+  {{ HistoryLink }}
 
-======================================================================
+Manage Alert:
+  {{ ManageLink }}
+
+More info on this Canarytoken?
+  https://docs.canarytokens.org/guide/
+
+Some of the best security teams in the world run Thinkst Canary.
+Find out why (https://canary.tools/)

--- a/templates/emails/notification.txt
+++ b/templates/emails/notification.txt
@@ -5,95 +5,125 @@ Your Canarytoken was triggered!
 
 Reminder:
   {{BasicDetails['memo']}}
-{% if BasicDetails['src_ip'] %}
+{% if BasicDetails['src_ip'] +%}
 Source IP:
   {{BasicDetails['src_ip']}}
 {% endif %}
+
 Date:
   {{BasicDetails['time_ymd']}}
 
 Time:
   {{BasicDetails['time_hm']}} UTC
-{% if BasicDetails['identity'] %}
+{% if BasicDetails['identity'] +%}
 Identity:
   {{BasicDetails['identity']}}
-{% endif %}{% if BasicDetails['useragent'] %}
+{% endif %}
+{% if BasicDetails['useragent'] +%}
 User agent:
   {{BasicDetails['useragent']}}
-{% endif %}{% if BasicDetails['pwa_location'] %}
+{% endif %}
+{% if BasicDetails['pwa_location'] +%}
 Location:
   Latitude: {{BasicDetails['pwa_location']['coords'].get('latitude', '-')}}
   Longitude: {{BasicDetails['pwa_location']['coords'].get('longitude', '-')}}
-  Accuracy (m): {{BasicDetails['pwa_location']['coords'].get('accuracy', '-')}}{% if BasicDetails['pwa_location'].get('google_maps_link') %}
+  Accuracy (m): {{BasicDetails['pwa_location']['coords'].get('accuracy', '-')}}
+{% if BasicDetails['pwa_location'].get('google_maps_link') %}
   Google Maps link: {{ BasicDetails['pwa_location']['google_maps_link'] }}
-  Apple Maps link: {{ BasicDetails['pwa_location']['apple_maps_link'] }}{% endif %}
-{% endif %}{% if BasicDetails['location'] %}
+  Apple Maps link: {{ BasicDetails['pwa_location']['apple_maps_link'] }}
+{% endif %}
+{% endif %}
+{% if BasicDetails['location'] +%}
 Location:
   {{BasicDetails.get('location', None)}}
-{% endif %}{% if BasicDetails['log4_shell_computer_name'] %}
+{% endif %}
+{% if BasicDetails['log4_shell_computer_name'] +%}
 Log4Shell hostname:
   {{BasicDetails['log4_shell_computer_name']}}
-{% endif %}{% if BasicDetails['sql_username'] %}
+{% endif %}
+{% if BasicDetails['sql_username'] +%}
 SQL Server username:
   {{BasicDetails['sql_username']}}
-{% endif %}{% if BasicDetails['aws_key_log_data'] and BasicDetails['aws_key_log_data']['service_used'] %}
+{% endif %}
+{% if BasicDetails['aws_key_log_data'] and BasicDetails['aws_key_log_data']['service_used'] +%}
 Service Used:
   {{ BasicDetails['aws_key_log_data']['service_used'][0].upper()}}
-{% endif %}{% if BasicDetails['cmd_process'] or BasicDetails['cmd_computer_name'] or BasicDetails['cmd_user_name']%}
-{% if BasicDetails['cmd_process'] %}
+{% endif %}
+{% if BasicDetails['cmd_process'] or BasicDetails['cmd_computer_name'] or BasicDetails['cmd_user_name'] +%}
+{% if BasicDetails['cmd_process'] +%}
 Sensitive command:
   {{BasicDetails['cmd_process']}}
-{% endif %}{% if BasicDetails['cmd_computer_name'] %}
+{% endif %}
+{% if BasicDetails['cmd_computer_name'] +%}
 Executed on:
   {{BasicDetails['cmd_computer_name']}}
-{% endif %}{% if BasicDetails['cmd_user_name'] %}
+{% endif %}
+{% if BasicDetails['cmd_user_name'] +%}
 Run by:
-  {{BasicDetails['cmd_user_name']}}{% endif %}
-{% endif %}{% if BasicDetails['windows_fake_fs_file_name'] or BasicDetails['windows_fake_fs_process_name']%}
-{% if BasicDetails['windows_fake_fs_file_name'] %}
+  {{BasicDetails['cmd_user_name']}}
+{% endif %}
+{% endif %}
+{% if BasicDetails['windows_fake_fs_file_name'] or BasicDetails['windows_fake_fs_process_name'] +%}
+{% if BasicDetails['windows_fake_fs_file_name'] +%}
 File opened:
   {{BasicDetails['windows_fake_fs_file_name']}}
-{% endif %}{% if BasicDetails['windows_fake_fs_process_name'] %}
+{% endif %}
+{% if BasicDetails['windows_fake_fs_process_name'] +%}
 Opened by:
-  {{BasicDetails['windows_fake_fs_process_name']}}{% endif %}
-{% endif %}{% if BasicDetails['merchant'] or BasicDetails['amount']%}
-{% if BasicDetails['merchant'] %}
+  {{BasicDetails['windows_fake_fs_process_name']}}
+{% endif %}
+{% endif %}
+{% if BasicDetails['merchant'] or BasicDetails['amount'] +%}
+{% if BasicDetails['merchant'] +%}
 Authorizing merchant:
   {{BasicDetails['merchant']}}
-{% endif %}{% if BasicDetails['amount'] %}
+{% endif %}
+{% if BasicDetails['amount'] +%}
 Transaction amount:
-  {{BasicDetails['amount']}}{% endif %}
-{% endif %}{% if BasicDetails['token_type'] == 'credit_card_v2' %}
-{% if BasicDetails['additional_info']['merchant'] %}
+  {{BasicDetails['amount']}}
+{% endif %}
+{% endif %}
+{% if BasicDetails['token_type'] == 'credit_card_v2' +%}
+{% if BasicDetails['additional_info']['merchant'] +%}
 Authorizing merchant:
   {{BasicDetails['additional_info']['merchant']}}
-{% endif %}{% if BasicDetails['additional_info']['transaction_amount'] %}
+{% endif %}
+{% if BasicDetails['additional_info']['transaction_amount'] +%}
 Transaction amount:
-  {{BasicDetails['additional_info']['transaction_amount']}} {{BasicDetails['additional_info']['transaction_currency']}}{% endif %}
-{% endif %}{% if BasicDetails['token_type'] == 'webdav' %}
-{% if BasicDetails['additional_info']['file_path'] %}
+  {{BasicDetails['additional_info']['transaction_amount']}} {{BasicDetails['additional_info']['transaction_currency']}}
+{% endif %}
+{% endif %}
+{% if BasicDetails['token_type'] == 'webdav' +%}
+{% if BasicDetails['additional_info']['file_path'] +%}
 File Path:
   {{BasicDetails['additional_info']['file_path']}}
-{% endif %}{% if BasicDetails['additional_info']['useragent'] %}
+{% endif %}
+{% if BasicDetails['additional_info']['useragent'] +%}
 WebDAV Client User-Agent:
   {{BasicDetails['additional_info']['useragent']}}
 {% endif %}
-{% endif %}{% if BasicDetails['generic_data'] %}
+{% endif %}
+{% if BasicDetails['generic_data'] +%}
 Generic data:
   {{ BasicDetails['generic_data']}}
-{% endif %}{% if BasicDetails['referer'] %}
+{% endif %}
+{% if BasicDetails['referer'] +%}
 Referer:
   {{ BasicDetails['referer']}}
-{% endif %}{% if BasicDetails['referrer'] %}
+{% endif %}
+{% if BasicDetails['referrer'] +%}
 Referer:
   {{ BasicDetails['referrer']}}
-{% endif %}{% if BasicDetails['request_args'] %}
+{% endif %}
+{% if BasicDetails['request_args'] +%}
 Request arguments:
   {{ BasicDetails['request_args']}}
-{% endif %}{% if BasicDetails['token'] %}
+{% endif %}
+{% if BasicDetails['token'] +%}
 Canarytoken ID:
   {{ BasicDetails['token']}}
 {% endif %}
+
 Alert History:
   {{ HistoryLink }}
 

--- a/tests/units/test_channel_output_email.py
+++ b/tests/units/test_channel_output_email.py
@@ -43,7 +43,7 @@ def test_dns_rendered_html(settings: SwitchboardSettings):
     )
     email_template = EmailOutputChannel.format_report_html(
         details,
-        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION}"),
+        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
     assert "https://some.link/manage/here" in email_template
     assert "https://some.link/history/here" in email_template
@@ -65,7 +65,7 @@ def test_slow_redirect_rendered_html(settings: SwitchboardSettings):
     )
     email_template = EmailOutputChannel.format_report_html(
         details,
-        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION}"),
+        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
     assert "https://some.link/manage/here" in email_template
     assert "https://some.link/history/here" in email_template
@@ -87,7 +87,7 @@ def test_cloned_site_rendered_html(settings: SwitchboardSettings):
     )
     email_template = EmailOutputChannel.format_report_html(
         details,
-        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION}"),
+        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
     assert "https://some.link/manage/here" in email_template
     assert "https://some.link/history/here" in email_template
@@ -108,7 +108,7 @@ def test_log4shell_rendered_html(settings: SwitchboardSettings):
     )
     email_template = EmailOutputChannel.format_report_html(
         details,
-        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION}"),
+        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
     assert "https://some.link/manage/here" in email_template
     assert "https://some.link/history/here" in email_template
@@ -129,7 +129,7 @@ def test_aws_keys_safetynet_rendered_html(settings: SwitchboardSettings):
     )
     email_template = EmailOutputChannel.format_report_html(
         details,
-        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION}"),
+        Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
     assert "https://some.link/manage/here" in email_template
     assert "https://some.link/history/here" in email_template
@@ -199,7 +199,7 @@ def test_sendgrid_send(
         api_key=settings.SENDGRID_API_KEY,
         email_content_html=EmailOutputChannel.format_report_html(
             details,
-            Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION}"),
+            Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
         ),
         email_address=EmailStr(email),
         from_email=settings.ALERT_EMAIL_FROM_ADDRESS,
@@ -235,7 +235,7 @@ def test_mailgun_send(
     result, message_id = mailgun_send(
         email_content_html=EmailOutputChannel.format_report_html(
             details,
-            Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION}"),
+            Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
         ),
         email_content_text=EmailOutputChannel.format_report_text(details),
         email_address=EmailStr(email),
@@ -263,7 +263,7 @@ def test_smtp_send(
     result, message_id = smtp_send(
         email_content_html=EmailOutputChannel.format_report_html(
             details,
-            Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION}"),
+            Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
         ),
         email_content_text=EmailOutputChannel.format_report_text(details),
         email_address=EmailStr("tokens-testing@thinkst.com"),

--- a/tests/units/test_channel_output_email.py
+++ b/tests/units/test_channel_output_email.py
@@ -41,7 +41,7 @@ def test_dns_rendered_html(settings: SwitchboardSettings):
         manage_url="https://some.link/manage/here",
         additional_data={},
     )
-    email_template = EmailOutputChannel.format_report_html(
+    email_template = EmailOutputChannel.format_token_alert_mail(
         details,
         Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
@@ -63,7 +63,7 @@ def test_slow_redirect_rendered_html(settings: SwitchboardSettings):
             "location": "https://fake.your/domain/stuff",
         },
     )
-    email_template = EmailOutputChannel.format_report_html(
+    email_template = EmailOutputChannel.format_token_alert_mail(
         details,
         Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
@@ -85,7 +85,7 @@ def test_cloned_site_rendered_html(settings: SwitchboardSettings):
             "location": "https://fake.your/domain/stuff/loc",
         },
     )
-    email_template = EmailOutputChannel.format_report_html(
+    email_template = EmailOutputChannel.format_token_alert_mail(
         details,
         Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
@@ -106,7 +106,7 @@ def test_log4shell_rendered_html(settings: SwitchboardSettings):
             "log4_shell_computer_name": "SRV01",
         },
     )
-    email_template = EmailOutputChannel.format_report_html(
+    email_template = EmailOutputChannel.format_token_alert_mail(
         details,
         Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
@@ -127,7 +127,7 @@ def test_aws_keys_safetynet_rendered_html(settings: SwitchboardSettings):
             "aws_key_log_data": {"safety_net": ["True"], "service_used": ["ses"]}
         },
     )
-    email_template = EmailOutputChannel.format_report_html(
+    email_template = EmailOutputChannel.format_token_alert_mail(
         details,
         Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
     )
@@ -197,7 +197,7 @@ def test_sendgrid_send(
 
     result, message_id = sendgrid_send(
         api_key=settings.SENDGRID_API_KEY,
-        email_content_html=EmailOutputChannel.format_report_html(
+        email_content_html=EmailOutputChannel.format_token_alert_mail(
             details,
             Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
         ),
@@ -233,11 +233,11 @@ def test_mailgun_send(
         pytest.skip("No Mailgun API key found; skipping...")
     details = _get_send_token_details()
     result, message_id = mailgun_send(
-        email_content_html=EmailOutputChannel.format_report_html(
+        email_content_html=EmailOutputChannel.format_token_alert_mail(
             details,
             Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
         ),
-        email_content_text=EmailOutputChannel.format_report_text(details),
+        email_content_text=EmailOutputChannel.format_token_alert_mail(details),
         email_address=EmailStr(email),
         from_email=settings.ALERT_EMAIL_FROM_ADDRESS,
         email_subject=settings.ALERT_EMAIL_SUBJECT,
@@ -261,11 +261,11 @@ def test_smtp_send(
 ):
     details = _get_send_token_details()
     result, message_id = smtp_send(
-        email_content_html=EmailOutputChannel.format_report_html(
+        email_content_html=EmailOutputChannel.format_token_alert_mail(
             details,
             Path(settings.TEMPLATES_PATH, f"{EmailTemplates.NOTIFICATION_HTML}"),
         ),
-        email_content_text=EmailOutputChannel.format_report_text(details),
+        email_content_text=EmailOutputChannel.format_token_alert_mail(details),
         email_address=EmailStr("tokens-testing@thinkst.com"),
         from_email=settings.ALERT_EMAIL_FROM_ADDRESS,
         email_subject=settings.ALERT_EMAIL_SUBJECT,


### PR DESCRIPTION
## Proposed changes
This PR fixes the plaintext mail template and rendering for tokens alerts.
With these changes, the plaintext token trigger alert notification mails now follow the same format as the HTML ones.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
