### PR TITLE
fix: allow disabling CAPTCHA for on-premises deployments

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -840,28 +840,25 @@ async def api_download(
     response_model=FetchLinksResponse,
 )
 async def api_mail_token_list(request: FetchLinksRequest) -> JSONResponse:
-    if frontend_settings.CLOUDFLARE_TURNSTILE_SECRET is None:
-        return JSONResponse(
-            content={"message": FetchLinksMessage.NOT_CONFIGURED.value},
-            status_code=SERVICE_UNAVAILABLE,
-        )
-    if not request.cf_turnstile_response:
-        return JSONResponse(
-            content={"message": FetchLinksMessage.TURNSTILE_REQUIRED.value},
-            status_code=UNAUTHORIZED,
-        )
+    # Skip CAPTCHA validation if not configured (e.g., for on-premises deployments)
+    if frontend_settings.CLOUDFLARE_TURNSTILE_SECRET is not None:
+        if not request.cf_turnstile_response:
+            return JSONResponse(
+                content={"message": FetchLinksMessage.TURNSTILE_REQUIRED.value},
+                status_code=UNAUTHORIZED,
+            )
+        if not await queries.validate_turnstile(
+            cf_turnstile_secret=frontend_settings.CLOUDFLARE_TURNSTILE_SECRET,
+            cf_turnstile_response=request.cf_turnstile_response,
+        ):
+            return JSONResponse(
+                content={"message": FetchLinksMessage.INVALID_TURNSTILE.value},
+                status_code=UNAUTHORIZED,
+            )
     if not is_valid_email(request.email):
         return JSONResponse(
             content={"message": FetchLinksMessage.INVALID_EMAIL.value},
             status_code=BAD_REQUEST,
-        )
-    if not await queries.validate_turnstile(
-        cf_turnstile_secret=frontend_settings.CLOUDFLARE_TURNSTILE_SECRET,
-        cf_turnstile_response=request.cf_turnstile_response,
-    ):
-        return JSONResponse(
-            content={"message": FetchLinksMessage.INVALID_TURNSTILE.value},
-            status_code=UNAUTHORIZED,
         )
 
     token_set = queries.list_email_tokens(request.email)

--- a/frontend_vue/src/components/EnterManageLinkEmailModal.vue
+++ b/frontend_vue/src/components/EnterManageLinkEmailModal.vue
@@ -50,6 +50,7 @@
         />
 
         <vue-turnstile
+          v-if="cloudflareSiteKey"
           v-model="token"
           class="flex align-center justify-center mt-24"
           :site-key="cloudflareSiteKey"
@@ -105,7 +106,7 @@ const emailInput = ref();
 const formRef = ref();
 const errorMessage = ref('');
 const loading = ref(false);
-const disabled = computed(() => loading.value || !token.value);
+const disabled = computed(() => loading.value || (cloudflareSiteKey ? !token.value : false));
 const isSuccess = ref(false);
 
 watch(token, (newVal) => {
@@ -153,7 +154,11 @@ const onSubmit = async (values: GenericObject) => {
   errorMessage.value = '';
   const email = values.email;
 
-  if (!token.value || !email || loading.value) {
+  // Skip CAPTCHA validation if site key is not configured
+  if (cloudflareSiteKey && (!token.value || !email || loading.value)) {
+    return;
+  }
+  if (!email || loading.value) {
     return;
   }
 


### PR DESCRIPTION
## Problem

When running canarytokens on-premises with a local domain, clicking "My Tokens" triggers a Cloudflare Turnstile CAPTCHA that doesn't appear because Cloudflare can't resolve local domains (see thinkst/canarytokens-docker#200).

## Solution

Allow the "My Tokens" feature to work without CAPTCHA when `CLOUDFLARE_TURNSTILE_SECRET` is not configured:

### Backend changes (`frontend/app.py`):
- Skip CAPTCHA validation when `CLOUDFLARE_TURNSTILE_SECRET` is not set
- Proceed with email token list functionality without CAPTCHA verification

### Frontend changes (`frontend_vue/src/components/EnterManageLinkEmailModal.vue`):
- Conditionally render CAPTCHA widget only when `VITE_CLOUDFLARE_TURNSTILE_SITE_KEY` is set
- Adjust form validation to not require CAPTCHA token when site key is not configured
- Update submit button disabled state to account for missing CAPTCHA

## Testing

1. Without CAPTCHA configured: The "My Tokens" modal should work without showing CAPTCHA
2. With CAPTCHA configured: The existing CAPTCHA flow should continue to work

## Related Issue

Fixes thinkst/canarytokens-docker#200