### PR TITLE
Update email placeholder to use example.com format

### DIFF
--- a/canarytokens/settings.py
+++ b/canarytokens/settings.py
@@ -32,7 +32,7 @@ class SwitchboardSettings(BaseSettings):
     USING_NGINX: bool = True
     TEMPLATES_PATH: str = "../templates"
 
-    ALERT_EMAIL_FROM_ADDRESS: EmailStr = EmailStr("illegal@email.com")
+    ALERT_EMAIL_FROM_ADDRESS: EmailStr = EmailStr("your-email@example.com")
     ALERT_EMAIL_FROM_DISPLAY: str = "Canarytokens-Test"
     ALERT_EMAIL_SUBJECT: str = "Canarytokens Alert"
     MAX_ALERTS_PER_MINUTE: int = 1

--- a/frontend_vue/src/components/ui/GenerateTokenSettingsNotifications.vue
+++ b/frontend_vue/src/components/ui/GenerateTokenSettingsNotifications.vue
@@ -5,7 +5,7 @@
         id="email"
         type="text"
         required
-        placeholder="your-email@email.com"
+        placeholder="your-email@example.com"
         label="Mail me here when the alert fires"
         full-width
         :has-arrow="true"

--- a/frontend_vue/src/views/ComponentPreview.vue
+++ b/frontend_vue/src/views/ComponentPreview.vue
@@ -300,7 +300,7 @@
           id="email"
           type="text"
           required
-          placeholder="your-email@email.com"
+          placeholder="your-email@example.com"
           label="Arrow in third position"
           full-width
           :has-arrow="true"


### PR DESCRIPTION
## Proposed changes

This PR updates the email field placeholder from "your-email@email.com" to "your-email@example.com".

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)

**Before:**
<img width="3024" height="1652" alt="image" src="https://github.com/user-attachments/assets/9cdb56a5-e071-43bd-96b1-09ddb3208391" />

**After:** 
<img width="3024" height="1658" alt="image" src="https://github.com/user-attachments/assets/1e46a54d-88ce-4413-b139-3a24cd165b5d" />
