### PR TITLE
Store emails in lower case

### DIFF
--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -171,11 +171,11 @@ def add_canary_nxdomain(domain: str) -> int:
 
 
 def add_email_token_idx(email: str, canarytoken: str) -> int:
-    return DB.get_db().sadd(KEY_EMAIL_IDX + email, canarytoken)
+    return DB.get_db().sadd(KEY_EMAIL_IDX + email.lower(), canarytoken)
 
 
 def remove_email_token_idx(email: str, canarytoken: str) -> None:
-    DB.get_db().srem(KEY_EMAIL_IDX + email, canarytoken)
+    DB.get_db().srem(KEY_EMAIL_IDX + email.lower(), canarytoken)
 
 
 def add_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> int:
@@ -215,7 +215,7 @@ def delete_webhook_tokens(webhook: str):
 
 
 def list_email_tokens(email_address) -> set[str]:
-    return DB.get_db().smembers(KEY_EMAIL_IDX + email_address)
+    return DB.get_db().smembers(KEY_EMAIL_IDX + email_address.lower())
 
 
 def list_webhook_tokens(webhook) -> set[str]:

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -103,6 +103,22 @@ def test_email_case_management(setup_db):
         db.hget(KEY_CANARYDROP + canarytoken.value(), "alert_email_recipient") == email
     )
 
+    second_token = Canarytoken()
+    second_canarydrop = Canarydrop(
+        generate=True,
+        type=TokenTypes.DNS,
+        alert_email_enabled=True,
+        alert_email_recipient=email.lower(),
+        canarytoken=second_token,
+        memo="stuff happened",
+        browser_scanner_enabled=False,
+    )
+    save_canarydrop(second_canarydrop)
+
+    set_members = db.smembers(key.lower())
+    assert len(set_members) == 2
+    assert all([token.value() in set_members for token in [canarytoken, second_token]])
+
     delete_email_tokens(key)
 
 

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -98,7 +98,7 @@ def test_email_case_management(setup_db):
 
     key = KEY_EMAIL_IDX + email
     assert len(db.smembers(key)) == 0
-    assert len(db.smembers(key.lower)) == 1
+    assert len(db.smembers(key.lower())) == 1
 
     delete_email_tokens(key)
 

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -99,6 +99,9 @@ def test_email_case_management(setup_db):
     key = KEY_EMAIL_IDX + email
     assert len(db.smembers(key)) == 0
     assert len(db.smembers(key.lower())) == 1
+    assert (
+        db.hget(KEY_CANARYDROP + canarytoken.value(), "alert_email_recipient") == email
+    )
 
     delete_email_tokens(key)
 

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -80,6 +80,29 @@ def test_add_delete_email(setup_db):
     assert not db.exists(key)
 
 
+def test_email_case_management(setup_db):
+    db: StrictRedis = setup_db
+    email = "Test@test.com"
+
+    canarytoken = Canarytoken()
+    canarydrop = Canarydrop(
+        generate=True,
+        type=TokenTypes.DNS,
+        alert_email_enabled=True,
+        alert_email_recipient=email,
+        canarytoken=canarytoken,
+        memo="stuff happened",
+        browser_scanner_enabled=False,
+    )
+    save_canarydrop(canarydrop)
+
+    key = KEY_EMAIL_IDX + email
+    assert len(db.smembers(key)) == 0
+    assert len(db.smembers(key.lower)) == 1
+
+    delete_email_tokens(key)
+
+
 def test_add_hit_get_canarytoken(setup_db):
     canarytoken = Canarytoken()
 


### PR DESCRIPTION
## Proposed changes

Convert emails to lower case at query time to make sure keys with the same email but different case are unified. 

This requires a companion script to be run in parallel to ensure that existing keys will behave correctly

T11053

## Types of changes

Change is breaking prior to DB migration

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion