### PR TITLE
Add JA4 monitoring/reporting to CSS cloned site alerts

### DIFF
--- a/canarytokens/models/common.py
+++ b/canarytokens/models/common.py
@@ -483,7 +483,7 @@ class TokenHit(BaseModel):
         )
         if "additional_data" in additional_data:
             additional_data.update(**additional_data.pop("additional_data"))
-        for key, replacement in [("l", "location"), ("r", "referer")]:
+        for key, replacement in [("l", "location"), ("r", "referer"), ("ja4", "ja4")]:
             if key in additional_data:
                 additional_data[replacement] = additional_data.pop(key)
             if self.src_data and key in self.src_data:

--- a/canarytokens/models/common.py
+++ b/canarytokens/models/common.py
@@ -483,7 +483,7 @@ class TokenHit(BaseModel):
         )
         if "additional_data" in additional_data:
             additional_data.update(**additional_data.pop("additional_data"))
-        for key, replacement in [("l", "location"), ("r", "referer"), ("ja4", "ja4")]:
+        for key, replacement in [("l", "location"), ("r", "referer")]:
             if key in additional_data:
                 additional_data[replacement] = additional_data.pop(key)
             if self.src_data and key in self.src_data:

--- a/canarytokens/models/cssclonedsite.py
+++ b/canarytokens/models/cssclonedsite.py
@@ -30,6 +30,7 @@ class CSSClonedWebTokenResponse(TokenResponse):
 class CSSClonedWebTokenHit(TokenHit):
     token_type: Literal[TokenTypes.CSSCLONEDSITE] = TokenTypes.CSSCLONEDSITE
     referrer: Optional[str]
+    ja4: Optional[str]
 
 
 class CSSClonedWebTokenHistory(TokenHistory[CSSClonedWebTokenHit]):

--- a/canarytokens/models/cssclonedsite.py
+++ b/canarytokens/models/cssclonedsite.py
@@ -30,7 +30,7 @@ class CSSClonedWebTokenResponse(TokenResponse):
 class CSSClonedWebTokenHit(TokenHit):
     token_type: Literal[TokenTypes.CSSCLONEDSITE] = TokenTypes.CSSCLONEDSITE
     referrer: Optional[str]
-    ja4: Optional[str]
+    tls_ja4_fingerprint: Optional[str]
 
 
 class CSSClonedWebTokenHistory(TokenHistory[CSSClonedWebTokenHit]):

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -327,7 +327,7 @@ class Canarytoken(object):
         hit_time = request.args.get("ts_key", [datetime.utcnow().strftime("%s.%f")])[0]
 
         def flatten_singletons(d):
