### PR TITLE
Fix for AWS Infra token "'NoneType' object has no attribute 'items'"

### DIFF
--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -893,14 +893,18 @@ class Canarytoken(object):
                     "Asset Name": next(
                         (
                             v
-                            for k, v in event_detail["requestParameters"].items()
+                            for k, v in (
+                                event_detail.get("requestParameters") or {}
+                            ).items()
                             if k in resource_name_keys
                         ),
                         "",
                     ),
                     "Request Parameters": ", ".join(
                         f"{k}: {v}"
-                        for k, v in event_detail["requestParameters"].items()
+                        for k, v in (
+                            event_detail.get("requestParameters") or {}
+                        ).items()
                     ),
                 },
                 identity={


### PR DESCRIPTION
## Proposed changes

Adds a default case to fall back on if `requestParameters` is ever empty so as to avoid an exception. Some AWS `eventName` don't send `requestParameters` (like `ListTables`) so the handler should parse this gracefully.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion