### PR TITLE
Make sure all settings are present before enabling the aws infra token

### DIFF
--- a/canarytokens/aws_infra/aws_management.py
+++ b/canarytokens/aws_infra/aws_management.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import boto3
 from botocore.exceptions import ClientError
 
+from canarytokens.aws_infra.utils import AWS_INFRA_ENABLED
 from canarytokens.settings import FrontendSettings
 
 # Get the project root directory
@@ -54,9 +55,9 @@ def _get_resource(service: str, region_name: str = settings.AWS_INFRA_AWS_REGION
     )
 
 
-S3_RESOURCE = _get_resource("s3")
-SQS_CLIENT = _get_client("sqs")
-SSM_CLIENT = _get_client("ssm")
+S3_RESOURCE = _get_resource("s3") if AWS_INFRA_ENABLED else None
+SQS_CLIENT = _get_client("sqs") if AWS_INFRA_ENABLED else None
+SSM_CLIENT = _get_client("ssm") if AWS_INFRA_ENABLED else None
 
 
 def queue_management_request(payload: dict):

--- a/canarytokens/aws_infra/state_management.py
+++ b/canarytokens/aws_infra/state_management.py
@@ -3,12 +3,16 @@ import logging
 from canarytokens import queries
 from canarytokens.aws_infra.aws_management import get_current_ingestion_bus
 from canarytokens.aws_infra.utils import (
+    AWS_INFRA_ENABLED,
     generate_external_id,
     generate_inventory_role_name,
     generate_tf_module_prefix,
 )
 from canarytokens.canarydrop import Canarydrop
-from canarytokens.exceptions import AWSInfraOperationNotAllowed
+from canarytokens.exceptions import (
+    AWSInfraOperationNotAllowed,
+    CanarytokenTypeNotEnabled,
+)
 from canarytokens.models import AWSInfraState
 from canarytokens.settings import FrontendSettings
 
@@ -21,6 +25,12 @@ def initialise(canarydrop: Canarydrop) -> bool:
     Initialize the AWS infrastructure state for the canarydrop.
     This sets the initial state and generates an external ID if not already set.
     """
+
+    if not AWS_INFRA_ENABLED:
+        logging.error("AWS Infrastructure is not enabled in settings.")
+        raise CanarytokenTypeNotEnabled(
+            "The required settings have not been set for AWS Infrastructure Canarytoken in settings.py."
+        )
     canarydrop.aws_tf_module_prefix = generate_tf_module_prefix()
     canarydrop.aws_infra_ingestion_bus_name = get_current_ingestion_bus()
     canarydrop.aws_customer_iam_access_external_id = generate_external_id()

--- a/canarytokens/aws_infra/utils.py
+++ b/canarytokens/aws_infra/utils.py
@@ -8,10 +8,21 @@ import httpx
 from attr import dataclass
 from typing import Optional
 
+from canarytokens.settings import FrontendSettings
+
+settings = FrontendSettings()
 
 log = logging.getLogger()
 
-
+AWS_INFRA_ENABLED = (
+    settings.AWS_INFRA_AWS_ACCOUNT
+    and settings.AWS_INFRA_AWS_REGION
+    and settings.AWS_INFRA_SHARED_SECRET
+    and settings.AWS_INFRA_MANAGEMENT_REQUEST_SQS_URL
+    and settings.AWS_INFRA_CALLBACK_DOMAIN
+    and settings.AWS_INFRA_INGESTION_BUS
+    and settings.AWS_INFRA_TF_MODULE_BUCKET
+)
 S3_BUCKET_NAME_REGEX = re.compile(
     r"^(?!\d{1,3}(\.\d{1,3}){3}$)[a-z0-9][a-z0-9\.\-]{1,61}[a-z0-9]$"
 )

--- a/canarytokens/exceptions.py
+++ b/canarytokens/exceptions.py
@@ -52,3 +52,11 @@ class AWSInfraDataGenerationLimitReached(Exception):
     """
 
     pass
+
+
+class CanarytokenTypeNotEnabled(Exception):
+    """
+    Exception raised when a canarytoken type is not enabled.
+    """
+
+    pass

--- a/canarytokens/settings.py
+++ b/canarytokens/settings.py
@@ -147,7 +147,7 @@ class FrontendSettings(BaseSettings):
     GEMINI_SYSTEM_PROMPT: Optional[str]
     GEMINI_TEMPERATURE: Optional[str] = "1.8"
 
-    # temporary
+    # for local aws infra testing
     AWS_ACCESS_KEY_ID: Optional[str]
     AWS_SECRET_ACCESS_KEY: Optional[str]
     AWS_SESSION_TOKEN: Optional[str]

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -56,6 +56,7 @@ from canarytokens.canarydrop import Canarydrop
 from canarytokens.exceptions import (
     AWSInfraDataGenerationLimitReached,
     CanarydropAuthFailure,
+    CanarytokenTypeNotEnabled,
     NoCanarydropFound,
     AWSInfraOperationNotAllowed,
 )
@@ -2563,6 +2564,8 @@ def _(
     canarydrop.aws_region = token_request_details.aws_region
     try:
         aws_infra.initialise(canarydrop)
+    except CanarytokenTypeNotEnabled as e:
+        return JSONResponse({"message": str(e)})
     except Exception:
         return JSONResponse(
             {"message": "Failed to generate AWS Infra Canarytoken."}, status_code=500


### PR DESCRIPTION
Check that all required settings are present for the aws infra canarytoken before allowing both, the token to be generated and/or the aws client is loaded.