-            return d[0] if len(d) == 1 else d  # noqa: E731
+            return d[0] if len(d) == 1 else d
 
         request_headers = {
             k.decode(): flatten_singletons([s.decode() for s in v])

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -661,7 +661,11 @@ class Canarytoken(object):
 
         referer = request.getHeader("Referer")
         r_arg = request.args.get(b"r", [None])[0]
+        if r_arg and isinstance(r_arg, bytes):
+            r_arg = r_arg.decode()
         ja4_arg = request.args.get(b"ja4", [None])[0]
+        if ja4_arg and isinstance(ja4_arg, bytes):
+            ja4_arg = ja4_arg.decode()
         src_data = {"referer": referer, "referrer": r_arg, "ja4": ja4_arg}
         return http_general_info, src_data
 

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -325,7 +325,10 @@ class Canarytoken(object):
         src_ip_chain = [o.strip() for o in src_ips.split(",")]
         # TODO: 'ts_key' -> which tokens fire this?
         hit_time = request.args.get("ts_key", [datetime.utcnow().strftime("%s.%f")])[0]
-        flatten_singletons = lambda d: d[0] if len(d) == 1 else d  # noqa: E731
+
+        def flatten_singletons(d):
+            return d[0] if len(d) == 1 else d  # noqa: E731
+
         request_headers = {
             k.decode(): flatten_singletons([s.decode() for s in v])
             for k, v in request.requestHeaders.getAllRawHeaders()
@@ -666,7 +669,11 @@ class Canarytoken(object):
         ja4_arg = request.args.get(b"ja4", [None])[0]
         if ja4_arg and isinstance(ja4_arg, bytes):
             ja4_arg = ja4_arg.decode()
-        src_data = {"referer": referer, "referrer": r_arg, "ja4": ja4_arg}
+        src_data = {
+            "referer": referer,
+            "referrer": r_arg,
+            "tls_ja4_fingerprint": ja4_arg,
+        }
         return http_general_info, src_data
 
     @staticmethod

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -645,10 +645,7 @@ class Canarytoken(object):
 
         location = request.args.get(b"l", [None])[0]
         referer = request.args.get(b"r", [None])[0]
-        src_data = {
-            "location": location,
-            "referer": referer,
-        }
+        src_data = {"location": location, "referer": referer}
         return http_general_info, src_data
 
     @staticmethod
@@ -664,12 +661,8 @@ class Canarytoken(object):
 
         referer = request.getHeader("Referer")
         r_arg = request.args.get(b"r", [None])[0]
-        if r_arg is not None:
-            r_arg = r_arg.decode()
-        src_data = {
-            "referer": referer,
-            "referrer": r_arg,
-        }
+        ja4_arg = request.args.get(b"ja4", [None])[0]
+        src_data = {"referer": referer, "referrer": r_arg, "ja4": ja4_arg}
         return http_general_info, src_data
 
     @staticmethod

--- a/frontend_vue/src/components/tokens/types.ts
+++ b/frontend_vue/src/components/tokens/types.ts
@@ -287,6 +287,7 @@ export type HitsType = {
   mail?: string | null;
   referer?: string | null;
   referrer?: string | null;
+  ja4?: string | null;
   location?: string | GeolocationPosition | CoordsType | null;
 };
 

--- a/frontend_vue/src/components/tokens/types.ts
+++ b/frontend_vue/src/components/tokens/types.ts
@@ -287,7 +287,7 @@ export type HitsType = {
   mail?: string | null;
   referer?: string | null;
   referrer?: string | null;
-  ja4?: string | null;
+  tls_ja4_fingerprint?: string | null;
   location?: string | GeolocationPosition | CoordsType | null;
 };
 

--- a/frontend_vue/src/utils/IncidentTypes.ts
+++ b/frontend_vue/src/utils/IncidentTypes.ts
@@ -12,6 +12,7 @@ type BasicInfo = {
   merchant: string | null;
   mail: string | null;
   referer: string | null;
+  ja4: string | null;
   request_args: any | null;
   location:
     | string

--- a/frontend_vue/src/utils/IncidentTypes.ts
+++ b/frontend_vue/src/utils/IncidentTypes.ts
@@ -12,7 +12,7 @@ type BasicInfo = {
   merchant: string | null;
   mail: string | null;
   referer: string | null;
-  ja4: string | null;
+  tls_ja4_fingerprint: string | null;
   request_args: any | null;
   location:
     | string

--- a/frontend_vue/src/utils/incidentDetailsService.ts
+++ b/frontend_vue/src/utils/incidentDetailsService.ts
@@ -28,6 +28,7 @@ export default function incidentDetailsService(
     merchant: hitAlert.merchant || null,
     mail: hitAlert.mail || null,
     referer: hitAlert.referer || hitAlert.referrer || null,
+    ja4: hitAlert.ja4 || null,
     request_args: hitAlert?.request_args || null,
   };
 

--- a/frontend_vue/src/utils/incidentDetailsService.ts
+++ b/frontend_vue/src/utils/incidentDetailsService.ts
@@ -28,7 +28,7 @@ export default function incidentDetailsService(
     merchant: hitAlert.merchant || null,
     mail: hitAlert.mail || null,
     referer: hitAlert.referer || hitAlert.referrer || null,
-    ja4: hitAlert.ja4 || null,
+    tls_ja4_fingerprint: hitAlert.tls_ja4_fingerprint || null,
     request_args: hitAlert?.request_args || null,
   };
 

--- a/templates/emails/_generated_dont_edit_notification.html
+++ b/templates/emails/_generated_dont_edit_notification.html
@@ -1304,6 +1304,60 @@
         </tbody>
       </table>
     </div>
+    <!--[if mso | IE]></td></tr></table><![endif]--> {% endif %}<!-- JA4 -->{% if BasicDetails['ja4'] %} <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" bgcolor="#f6f8fb" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="background:#f6f8fb;background-color:#f6f8fb;margin:0px auto;max-width:540px;border-radius:16px 16px;overflow:hidden;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#f6f8fb;background-color:#f6f8fb;width:100%;border-collapse:separate;">
+                  <tbody>
+                    <tr>
+                      <td style="border-radius:16px 16px;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="vertical-align:top;padding:0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                                    <tbody>
+                                      <tr>
+                                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                          <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+                                              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                                                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px">
+                                              </td>
+                                              <td>
+                                                <p style="font-weight:600;display:block;line-height:1;margin:0;">JA4</p>
+                                                <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['ja4'] | e}}</p>
+                                              </td>
+                                            </tr>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <!--[if mso | IE]></td></tr></table><![endif]--> {% endif %}<!-- Referrer -->{% if BasicDetails['referrer'] %} <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">

--- a/templates/emails/_generated_dont_edit_notification.html
+++ b/templates/emails/_generated_dont_edit_notification.html
@@ -1250,6 +1250,60 @@
         </tbody>
       </table>
     </div>
+    <!--[if mso | IE]></td></tr></table><![endif]--> {% endif %}<!-- JA4 -->{% if BasicDetails['tls_ja4_fingerprint'] %} <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
+      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
+        <tbody>
+          <tr>
+            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
+              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" bgcolor="#f6f8fb" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
+              <div style="background:#f6f8fb;background-color:#f6f8fb;margin:0px auto;max-width:540px;border-radius:16px 16px;overflow:hidden;">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#f6f8fb;background-color:#f6f8fb;width:100%;border-collapse:separate;">
+                  <tbody>
+                    <tr>
+                      <td style="border-radius:16px 16px;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
+                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
+                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
+                            <tbody>
+                              <tr>
+                                <td style="vertical-align:top;padding:0px;">
+                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
+                                    <tbody>
+                                      <tr>
+                                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
+                                          <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
+                                            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+                                              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                                                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px">
+                                              </td>
+                                              <td>
+                                                <p style="font-weight:600;display:block;line-height:1;margin:0;">TLS JA4 Fingerprint</p>
+                                                <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['tls_ja4_fingerprint'] | e}}</p>
+                                              </td>
+                                            </tr>
+                                          </table>
+                                        </td>
+                                      </tr>
+                                    </tbody>
+                                  </table>
+                                </td>
+                              </tr>
+                            </tbody>
+                          </table>
+                        </div>
+                        <!--[if mso | IE]></td></tr></table><![endif]-->
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
     <!--[if mso | IE]></td></tr></table><![endif]--> {% endif %}<!-- Referer -->{% if BasicDetails['referer'] %} <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
     <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
       <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
