### PR TITLE
Use smart union for TokenHit pydantic model

### DIFF
--- a/canarytokens/models.py
+++ b/canarytokens/models.py
@@ -1613,6 +1613,9 @@ class TokenHit(BaseModel):
     src_data: Optional[dict]  # v2 stores empty {} src_data for tokens without src_data.
     useragent: Optional[str]
 
+    class Config:
+        smart_union = True
+
     @validator("geo_info", pre=True)
     def adjust_geo_info(cls, value):
         # Allow loading v2 data.

--- a/tests/integration/test_against_token_server.py
+++ b/tests/integration/test_against_token_server.py
@@ -406,12 +406,12 @@ def test_web_bug_token(
     "location, referrer, version",
     [
         (
-            b"https://example.com/sitemap123456789123523134521239172390182312369879081283123126.xml",
-            b"",
+            "https://example.com/sitemap123456789123523134521239172390182312369879081283123126.xml",
+            "",
             v3,
         ),
-        (b"http://test.com/testloc", b"http://test.com/testref", v3),
-        (b"http://test.com/testloc2", b"about:blank", v3),
+        ("http://test.com/testloc", "http://test.com/testref", v3),
+        ("http://test.com/testloc2", "about:blank", v3),
     ],
 )
 def test_cloned_web_token(
@@ -605,7 +605,10 @@ def test_slow_redirect_token(
     token_history = SlowRedirectTokenHistory(**history_resp)
 
     assert len(token_history.hits) == 1
-    assert token_history.hits[0].additional_info.browser.vendor == ["Google Inc."]
+    token_hit = token_history.hits[0]
+    assert token_hit.location == location
+    assert token_hit.referer == referrer
+    assert token_hit.additional_info.browser.vendor == ["Google Inc."]
     #
 
 


### PR DESCRIPTION
## Proposed changes

Use smart_union for TokenHit pydantic models to ensure that the resulting type for fields remain consistent if there are environment changes.

In the TokenHit models we have fields like `referer` that have type `Union[str, byte]`. By default the pydantic model tries to coerce the input into both types and then chooses the best match. This is nondeterministic and the results can change when there are environment changes. For e.g. mapping a str input to `referer` could sometime result in a `byte` type and sometime in a `str` type. By adding the smart_union config, we ensure the result will match the type of the input.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...