### PR TITLE
Respect `CANARY_MAX_HISTORY` and make the hit limit consistent

### DIFF
--- a/canarytokens/channel_http.py
+++ b/canarytokens/channel_http.py
@@ -222,7 +222,8 @@ class CanarytokenPage(InputChannel, resource.Resource):
                     for k, v in request.args.items()
                     if k.decode() not in ["key", "canarytoken", "name"]
                 }
-                canarydrop.add_additional_info_to_hit(
+                queries.add_additional_info_to_hit(
+                    canarytoken=canarydrop.canarytoken,
                     hit_time=key,
                     additional_info={
                         request.args[b"name"][0].decode(): additional_info
@@ -249,7 +250,8 @@ class CanarytokenPage(InputChannel, resource.Resource):
                     for k, v in request.args.items()
                     if k.decode() not in ["key", "canarytoken", "name"]
                 }
-                canarydrop.add_additional_info_to_hit(
+                queries.add_additional_info_to_hit(
+                    canarytoken=canarydrop.canarytoken,
                     hit_time=key,
                     additional_info={
                         request.args[b"name"][0].decode(): additional_info

--- a/canarytokens/settings.py
+++ b/canarytokens/settings.py
@@ -35,6 +35,7 @@ class SwitchboardSettings(BaseSettings):
     ALERT_EMAIL_FROM_ADDRESS: EmailStr = EmailStr("illegal@email.com")
     ALERT_EMAIL_FROM_DISPLAY: str = "Canarytokens-Test"
     ALERT_EMAIL_SUBJECT: str = "Canarytokens Alert"
+    MAX_HISTORY: int = 50
     MAX_ALERTS_PER_MINUTE: int = 1
     # Maximum number of alert failures before a mechanism is disabled
     MAX_ALERT_FAILURES: int = 5

--- a/frontend_vue/src/components/ManageToken.vue
+++ b/frontend_vue/src/components/ManageToken.vue
@@ -131,7 +131,7 @@ import DeleteTokenButton from '@/components/ui/DeleteTokenButton.vue';
 import MemoDisplay from '@/components/ui/MemoDisplay.vue';
 import TokenIcon from '@/components/icons/TokenIcon.vue';
 
-const MAX_ALERTS = 11;
+const MAX_ALERTS = 50;
 
 const route = useRoute();
 const router = useRouter();

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -24,7 +24,6 @@ from canarytokens.redismanager import (
     KEY_WEBHOOK_IDX,
 )
 from canarytokens.queries import (
-    add_canarydrop_hit,
     delete_canarydrop,
     delete_email_tokens,
     delete_webhook_tokens,
@@ -104,7 +103,7 @@ def test_add_hit_get_canarytoken(setup_db):
         is_tor_relay=False,
         input_channel="dns",
     )
-    add_canarydrop_hit(token_hit=token_hit, canarytoken=canarytoken)
+    canarydrop.add_canarydrop_hit(token_hit=token_hit)
     cd = get_canarydrop(canarytoken=canarytoken)
     assert cd.triggered_details
 
@@ -137,7 +136,7 @@ def test_add_hit_get_canarytoken_wrong_type(setup_db):
         useragent="Unknown",
     )
     with pytest.raises(ValueError):
-        add_canarydrop_hit(token_hit=token_hit, canarytoken=canarytoken)
+        canarydrop.add_canarydrop_hit(token_hit=token_hit)
     cd = get_canarydrop(canarytoken=canarytoken)
     assert cd.triggered_details
 
@@ -180,7 +179,7 @@ def test_delete_drop(setup_db):
         location="/get",
         useragent="Unknown",
     )
-    add_canarydrop_hit(token_hit=token_hit, canarytoken=canarytoken)
+    canarydrop.add_canarydrop_hit(token_hit=token_hit)
     cd = get_canarydrop(canarytoken=canarytoken)
 
     for key in critical_keys:


### PR DESCRIPTION
## Proposed changes

Canarytokens historically had a setting for the maximum number of hits tracked for a given token. This PR restores that config option, `CANARY_MAX_HISTORY`, and gives it a default value of 50.

Additionally, it resolves a bug whereby a different number of hits were kept depending on the HTTP method most recently used to trigger the token, and adds a unit test to ensure this no longer happens.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation Update

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
