### PR TITLE
Fix scrollbar on code snippets

### DIFF
--- a/frontend_vue/src/components/base/BaseCodeSnippet.vue
+++ b/frontend_vue/src/components/base/BaseCodeSnippet.vue
@@ -31,7 +31,7 @@
         :id="label"
         :code="code"
         :lang="lang"
-        class="min-h-[3.5rem] overflow-scroll rounded-2xl"
+        class="min-h-[3.5rem] overflow-auto rounded-2xl"
         :style="{
           height: componentHeight,
         }"


### PR DESCRIPTION
Inside the code snippet component, we currently always display the scrollbar, even when the content does not overflow. This one-line change ensures the scrollbar only appears when necessary.

Test:
We overlooked this issue because most macOS users have a system setting (Appearance > Show scrollbars) that automatically hides them when they aren't needed. 

If you cannot reproduce the issue, please adjust that setting to "Always" to see the fix in action.

Before:
<img width="584" height="375" alt="Screenshot 2026-05-11 at 09 54 58" src="https://github.com/user-attachments/assets/4fbe5756-0aeb-4a3b-8ae8-307c3ba355c3" />
<img width="842" height="485" alt="Screenshot 2026-05-11 at 09 43 50" src="https://github.com/user-attachments/assets/3fea7348-bbb7-42bc-9efd-885ae92ca10e" />


After:
<img width="581" height="342" alt="Screenshot 2026-05-11 at 09 54 47" src="https://github.com/user-attachments/assets/6946d25d-f215-4427-82f6-2d72c2f4bc91" />
<img width="722" height="501" alt="Screenshot 2026-05-11 at 09 43 43" src="https://github.com/user-attachments/assets/246de110-112b-4c68-89c2-e376da50be4d" />

