### PR TITLE
Restrict crawler indexing to root path only

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -286,13 +286,6 @@ app = FastAPI(
 vue_index = Jinja2Templates(directory="../dist/")
 
 
-def split_tags(tags: Optional[str]) -> set[str]:
-    """Split tags string into set of tags"""
-    if not tags:
-        return set()
-    return set(tag.strip() for tag in tags.split(","))
-
-
 if frontend_settings.NEW_UI:
 
     @app.get("/")
@@ -307,8 +300,7 @@ if frontend_settings.NEW_UI:
     def index(request: Request):
         response = vue_index.TemplateResponse("index.html", {"request": request})
         if request.url.path not in ["/", "/nest"]:
-            robot_tags = split_tags(response.headers.get("X-Robots-Tag"))
-            robot_tags.add("noindex")
+            robot_tags = ['noindex', 'nofollow']
             response.headers["X-Robots-Tag"] = ", ".join(robot_tags)
 
         return response


### PR DESCRIPTION
## Proposed changes

Currently, all paths can be picked up by web crawlers. This changes it so that web crawlers can only index the `/` and `/nest` paths.

## Types of changes
Adds `noindex` in `X-Robots-Tag` header.

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have manually verified the fix has worked.
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

Vue displays everything using `index.html`. To add the `noindex` header I had to add it on the python side.

I checked the headers using dev tools in my browser. I checked:

1. The landing page `/nest` did not have a `noindex` in `X-Robots-Tag` header.
2. Created a web bug token. Went to manage. Refreshed the page. Saw `noindex` in `X-Robots-Tag` header.