### PR TITLE
Fix tor exit node list not being fetched

### DIFF
--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import base64
 import datetime
+import ipaddress
 import json
 import re
 import secrets
@@ -16,6 +17,9 @@ import httpx
 import requests
 from pydantic import EmailStr, HttpUrl, ValidationError, parse_obj_as
 from twisted.logger import Logger
+from twisted.internet.defer import inlineCallbacks
+from twisted.web.client import Agent, readBody
+from twisted.internet import reactor
 
 from canarytokens import (
     canarydrop as cand,
@@ -713,21 +717,46 @@ def is_tor_relay(ip):
         update_tor_exit_nodes_loop()  # FIXME: DESIGN: we call deferred and expect a result in redis, Now!
     return DB.get_db().sismember(KEY_TOR_EXIT_NODES, json.dumps(ip))
 
+@inlineCallbacks
+def update_tor_exit_nodes():
+    agent = Agent(reactor)
+    response = yield agent.request(
+        b"GET",
+        b"https://check.torproject.org/exit-addresses",
+    )
 
-# def update_tor_exit_nodes(contents):
-#     if "ExitAddress" in contents:
-#         DB.get_db().delete(KEY_TOR_EXIT_NODES)
-#     for line in contents.splitlines():
-#         if "ExitAddress" in line:
-#             DB.get_db().sadd(KEY_TOR_EXIT_NODES, json.dumps(line.split(" ")[1]))
+    if response.code != 200:
+        log.error(f"Failed to update tor exit nodes, received status {response.code}")
+        return
+
+    body = yield readBody(response)
+    contents = body.decode("utf-8", errors="replace")
+
+    errored = False
+    ips = []
+    for line in contents.splitlines():
+        if "ExitAddress" in line:
+            parts = line.split()
+            if len(parts) < 2:
+                errored = True
+                break
+            try:
+                ip = ipaddress.ip_address(parts[1])
+                ips.append(str(ip))
+            except ValueError:
+                errored = True
+                break
+
+    if len(ips) == 0 or errored:
+        log.error("Received unexpected response format from server")
+        return
+
+    DB.get_db().delete(KEY_TOR_EXIT_NODES)
+    DB.get_db().sadd(KEY_TOR_EXIT_NODES, *ips)
 
 
 def update_tor_exit_nodes_loop():
-    # This breaks tests as it's an uncontrolled side effect
-    return
-    # d = getPage(b"https://check.torproject.org/exit-addresses")
-    # d.addCallback(update_tor_exit_nodes)
-
+    update_tor_exit_nodes()
 
 def get_certificate(key) -> models.KubeCerts:
     certificate = DB.get_db().hgetall("{}{}".format(KEY_KUBECONFIG_CERTS, key))

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from twisted.logger import LogLevel, capturedLogs
+from twisted.internet.defer import inlineCallbacks, succeed
 import pytest
 from pydantic import EmailStr
 from redis import StrictRedis
@@ -22,6 +23,7 @@ from canarytokens.redismanager import (
     KEY_CANARYDROPS_TIMELINE,
     KEY_EMAIL_IDX,
     KEY_WEBHOOK_IDX,
+    KEY_TOR_EXIT_NODES,
 )
 from canarytokens.queries import (
     delete_canarydrop,
@@ -473,6 +475,57 @@ def test_add_add_get_return_for_token(setup_db):
     queries.add_return_for_token("gif")
     assert queries.get_return_for_token() == "gif"
 
+@inlineCallbacks
+def test_update_tor_exit_nodes_http_not_ok(monkeypatch):
+    class MockResponse:
+        code = 404
+    class MockAgent:
+        def __init__(self, reactor): pass
+        def request(self, method, url):
+            return succeed(MockResponse())
+    monkeypatch.setattr(queries, "Agent", MockAgent)
+
+    with capturedLogs() as captured:
+        yield queries.update_tor_exit_nodes()
+
+    print(captured, len(captured))
+    assert "Failed to update tor exit nodes" in captured[0]["log_format"]
+    assert captured[0]["log_level"] == LogLevel.error
+
+@inlineCallbacks
+def test_update_tor_exit_nodes(setup_db, monkeypatch):
+    db: StrictRedis = setup_db
+    class MockResponse:
+        code = 200
+    class MockAgent:
+        def __init__(self, reactor): pass
+        def request(self, method, url):
+            return succeed(MockResponse())
+    def mock_read(url):
+        return succeed(b"""\
+ExitNode 46F8D3CCA2FE7C8D4907930CF0B8871BE7EA98E4
+Published 2026-04-13 13:36:56
+LastStatus 2026-04-14 06:00:00
+ExitAddress 38.135.24.245 2026-04-14 06:19:40
+ExitNode 376DC7CAD597D3A4CBB651999CFAD0E77DC9AE8C
+Published 2026-04-14 04:38:41
+LastStatus 2026-04-14 06:00:00
+ExitAddress 104.244.73.43 2026-04-14 06:11:46
+ExitNode 5D84900DBE6D6365684A9675B81A68ACE9577A68
+Published 2026-04-14 04:17:21
+LastStatus 2026-04-14 06:00:00
+ExitAddress 104.244.73.193 2026-04-14 06:33:13
+"""
+        )
+
+    monkeypatch.setattr(queries, "Agent", MockAgent)
+    monkeypatch.setattr(queries, "readBody", mock_read)
+
+    db.delete(KEY_TOR_EXIT_NODES)
+    yield queries.update_tor_exit_nodes()
+    nodes = db.smembers(KEY_TOR_EXIT_NODES)
+    for ip in ("38.135.24.245", "104.244.73.43", "104.244.73.193"):
+        assert ip in nodes
 
 @pytest.mark.parametrize(
     "target, expect_block",


### PR DESCRIPTION
## Proposed changes

Tor exit node checking was broken in a refactor some time ago.  This fixes the tor exit node checking feature.  See T11995

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [X] Lint and unit tests pass locally with my changes (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
