### PR TITLE
Add AWS infra token to Cloud filter Category

### DIFF
--- a/frontend_vue/src/utils/tokenServices.ts
+++ b/frontend_vue/src/utils/tokenServices.ts
@@ -56,7 +56,7 @@ export const tokenServices: TokenServicesType = {
       'You apply the Terraform plan to your AWS account, creating the decoy resources',
       'We send you an alert if any of the decoy resources are accessed',
     ],
-    category: TOKEN_CATEGORY.OTHER,
+    category: TOKEN_CATEGORY.CLOUD,
     keywords: ['aws', 'infra', 'bucket', 'cloud'],
     isCustomGenerateFlow: true,
   },


### PR DESCRIPTION
## Proposed changes

Move AWS infra token from 'Other' to 'Cloud' category on filter