@@ -1280,60 +1334,6 @@
                                               <td>
                                                 <p style="font-weight:600;display:block;line-height:1;margin:0;">Referer</p>
                                                 <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['referer'] | e}}</p>
-                                              </td>
-                                            </tr>
-                                          </table>
-                                        </td>
-                                      </tr>
-                                    </tbody>
-                                  </table>
-                                </td>
-                              </tr>
-                            </tbody>
-                          </table>
-                        </div>
-                        <!--[if mso | IE]></td></tr></table><![endif]-->
-                      </td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-              <!--[if mso | IE]></td></tr></table></td></tr></table><![endif]-->
-            </td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-    <!--[if mso | IE]></td></tr></table><![endif]--> {% endif %}<!-- JA4 -->{% if BasicDetails['ja4'] %} <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:600px;" width="600" bgcolor="#FFFFFF" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-    <div style="background:#FFFFFF;background-color:#FFFFFF;margin:0px auto;max-width:600px;">
-      <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#FFFFFF;background-color:#FFFFFF;width:100%;">
-        <tbody>
-          <tr>
-            <td style="direction:ltr;font-size:0px;padding:0px 30px 30px;text-align:center;">
-              <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" width="600px" ><table align="center" border="0" cellpadding="0" cellspacing="0" class="" role="presentation" style="width:540px;" width="540" bgcolor="#f6f8fb" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
-              <div style="background:#f6f8fb;background-color:#f6f8fb;margin:0px auto;max-width:540px;border-radius:16px 16px;overflow:hidden;">
-                <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#f6f8fb;background-color:#f6f8fb;width:100%;border-collapse:separate;">
-                  <tbody>
-                    <tr>
-                      <td style="border-radius:16px 16px;direction:ltr;font-size:0px;padding:20px 0;text-align:center;">
-                        <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:540px;" ><![endif]-->
-                        <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-                          <table border="0" cellpadding="0" cellspacing="0" role="presentation" width="100%">
-                            <tbody>
-                              <tr>
-                                <td style="vertical-align:top;padding:0px;">
-                                  <table border="0" cellpadding="0" cellspacing="0" role="presentation" style width="100%">
-                                    <tbody>
-                                      <tr>
-                                        <td align="left" style="font-size:0px;padding:10px 25px;word-break:break-word;">
-                                          <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:'Helvetica Neue', Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
-                                            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
-                                              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
-                                                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px">
-                                              </td>
-                                              <td>
-                                                <p style="font-weight:600;display:block;line-height:1;margin:0;">JA4</p>
-                                                <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['ja4'] | e}}</p>
                                               </td>
                                             </tr>
                                           </table>

