### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -14,24 +14,33 @@ on:
         required: false
         default: "master"
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
     env:
       COPYFILE_DISABLE: 1
 
     steps:
       - name: set Canarytokens Docker repo branch
+        env:
+          INPUT_BRANCH: ${{ github.event.inputs.canarytokens-docker-branch }}
         run: |
-          if [ -z "${{ github.event.inputs.canarytokens-docker-branch }}" ]; then
+          if [ -z "$INPUT_BRANCH" ]; then
             BRANCH="master"
           else
-            BRANCH="${{ github.event.inputs.canarytokens-docker-branch }}"
+            BRANCH="$INPUT_BRANCH"
           fi
           echo "CANARYTOKENS_DOCKER_BRANCH=$BRANCH" >> "$GITHUB_ENV"
 
 
-      - uses: actions/checkout@v4.2.0
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
 
       - name: Fetch dockerfile
         run: |
@@ -40,17 +49,17 @@ jobs:
             -o dockerfiles/Dockerfile.ci
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5.5.1
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
         with:
           images: |
             thinkst/canarytokens
@@ -66,7 +75,7 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v6.8.0
+        uses: docker/build-push-action@32945a339266b759abcbdc89316275140b0fc960 # v6.8.0
         with:
           context: .
           file: dockerfiles/Dockerfile.ci

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -49,7 +49,7 @@ jobs:
             -o dockerfiles/Dockerfile.ci
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to DockerHub
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0

--- a/.github/workflows/build_docker.yml
+++ b/.github/workflows/build_docker.yml
@@ -180,6 +180,8 @@ jobs:
   trigger_playwright:
       needs: test-gate
       if: ${{ always() && needs.test-gate.result == 'success' && needs.test-gate.outputs.ran_any == 'true' }}
+      permissions:
+        contents: read
       uses: ./.github/workflows/playwright.yml
       with:
         branch: "${{ github.ref_name }}"

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,35 +14,44 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   chrome:
     runs-on: ubuntu-latest
     name: Playwright E2E tests
     steps:
       - name: Checkout 🔖
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           ref: "${{ inputs.branch }}"
+          persist-credentials: false
 
       - name: Setup Node.js 🔨
-        uses: actions/setup-node@v4.0.4
+        uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
         with:
           node-version: 20
 
       - name: Set Test Domain Environment Variable
+        env:
+          INPUT_BRANCH: ${{ inputs.branch }}
+          SSL_URL: ${{ secrets.SSL_SECURE_SERVER_URL }}
+          HONEYPDFS_URL: ${{ secrets.HONEYPDFS_URL }}
+          SYRUPPDFS_URL: ${{ secrets.SYRUPPDFS_URL }}
         run: |
-          if [ "${{ inputs.branch }}" == "master" ]; then
-            echo "PLAYWRIGHT_BASE_URL=${{ secrets.SSL_SECURE_SERVER_URL }}" >> $GITHUB_ENV
-          elif [ "${{ inputs.branch }}" == "dev" ]; then
-            echo "PLAYWRIGHT_BASE_URL=${{ secrets.HONEYPDFS_URL }}" >> $GITHUB_ENV
-          elif [ "${{ inputs.branch }}" == "dev2" ]; then
-            echo "PLAYWRIGHT_BASE_URL=${{ secrets.SYRUPPDFS_URL }}" >> $GITHUB_ENV
+          if [ "$INPUT_BRANCH" == "master" ]; then
+            echo "PLAYWRIGHT_BASE_URL=$SSL_URL" >> $GITHUB_ENV
+          elif [ "$INPUT_BRANCH" == "dev" ]; then
+            echo "PLAYWRIGHT_BASE_URL=$HONEYPDFS_URL" >> $GITHUB_ENV
+          elif [ "$INPUT_BRANCH" == "dev2" ]; then
+            echo "PLAYWRIGHT_BASE_URL=$SYRUPPDFS_URL" >> $GITHUB_ENV
           else
-            echo "${{ inputs.branch }}: No matching branch for domain testing. Exiting." && exit 1
+            echo "$INPUT_BRANCH: No matching branch for domain testing. Exiting." && exit 1
           fi
 
       - name: Debug Test Domain
-        run: echo "PLAYWRIGHT_BASE_URL=${{ env.PLAYWRIGHT_BASE_URL }}"
+        run: echo "PLAYWRIGHT_BASE_URL=$PLAYWRIGHT_BASE_URL"
 
       - name: Install dependencies
         run: |
@@ -56,7 +65,7 @@ jobs:
           npx playwright test
 
       - name: Upload screenshots of tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-screenshots
@@ -65,7 +74,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -65,7 +65,7 @@ jobs:
           npx playwright test
 
       - name: Upload screenshots of tests
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ !cancelled() }}
         with:
           name: playwright-screenshots
@@ -74,7 +74,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ !cancelled() }}
         with:
           name: playwright-report

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -3,13 +3,15 @@ on:
   schedule:
     - cron: "0 12 * * *"
 
+permissions: {}
+
 jobs:
   stale:
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 14

--- a/.github/workflows/stale_issues.yml
+++ b/.github/workflows/stale_issues.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 14

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ on:
       canarytokens-branch:
         description: "Branch of the canarytokens repo to pull for build. Defaults to master"
         required: false
+
+permissions: {}
+
 jobs:
   tests:
     runs-on: ubuntu-latest
@@ -54,17 +57,18 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
         with:
           role-to-assume: arn:aws:iam::211125554061:role/Canarytokens-staging-github-action
           role-session-name: GitHubActions-${{ github.actor }}-${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}
           aws-region: ${{ env.AWS_REGION }}
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: '${{ github.event.inputs.canarytokens-branch }}'
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full python version
@@ -87,7 +91,7 @@ jobs:
           sudo apt-get install -y osslsigncode
           sudo apt install redis-tools
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
@@ -145,9 +149,13 @@ jobs:
 
   windows-tests:
     runs-on: windows-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.13'
       - name: Install deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full python version
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
       - name: Install deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,12 +57,12 @@ jobs:
 
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@ff717079ee2060e4bcee96c4779b553acc87447c # v4
+        uses: aws-actions/configure-aws-credentials@a03048d87541d1d9fcf2ecf528a4a65ba9bd7838 # v5.0.0
         with:
           role-to-assume: arn:aws:iam::211125554061:role/Canarytokens-staging-github-action
           role-session-name: GitHubActions-${{ github.actor }}-${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}
           aws-region: ${{ env.AWS_REGION }}
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           ref: '${{ github.event.inputs.canarytokens-branch }}'
           persist-credentials: false
@@ -152,7 +152,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
       - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Get full python version
@@ -91,7 +91,7 @@ jobs:
           sudo apt-get install -y osslsigncode
           sudo apt install redis-tools
       - name: Set up cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.full-python-version.outputs.version }}-${{ hashFiles('**/poetry.lock') }}
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.13'
       - name: Install deps


### PR DESCRIPTION
## Summary
- Pin all action references to SHA hashes to prevent supply chain attacks
- Add explicit least-privilege `permissions` blocks to all workflows
- Set `persist-credentials: false` on all checkout steps
- Fix template injection in `build_docker.yml` and `playwright.yml` by using environment variables instead of direct expression expansion in `run` blocks