### PR TITLE
Make "Tor Known Exit Node" case consistent with other items in alert history

### DIFF
--- a/frontend_vue/src/components/constants.ts
+++ b/frontend_vue/src/components/constants.ts
@@ -140,7 +140,7 @@ export const INCIDENT_CHANNEL_TYPE_LABELS = {
 
 export const INCIDENT_DETAIL_CUSTOM_LABELS = {
   org: 'Organisation',
-  is_tor_relay: 'Tor Known Exit Node',
+  is_tor_relay: 'Tor known exit node',
   aws_keys: 'AWS Access Key ID',
   useragent: 'User-agent',
   src_port: 'Client Source Port',

--- a/frontend_vue/src/utils/incidentUtils.spec.ts
+++ b/frontend_vue/src/utils/incidentUtils.spec.ts
@@ -16,7 +16,7 @@ describe('formatLabels', () => {
         City: 'string',
         'Something else': 'value',
       },
-      'Tor Known Exit Node': true,
+      'Tor known exit node': true,
       'Token type': 'aws_keys',
     };
 
@@ -46,7 +46,7 @@ describe('formatLabels', () => {
       'Computer executing command': 'something',
       'Key Last Used': 'something',
       Organisation: 'something',
-      'Tor Known Exit Node': 'something',
+      'Tor known exit node': 'something',
       'User executing command': 'something',
       'User-agent': 'something',
     };


### PR DESCRIPTION

## Proposed changes
 In token alert history, all data point labels have only first word capitalized except "Tor Known Exit Node".  This modifies the displayed value to "Tor known exit node" to be consistent with the other data point labels.

Maniphest Tasks: T11946

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [X] Lint and unit tests pass locally with my changes (if applicable)
- [X] I have added necessary documentation (if appropriate)