--- a/templates/emails/notification.mjml
+++ b/templates/emails/notification.mjml
@@ -630,6 +630,30 @@
 
     </mj-wrapper>
     <mj-raw>{% endif %}</mj-raw>
+    
+    <!-- JA4 -->
+    <mj-raw>{% if BasicDetails['ja4'] %}</mj-raw>
+    <mj-wrapper padding="0px 30px 30px" background-color="#FFF">
+      <mj-section background-color="#f6f8fb" border-radius="16px 16px">
+        <mj-column width="100%" padding="0px">
+          <mj-table>
+
+            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px" />
+              </td>
+              <td>
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">JA4</p>
+                <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['ja4'] | e}}</p>
+              </td>
+            </tr>
+
+          </mj-table>
+        </mj-column>
+      </mj-section>
+
+    </mj-wrapper>
+    <mj-raw>{% endif %}</mj-raw>
 
     <!-- Referrer -->
     <mj-raw>{% if BasicDetails['referrer'] %}</mj-raw>
@@ -643,7 +667,7 @@
                 <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px" />
               </td>
               <td>
-                <p style="font-weight:600;display:block;line-height:1;margin:0;">Referer</p>
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">Referrer</p>
                 <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['referrer'] | e}}</p>
               </td>
             </tr>

--- a/templates/emails/notification.mjml
+++ b/templates/emails/notification.mjml
@@ -607,6 +607,30 @@
     </mj-wrapper>
     <mj-raw>{% endif %}</mj-raw>
 
