### PR TITLE
Wizard frontend updates

### DIFF
--- a/canarytokens/aws_infra/operations.py
+++ b/canarytokens/aws_infra/operations.py
@@ -155,7 +155,8 @@ def _get_error_message(
     """
     SERVICE_ERROR_MESSAGE_MAP = {
         AWSInfraServiceError.FAILURE_CHECK_ROLE: f"Could not assume the role{role} in the account. Please make sure the role exists and that the external ID is correct.",
-        AWSInfraServiceError.FAILURE_INGESTION_SETUP: f"Could not setup alerting. If you have previously created an AWS Infra Canarytoken in this AWS account{account} in the same region{region}, then you need to delete the existing Canarytoken before creating a new one. Alternatively, you can rather edit the decoys in the existing Canarytoken. Hint: look in your inbox for a previous Infrastructure Canarytoken email to get the Manage link.",
+        AWSInfraServiceError.FAILURE_INVENTORY_REGION_DISABLED: f"The region{region} is not enabled in the AWS account{account}. Please enable it and try again or choose a different region.",
+        AWSInfraServiceError.FAILURE_INGESTION_SETUP: f'Could not setup alerting. If you have previously created an AWS Infra Canarytoken in this AWS account{account} in the same region{region}, then you need to delete the existing Canarytoken before creating a new one. Alternatively, you can rather edit the decoys in the existing Canarytoken. Hint: if you\'ve lost your Manage link, you can retrieve it by clicking on "My Canarytokens" at the top of the page.',
         AWSInfraServiceError.FAILURE_INGESTION_TEARDOWN: "",  # UI does not show this error
         AWSInfraServiceError.FAILURE_INVENTORY_ACCESS_DENIED: f"Could not retrieve the inventory of the AWS account{account} because access was denied. Please make sure the policy, Canarytokens-Inventory-ReadOnly-Policy, is attached to the inventory role{role} that you created for us to inventory your resources.",
         AWSInfraServiceError.FAILURE_INVENTORY_REGION_DISABLED: f"The region{region} is not enabled in the AWS account{account}. Please enable it and try again or choose a different region.",

--- a/canarytokens/aws_infra/operations.py
+++ b/canarytokens/aws_infra/operations.py
@@ -160,7 +160,7 @@ def _get_error_message(
         AWSInfraServiceError.FAILURE_INGESTION_TEARDOWN: "",  # UI does not show this error
         AWSInfraServiceError.FAILURE_INVENTORY_ACCESS_DENIED: f"Could not retrieve the inventory of the AWS account{account} because access was denied. Please make sure the policy, Canarytokens-Inventory-ReadOnly-Policy, is attached to the inventory role{role} that you created for us to inventory your resources.",
         AWSInfraServiceError.FAILURE_INVENTORY_REGION_DISABLED: f"The region{region} is not enabled in the AWS account{account}. Please enable it and try again or choose a different region.",
-        AWSInfraServiceError.FAILURE_INVENTORY_TOKEN_EXISTS: f"There's already a Canarytoken setup in{region} for {account}, so you won't be able to continue. Either edit or delete that Canarytoken through it's Manage link (if you no longer have the Manage link, you can obtain it from the \"My Canarytokens\" link above). If you do delete the Canarytoken, we recommend first running `$ terraform destroy` on the decoy Terraform plan, to remove the decoys from your AWS account before the Canarytoken is removed.",
+        AWSInfraServiceError.FAILURE_INVENTORY_TOKEN_EXISTS: f"There's already a Canarytoken setup in{region} for {account}, so you won't be able to continue. Either edit or delete that Canarytoken through it's Manage link. If you do delete the Canarytoken, we recommend first running `$ terraform destroy` on the decoy Terraform plan, to remove the decoys from your AWS account before the Canarytoken is removed.",
         AWSInfraServiceError.NO_ERROR: "",
         AWSInfraServiceError.REQ_HANDLE_INVALID: "The handle ID provided is invalid.",
         AWSInfraServiceError.REQ_HANDLE_TIMEOUT: "Handle response timed out.",

--- a/frontend_vue/src/components/base/BaseModal.vue
+++ b/frontend_vue/src/components/base/BaseModal.vue
@@ -11,7 +11,7 @@
   >
     <div
       class="absolute inset-[0px] h-full overflow-auto sm:flex p-16"
-      @click.self="() => emit('update:modelValue', false)"
+      @click.self="handleOverlayClick"
     >
       <div
         class="md:w-[60vw] lg:w-[50vw] mx-auto bg-white rounded-3xl max-w-screen-lg sm:self-center my-auto"
@@ -56,7 +56,7 @@
         <div
           v-bind="$attrs"
           class="flex flex-col items-center justify-center px-16 py-16 sm:px-32 bg-grey-50 text-grey-800"
-          :class="[{ 'pb-24 rounded-b-3xl': hideFooter }, contentSlotClasses]"
+          :class="[{ 'pb-24 rounded-b-3xl': hideFooter }, props.contentClass]"
         >
           <!-- Default slot -->
           <slot></slot>
@@ -77,24 +77,32 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
 import { VueFinalModal } from 'vue-final-modal';
 
-const props = defineProps<{
-  hasCloseButton: boolean;
-  title: string;
-  hideFooter?: boolean;
-  contentClass?: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    hasCloseButton: boolean;
+    title: string;
+    hideFooter?: boolean;
+    contentClass?: string;
+    clickToClose?: boolean;
+  }>(),
+  {
+    clickToClose: true,
+    contentClass: '',
+  }
+);
 
 const emit = defineEmits<{
   (e: 'update:modelValue', value: boolean): void;
   (e: 'handleBackButton', value: false): void;
 }>();
 
-const contentSlotClasses = computed(() => {
-  return props.contentClass ? props.contentClass : '';
-});
+function handleOverlayClick() {
+  if (props.clickToClose) {
+    emit('update:modelValue', false);
+  }
+}
 
 const modalCustomTransition = {
   'enter-active-class': 'ease-out duration-300',

--- a/frontend_vue/src/components/tokens/aws_infra/GenerateTokenForm.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/GenerateTokenForm.vue
@@ -23,7 +23,7 @@
   </BaseGenerateTokenSettings>
   <GenerateTokenFormInyoni :aws-form-ref="awsFormRef" />
   <GenerateTokenSettingsNotifications
-    memo-helper-example="A memo placeholder"
+    memo-helper-example="Production Account"
   />
 </template>
 

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
@@ -1,8 +1,9 @@
 <template>
   <BaseModal
     :title="`${assetLabel} Decoys`"
-    :has-close-button="true"
+    :has-close-button="!showAssetDetails ? true : false"
     class="flex flex-row items-stretch"
+    :click-to-close="false"
     @update:model-value="handleCloseModal"
   >
     <!-- Back Button-->

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/ModalAsset.vue
@@ -3,6 +3,7 @@
     :title="`${assetLabel} Decoys`"
     :has-close-button="true"
     class="flex flex-row items-stretch"
+    @update:model-value="handleCloseModal"
   >
     <!-- Back Button-->
     <template #header-btn-left>

--- a/frontend_vue/src/components/tokens/aws_infra/plan_generator/useAIGenerateAssets.ts
+++ b/frontend_vue/src/components/tokens/aws_infra/plan_generator/useAIGenerateAssets.ts
@@ -17,6 +17,17 @@ export function useAIGeneratedAssets(
   isLoadingAssetCard: Ref<Record<AssetTypesEnum, boolean>>
 ) {
   const isAiGenerateErrorMessage = ref('');
+  const aiGeneratedAssetsCount = ref(0);
+
+  function countAIGeneratedAssets(planData: ProposedAWSInfraTokenPlanData) {
+    let totalAssets = 0;
+    Object.values(planData).forEach((assets) => {
+      if (assets) {
+        totalAssets += assets.length;
+      }
+    });
+    aiGeneratedAssetsCount.value = totalAssets;
+  }
 
   async function fetchAIgeneratedAssets(
     initialAssetData: ProposedAWSInfraTokenPlanData
@@ -39,6 +50,12 @@ export function useAIGeneratedAssets(
       if (res.status === 429) {
         isAiGenerateErrorMessage.value =
           'You have reached your limit for AI-generated decoy names. You can continue with manual setup.';
+
+        const dataGenerationRemaining = Math.floor(
+        res.data.data_generation_remaining
+        );
+        updateAiCurrentAvailableNamesCount(dataGenerationRemaining);
+
         return;
       }
 
@@ -60,6 +77,7 @@ export function useAIGeneratedAssets(
       }
 
       assetsData.value = { ...assetsData.value, ...updatedPlanData };
+      countAIGeneratedAssets(assetsData.value);
     } catch (err: any) {
       isAiGenerateErrorMessage.value =
         err.data?.message ||
@@ -72,5 +90,6 @@ export function useAIGeneratedAssets(
   return {
     isAiGenerateErrorMessage,
     fetchAIgeneratedAssets,
+    aiGeneratedAssetsCount,
   };
 }

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateAwsSnippet.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateAwsSnippet.vue
@@ -49,15 +49,14 @@
                 class="w-[5rem]"
               />
             </div>
-            <h2 class="text-2xl mb-16">Execute the AWS CLI snippet below</h2>
             <p>
-              Run these commands to grant read-only access so we can inventory
-              your accound and suggest decoy resources.
-            </p>
-            <p>
-              <span class="font-bold text-green-500">Plase note:</span> We send
-              limited inventory data to Google's Gemini to generate realistic
-              decoy names.
+              Execute the AWS CLI snippet below. These commands create a
+              read-only IAM role (
+              <span class="monospace">{{ roleName }}</span> ) and policy (
+              <span class="monospace"
+                >Canarytokens-Inventory-ReadOnly-Policy</span
+              >
+              ).
             </p>
           </div>
           <BaseLabelArrow
@@ -382,5 +381,9 @@ aws iam attach-role-policy --role-name ${roleName.value} --policy-arn arn:aws:ia
   :deep(pre) > code {
     white-space: pre-wrap;
   }
+}
+
+.monospace {
+  font-family: 'Courier New', Courier, monospace;
 }
 </style>

--- a/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateLoadingState.vue
+++ b/frontend_vue/src/components/tokens/aws_infra/token_setup_steps/GenerateLoadingState.vue
@@ -22,12 +22,11 @@
       alt="Loading"
       class="w-[15rem] h-[15rem] mt-40"
     />
-    <p class="mt-40">Please, don't close this window</p>
+    <p class="mt-40">Please, don't close this window.</p>
   </div>
 </template>
 
 <script setup lang="ts">
-
 import getImageUrl from '@/utils/getImageUrl';
 
 const props = defineProps<{


### PR DESCRIPTION
## Proposed changes

-  Replace memo placeholder on the Generate Token modal 
-  Change the text on the Wizard Step 1 by dynamically including the role and policy name
- 2nd step wizard: change title to Review your Decoys
- 2nd step wizard: add the number of generated assets in the introductory description
- Fix wording for setup ingestion error

### Bug fixing
When a user was editing an asset's details, clicking outside the modal or on the 'X' button would close it without properly resetting the form. This was because the modal's internal value updated before the system could intercept the event and reset the form.

To fix this, the 'X' button has been removed and the clickToClose property has been added to disable closing the modal by clicking the overlay. Users can now only close the modal by clicking the 'Cancel' button when editing the asset details, ensuring the form resets correctly.