### PR TITLE
Add aws infra event name to email

### DIFF
--- a/templates/emails/_generated_dont_edit_notification.html
+++ b/templates/emails/_generated_dont_edit_notification.html
@@ -1112,6 +1112,9 @@
                                                 </p> {% endif %} {% if BasicDetails['additional_info']['decoy_resource']['Asset Name'] %} <p style="font-weight:600;display:block;line-height:1;margin:0;">Asset Name</p>
                                                 <p style="font-weight:400;color:#060606;margin:0 0 16px 0;">
                                                   <a href style="text-decoration:none !important; color:#060606">{{BasicDetails['additional_info']['decoy_resource']['Asset Name']}}</a>
+                                                </p> {% endif %} {% if BasicDetails['additional_info']['event']['Event Name'] %} <p style="font-weight:600;display:block;line-height:1;margin:0;">Event Name</p>
+                                                <p style="font-weight:400;color:#060606;margin:0 0 16px 0;">
+                                                  <a href style="text-decoration:none !important; color:#060606">{{BasicDetails['additional_info']['event']['Event Name']}}</a>
                                                 </p> {% endif %}
                                               </td>
                                             </tr>

--- a/templates/emails/notification.mjml
+++ b/templates/emails/notification.mjml
@@ -532,6 +532,12 @@
                   <a href="" style="text-decoration:none !important; color:#060606">{{BasicDetails['additional_info']['decoy_resource']['Asset Name']}}</a>
                 </p>
               {% endif %}
+              {% if BasicDetails['additional_info']['event']['Event Name'] %}
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">Event Name</p>
+                <p style="font-weight:400;color:#060606;margin:0 0 16px 0;">
+                  <a href="" style="text-decoration:none !important; color:#060606">{{BasicDetails['additional_info']['event']['Event Name']}}</a>
+                </p>
+              {% endif %}
               </td>
             </tr>
 

--- a/templates/emails/notification.txt
+++ b/templates/emails/notification.txt
@@ -103,6 +103,20 @@ WebDAV Client User-Agent:
   {{BasicDetails['additional_info']['useragent']}}
 {% endif %}
 {% endif %}
+{% if BasicDetails['token_type'] == 'aws_infra' %}
+{% if BasicDetails['additional_info']['decoy_resource']['asset_type'] %}
+Asset Type:
+  {{ BasicDetails['additional_info']['decoy_resource']['asset_type'] }}
+{% endif %}
+{% if BasicDetails['additional_info']['decoy_resource']['Asset Name'] %}
+Asset Name:
+  {{ BasicDetails['additional_info']['decoy_resource']['Asset Name'] }}
+{% endif %}
+{% if BasicDetails['additional_info']['event']['Event Name'] %}
+Event Name:
+  {{ BasicDetails['additional_info']['event']['Event Name'] }}
+{% endif %}
+{% endif %}
 {% if BasicDetails['generic_data'] +%}
 Generic data:
   {{ BasicDetails['generic_data']}}


### PR DESCRIPTION
## Proposed changes

Add the AWS Infra event name to the email html template and plain text template.

At the moment we do not have filtering for specific events (requested in https://github.com/thinkst/canarytokens/issues/797), In this change we add the event name to the email template so that the user is able to filter out emails with specific events on their end.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

I triggered an alert with the new templates and made sure that the email receive was displaying the field correctly for both the plain text and html.