### PR TITLE
AWS Infra: force sanitised names id data generation fails

### DIFF
--- a/canarytokens/aws_infra/data_generation.py
+++ b/canarytokens/aws_infra/data_generation.py
@@ -151,7 +151,7 @@ async def _finalize_list(
 
         if similarity_score < _SIMILARITY_THRESHOLD:
             validated_names.append(name)
-    return validated_names
+    return list(set(validated_names))
 
 
 async def _gemini_request(prompt: str):
@@ -206,6 +206,7 @@ def _sanitize_name(name: str) -> str:
     """
     Sanitize a name by replacing invalid characters and trimming to max length.
     """
+    name = name[1:] if name.startswith("/") else name
     sanitized = name.replace("/", "-")
     sanitized = sanitized[:_MAX_ASSET_NAME_LENGTH]
     while sanitized and not sanitized[-1].isalnum():
@@ -246,7 +247,8 @@ async def generate_names(
 
     while len(validated_names) < count:
         attempts += 1
-        if attempts == _NAME_GEN_MAX_ATTEMPTS:
+        # raise error with not at least one valid name after max attempts
+        if attempts == _NAME_GEN_MAX_ATTEMPTS and not validated_names:
             raise RuntimeError(
                 f"Failed to generate enough valid names for {asset_type.name} after {_NAME_GEN_MAX_ATTEMPTS} attempts."
             )


### PR DESCRIPTION
## Proposed changes

If Gemini fails to generate enough valid names for the AWS Infra token, try to force the sanitisation of the names after the last generation attempt.

The prompt does include instructions to generate valid names, this change is to guarantee valid names for in case Gemini did not follow these instructions. Also, instead of raising an error if not enough names were generated, we send the names that we did generate and only raise an error if no valid names were generated.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] Lint and unit tests pass locally with my changes (if applicable)
- [ ] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...