### PR TITLE
Add domain name validation for CSS and Cloned Site tokens

### DIFF
--- a/frontend_vue/src/utils/formValidators.ts
+++ b/frontend_vue/src/utils/formValidators.ts
@@ -60,6 +60,8 @@ const validationNotificationSettings = {
   webhook_url: Yup.string().url(validationMessages.validURL),
 };
 
+const validDnsRegexPattern = /^([a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,}$/;
+
 //@ts-expect-error comment out for POC
 export const formValidators: ValidateSchemaType = {
   [TOKENS_TYPE.WEB_BUG]: {
@@ -197,13 +199,17 @@ export const formValidators: ValidateSchemaType = {
   [TOKENS_TYPE.CLONED_WEBSITE]: {
     schema: Yup.object().shape({
       ...validationNotificationSettings,
-      clonedsite: Yup.string().required('Domain is required'),
+      clonedsite: Yup.string()
+        .required('Domain is required')
+        .matches(validDnsRegexPattern, 'Must be valid domain eg: example.com'),
     }),
   },
   [TOKENS_TYPE.CSS_CLONED_SITE]: {
     schema: Yup.object().shape({
       ...validationNotificationSettings,
-      expected_referrer: Yup.string().required('Domain is required'),
+      expected_referrer: Yup.string()
+        .required('Domain is required')
+        .matches(validDnsRegexPattern, 'Must be valid domain eg: example.com'),
     }),
   },
   [TOKENS_TYPE.KUBECONFIG]: {


### PR DESCRIPTION
## Proposed changes

Currently cloned site + css tokens do no perform domain validation. It's quite easy to make a mistake here and use, for example the https:// url for the domain, meaning the token will always fire.

This added validation should prevent this.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...