### PR TITLE
Add acquirer identifier to cc token

### DIFF
--- a/canarytokens/credit_card_v2.py
+++ b/canarytokens/credit_card_v2.py
@@ -75,6 +75,7 @@ class CreditCardTrigger3DSNotification(BaseModel):
     transaction_amount: Optional[str]
     transaction_currency: Optional[str]
     merchant_identifier: Optional[str]
+    acquirer_identifier: Optional[str]
 
 
 class CreditCardTriggerTransaction(BaseModel):
@@ -90,6 +91,7 @@ class CreditCardTriggerTransaction(BaseModel):
     transaction_type: Optional[str]
     status: Optional[str]
     merchant_identifier: Optional[str]
+    acquirer_identifier: Optional[str]
 
 
 AnyCreditCardTrigger = Union[

--- a/canarytokens/models/credit_card_v2.py
+++ b/canarytokens/models/credit_card_v2.py
@@ -19,6 +19,7 @@ from .common import (
 class CreditCardV2AdditionalInfo(BaseModel):
     merchant: Optional[str]
     merchant_identifier: Optional[str]
+    acquirer_identifier: Optional[str]
     transaction_amount: Optional[str]
     transaction_currency: Optional[str]
     masked_card_number: Optional[str]

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -560,14 +560,17 @@ class Canarytoken(object):
         if merchant := request_data.get("merchant") or request_data.get(
             "merchant_detail"
         ):
-            merchant_identifier = merchant.get("identifier") or merchant.get(
-                "merchant_id"
-            )
-
             if merchant_identifier := merchant.get("identifier") or merchant.get(
                 "merchant_id"
             ):
                 request_data["merchant_identifier"] = merchant_identifier
+
+            if acquirer_identifier := merchant.get("acquirer_id"):
+                request_data["acquirer_identifier"] = acquirer_identifier
+            elif acquirer_identifier := request_data.get(
+                "acquiring_institution_identifier"
+            ):
+                request_data["acquirer_identifier"] = acquirer_identifier
 
             request_data["merchant"] = ", ".join(
                 v

--- a/frontend_vue/src/components/tokens/types.ts
+++ b/frontend_vue/src/components/tokens/types.ts
@@ -252,6 +252,7 @@ export type AdditionalInfoType = {
   useragent?: null | string;
   merchant?: string;
   merchant_identifier?: string;
+  acquirer_identifier?: string;
   transaction_amount?: string;
   transaction_currency?: string;
   masked_card_number?: string;
@@ -282,6 +283,7 @@ export type HitsType = {
   amount?: string | null;
   merchant?: string | null;
   merchant_identifier?: string | null;
+  acquirer_identifier?: string | null;
   mail?: string | null;
   referer?: string | null;
   referrer?: string | null;

--- a/templates/emails/_generated_dont_edit_notification.html
+++ b/templates/emails/_generated_dont_edit_notification.html
@@ -998,6 +998,9 @@
                                                 </p> {% endif %} {% if BasicDetails['additional_info']['merchant_identifier'] %} <p style="font-weight:600;display:block;line-height:1;margin:0;">Merchant identifier</p>
                                                 <p style="font-weight:400;color:#060606;margin:0 0 16px 0;">
                                                   <a href style="text-decoration:none !important; color:#060606">{{BasicDetails['additional_info']['merchant_identifier'] | e}}</a>
+                                                </p> {% endif %} {% if BasicDetails['additional_info']['acquirer_identifier'] %} <p style="font-weight:600;display:block;line-height:1;margin:0;">Acquirer identifier</p>
+                                                <p style="font-weight:400;color:#060606;margin:0 0 16px 0;">
+                                                  <a href style="text-decoration:none !important; color:#060606">{{BasicDetails['additional_info']['acquirer_identifier'] | e}}</a>
                                                 </p> {% endif %} {% if BasicDetails['additional_info']['transaction_amount'] %} <p style="font-weight:600;display:block;line-height:1;margin:0;">Transaction amount</p>
                                                 <p style="font-weight:400;color:#060606;margin:0;">{{BasicDetails['additional_info']['transaction_amount']}} {{BasicDetails['additional_info']['transaction_currency']}}</p> {% endif %}
                                               </td>

--- a/templates/emails/notification.mjml
+++ b/templates/emails/notification.mjml
@@ -465,6 +465,12 @@
                   <a href="" style="text-decoration:none !important; color:#060606">{{BasicDetails['additional_info']['merchant_identifier'] | e}}</a>
                 </p>
               {% endif %}
+              {% if BasicDetails['additional_info']['acquirer_identifier'] %}
+                <p style="font-weight:600;display:block;line-height:1;margin:0;">Acquirer identifier</p>
+                <p style="font-weight:400;color:#060606;margin:0 0 16px 0;">
+                  <a href="" style="text-decoration:none !important; color:#060606">{{BasicDetails['additional_info']['acquirer_identifier'] | e}}</a>
+                </p>
+              {% endif %}
               {% if BasicDetails['additional_info']['transaction_amount'] %}
                 <p style="font-weight:600;display:block;line-height:1;margin:0;">Transaction amount</p>
                 <p style="font-weight:400;color:#060606;margin:0;">{{BasicDetails['additional_info']['transaction_amount']}} {{BasicDetails['additional_info']['transaction_currency']}}</p>

--- a/templates/emails/notification.txt
+++ b/templates/emails/notification.txt
@@ -92,6 +92,10 @@ Authorizing merchant:
 Merchant identifier:
   {{BasicDetails['additional_info']['merchant_identifier']}}
 {% endif %}
+{% if BasicDetails['additional_info']['acquirer_identifier'] +%}
+Acquirer identifier:
+  {{BasicDetails['additional_info']['acquirer_identifier']}}
+{% endif %}
 {% if BasicDetails['additional_info']['transaction_amount'] +%}
 Transaction amount:
   {{BasicDetails['additional_info']['transaction_amount']}} {{BasicDetails['additional_info']['transaction_currency']}}

--- a/tests/units/test_http_channel.py
+++ b/tests/units/test_http_channel.py
@@ -473,6 +473,7 @@ def test_POST_cc_token_v2_back(
     )
 
     merchant_identifier = "MID123456789"
+    acquirer_identifier = "AID987654321"
     merchant_name = "ACME Airline Co."
     merchant_city = "New York"
     merchant_country = "US"
@@ -488,6 +489,7 @@ def test_POST_cc_token_v2_back(
         "transaction_currency": currency,
         "merchant_detail": {
             "identifier": merchant_identifier,
+            "acquirer_id": acquirer_identifier,
             "name": merchant_name,
             "city": merchant_city,
             "country": merchant_country,
@@ -513,6 +515,7 @@ def test_POST_cc_token_v2_back(
     hit_info = hit.additional_info
 
     assert hit_info.merchant_identifier == merchant_identifier
+    assert hit_info.acquirer_identifier == acquirer_identifier
     assert hit_info.masked_card_number == masked_card
     assert hit_info.transaction_amount == amount
     assert hit_info.transaction_currency == currency


### PR DESCRIPTION
## Proposed changes
Add acquirer_identifier field to cc token alerts

The field is exposed by our service provider. The field is the unique identifier of the acquiring institution i.e. the financial institution that processes card payments on behalf of the merchant (the merchant's bank).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Testing
1. Create a Credit Card token.
2. Trigger the incident.
3. Acquirer identifier will be present in the alert email as well as in the alerts history.