### PR TITLE
Use the `PUBLIC_DOMAIN` for My Tokens mails

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -880,7 +880,7 @@ async def api_mail_token_list(request: FetchLinksRequest) -> JSONResponse:
                 islice(token_list, frontend_settings.TOKENS_FETCH_LIMIT)
             ),
             "token_list_length": len(token_list),
-            "public_domain": frontend_settings.DOMAINS[0],
+            "public_domain": switchboard_settings.PUBLIC_DOMAIN,
             "switchboard_scheme": switchboard_settings.SWITCHBOARD_SCHEME,
         }
         html_template_name = "token_list.html"


### PR DESCRIPTION
## Proposed changes
This PR changes My Tokens mails to use the `PUBLIC_DOMAIN` setting in links etc instead of one of the domains used for tokens.

Counter-intuitively, the frontend domain is specified in `switchboard.env`.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)

## Testing

I ran a local instance with mail creds configured and the setting:
```
CANARY_PUBLIC_DOMAIN=links.should.use.this.domain.zzzz.not.invalid
```
in `switchboard.env`.

After creating a token, I went through the My Tokens flow and checked that the manage link uses the correct domain:
<img width="1130" height="657" alt="Screenshot 2026-04-07 at 15 53 23" src="https://github.com/user-attachments/assets/6e0869a7-9121-4e0b-931e-71451f037453" />

The image also uses the same domain, and therefore (correctly) fails to load given the local test.

The plaintext mail is also correct:
```
Your Canarytokens
-----------------

You asked us for a list of your Canarytokens, so here it is! These are all the Canarytokens registered to your email address. With each is a Manage link, where you can configure or delete the Canarytoken.

If you didn't request this email, you can ignore or delete it.


  Type: Web bug
  Date: 2026-04-07 13:50 UTC
  Token ID: bhxp23uu2xr4wxf8plhb6njol
  Link: http://links.should.use.this.domain.zzzz.not.invalid/manage?token=bhxp23uu2xr4wxf8plhb6njol&auth=029bafcf33068141c91da6b0a649c7cd
```

