### PR TITLE
Reduce coverage requirement for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         # Here we check coverage info on all tests
         run: |
           cd tests
-          poetry run coverage report --omit="integration/test_custom_binary.py,integration/test_sql_server_token.py" --fail-under 85
+          poetry run coverage report --omit="integration/test_custom_binary.py,integration/test_sql_server_token.py" --fail-under 75
         continue-on-error: ${{ github.ref_name != 'master' }}
 
 


### PR DESCRIPTION
## Proposed changes

Reduce the coverage requirement from 85 % to 75 %.

The coverage has fallen below 85 % for quite some time which means that the check is failing in our workflow and stopping subsequent actions from running (when on master). We should reduce it for now and try to adhere to it. When in future we add more tests we can increase it again.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x ] Lint and unit tests pass locally with my changes (if applicable)
- [ x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...