### PR TITLE
Cleanup canarydrop on failed AWS API token creation

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1865,6 +1865,7 @@ def _create_aws_key_token_response(
         )
     except Exception as e:
         capture_exception(error=e, context=("get_aws_key", None))
+        queries.delete_canarydrop(canarydrop)
         # We can fail by getting 404 from AWSID_URL or failing validation
         return JSONResponse(
             {"message": "Failed to generate AWS Keys. We looking into it."},


### PR DESCRIPTION
## Proposed changes

When we create the AWS API canarydrop, we first try and generate the aws id creds, then update the canarydrop with those keys. This means that when we fail to generate new creds (for whatever reason) we still create the drops.

We need update the logic to remove the drop on failed key creation as these tokens are just left dangling.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [X] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion