### PR TITLE
Remove deleted `wg` tokens from keymap

### DIFF
--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -14,8 +14,13 @@ import requests
 from pydantic import EmailStr, HttpUrl, ValidationError, parse_obj_as
 from twisted.logger import Logger
 
-from canarytokens import canarydrop as cand
-from canarytokens import models, tokens, constants
+from canarytokens import (
+    canarydrop as cand,
+    constants,
+    models,
+    tokens,
+    wireguard,
+)
 from canarytokens.exceptions import (
     CanarydropAuthFailure,
     NoCanarydropFound,
@@ -259,6 +264,9 @@ def delete_canarydrop(canarydrop: cand.Canarydrop) -> None:
         remove_webhook_token_idx(canarydrop.alert_webhook_url, token)
 
     remove_auth_token_idx(canarydrop.auth, token)
+
+    if canarydrop.type == models.TokenTypes.WIREGUARD:
+        wireguard.deleteCanarytokenPrivateKey(canarydrop.wg_key)
 
 
 # def _v2_compatibility_serialize_canarydrop(serialized_drop:dict[str, str], canarydrop:cand.Canarydrop)->dict[str, str]:


### PR DESCRIPTION
## Proposed changes
This change removes deleted wireguard tokens' public key from the key map, gracefully handling them instead of raising an error. It also adds that deletion step to the `/delete` endpoint.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)

## Manual tests
- [x] Without the modifications to `/delete`:
  - [x] made a token, fired it, deleted it, fired it again multiple times
  - [x] ensured that the `switchboard` log output showed:
    - [x] the firing
    - [x] removing from the key map
    - [x] token not found in the keymap on subsequent connection attempts
- [x] With the modification to `/delete`:
  - [x] made a token, deleted it, fired it
  - [x] ensured that the `switchboard` log output showed token not found in the keymap