+    <!-- JA4 -->
+    <mj-raw>{% if BasicDetails['tls_ja4_fingerprint'] %}</mj-raw>
+    <mj-wrapper padding="0px 30px 30px" background-color="#FFF">
+      <mj-section background-color="#f6f8fb" border-radius="16px 16px">
+        <mj-column width="100%" padding="0px">
+          <mj-table>
+
+            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
+              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
+                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px" />
+              </td>
+              <td>
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">TLS JA4 Fingerprint</p>
+                <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['tls_ja4_fingerprint'] | e}}</p>
+              </td>
+            </tr>
+
+          </mj-table>
+        </mj-column>
+      </mj-section>
+
+    </mj-wrapper>
+    <mj-raw>{% endif %}</mj-raw>
+
     <!-- Referer -->
     <mj-raw>{% if BasicDetails['referer'] %}</mj-raw>
     <mj-wrapper padding="0px 30px 30px" background-color="#FFF">
@@ -621,30 +645,6 @@
               <td>
                 <p style="font-weight:600;display:block;line-height:1;margin:0;">Referer</p>
                 <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['referer'] | e}}</p>
-              </td>
-            </tr>
-
-          </mj-table>
-        </mj-column>
-      </mj-section>
-
-    </mj-wrapper>
-    <mj-raw>{% endif %}</mj-raw>
-    
-    <!-- JA4 -->
-    <mj-raw>{% if BasicDetails['ja4'] %}</mj-raw>
-    <mj-wrapper padding="0px 30px 30px" background-color="#FFF">
-      <mj-section background-color="#f6f8fb" border-radius="16px 16px">
-        <mj-column width="100%" padding="0px">
-          <mj-table>
-
-            <tr style="color:#818a8e;font-size:16px;text-align:left;font-weight:600">
-              <td style="padding: 0px 10px; width:40px; font-weight:400; vertical-align: middle;" rowspan="2">
-                <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px" />
-              </td>
-              <td>
-                <p style="font-weight:600;display:block;line-height:1;margin:0;">JA4</p>
-                <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['ja4'] | e}}</p>
               </td>
             </tr>
 

--- a/templates/emails/notification.mjml
+++ b/templates/emails/notification.mjml
@@ -667,7 +667,7 @@
                 <img align="center" src="https://{{ BasicDetails['public_domain'] }}/resources/notification-email/default.png" width="40px" />
               </td>
               <td>
-                <p style="font-weight:600;display:block;line-height:1;margin:0;">Referrer</p>
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">Referer</p>
                 <p style="font-weight:400;color:#060606;margin:0;">{{ BasicDetails['referrer'] | e}}</p>
               </td>
             </tr>

--- a/templates/emails/notification.txt
+++ b/templates/emails/notification.txt
@@ -133,13 +133,13 @@ Event Name:
 Generic data:
   {{ BasicDetails['generic_data']}}
 {% endif %}
+{% if BasicDetails['tls_ja4_fingerprint'] +%}
+TLS JA4 Fingerprint:
+  {{ BasicDetails['tls_ja4_fingerprint']}}
+{% endif %}
 {% if BasicDetails['referer'] +%}
 Referer:
   {{ BasicDetails['referer']}}
-{% endif %}
-{% if BasicDetails['ja4'] +%}
-JA4:
-  {{ BasicDetails['ja4']}}
 {% endif %}
 {% if BasicDetails['referrer'] +%}
 Referer:

--- a/templates/emails/notification.txt
+++ b/templates/emails/notification.txt
@@ -137,6 +137,10 @@ Generic data:
 Referer:
   {{ BasicDetails['referer']}}
 {% endif %}
+{% if BasicDetails['ja4'] +%}
+JA4:
+  {{ BasicDetails['ja4']}}
+{% endif %}
 {% if BasicDetails['referrer'] +%}
 Referer:
   {{ BasicDetails['referrer']}}


### PR DESCRIPTION
## Proposed changes

These commits expose the client's JA4 fingerprint to the token server from the AWS Cloudfront Function and to the user. JA4 fingerprints provide an approximate way to track the TLS settings of a client, and are tracked in Entra ID sign-in logs. By monitoring these values, users can correlate those logs, as well as identify new AitM kits.

This also provides us the ability (in the future) to alert on suspicious JA4 values even when the referer is valid--catching AitM kits that proxy all traffic.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion
