### PR TITLE
Improve tor exit node list request behavior during tests

### DIFF
--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -712,10 +712,16 @@ def is_email_blocked(email):
     ) or DB.get_db().sismember(KEY_EMAIL_BLOCK_LIST, san)
 
 
-def is_tor_relay(ip):
+def is_tor_relay(ip: str) -> Optional[bool]:
     if not DB.get_db().exists(KEY_TOR_EXIT_NODES):
-        update_tor_exit_nodes_loop()  # FIXME: DESIGN: we call deferred and expect a result in redis, Now!
-    return DB.get_db().sismember(KEY_TOR_EXIT_NODES, json.dumps(ip))
+        log.warn("is_tor_relay used before exit node list exists")
+        return None
+    return bool(DB.get_db().sismember(KEY_TOR_EXIT_NODES, ip))
+
+
+def clear_tor_exit_nodes() -> None:
+    DB.get_db().delete(KEY_TOR_EXIT_NODES)
+
 
 @inlineCallbacks
 def update_tor_exit_nodes():
@@ -753,10 +759,8 @@ def update_tor_exit_nodes():
 
     DB.get_db().delete(KEY_TOR_EXIT_NODES)
     DB.get_db().sadd(KEY_TOR_EXIT_NODES, *ips)
+    return ips
 
-
-def update_tor_exit_nodes_loop():
-    update_tor_exit_nodes()
 
 def get_certificate(key) -> models.KubeCerts:
     certificate = DB.get_db().hgetall("{}{}".format(KEY_KUBECONFIG_CERTS, key))

--- a/switchboard/switchboard.tac
+++ b/switchboard/switchboard.tac
@@ -24,7 +24,7 @@ from canarytokens.loghandlers import WebhookLogObserver
 from canarytokens.queries import (
     add_return_for_token,
     set_ip_info_api_key,
-    update_tor_exit_nodes_loop,
+    update_tor_exit_nodes,
 )
 from canarytokens.redismanager import DB
 from canarytokens.settings import FrontendSettings, SwitchboardSettings
@@ -172,7 +172,7 @@ canarytokens_wireguard = ChannelWireGuard(
 canarytokens_wireguard.service.setServiceParent(application)
 
 # loop to update tor exit nodes every 30 min
-loop_http = internet.task.LoopingCall(update_tor_exit_nodes_loop)
+loop_http = internet.task.LoopingCall(update_tor_exit_nodes)
 loop_http.start(1800)
 
 # Start the cleanup daemon for inactive AWS infra canarydrops.

--- a/tests/integration/test_upstream_servers.py
+++ b/tests/integration/test_upstream_servers.py
@@ -1,0 +1,17 @@
+from canarytokens import queries
+from twisted.internet.defer import inlineCallbacks
+
+@inlineCallbacks
+def test_upstream_tor_exit_nodes_list(setup_db):
+    # Test the real upstream exactly once to not overload it with requests
+    # originating from CI, but still be alerted if it stops working
+
+    queries.clear_tor_exit_nodes()
+    assert queries.is_tor_relay('8.8.8.8') is None
+
+    ips = yield queries.update_tor_exit_nodes()
+    assert len(ips) > 10
+    for ip in ips:
+        assert queries.is_tor_relay(ip) is True
+
+    assert queries.is_tor_relay('8.8.8.8') is False

--- a/tests/units/test_queries.py
+++ b/tests/units/test_queries.py
@@ -488,7 +488,6 @@ def test_update_tor_exit_nodes_http_not_ok(monkeypatch):
     with capturedLogs() as captured:
         yield queries.update_tor_exit_nodes()
 
-    print(captured, len(captured))
     assert "Failed to update tor exit nodes" in captured[0]["log_format"]
     assert captured[0]["log_level"] == LogLevel.error
 


### PR DESCRIPTION
## Proposed changes

We were seeing warnings in tests performed in CI regarding failed requests to fetch the tor exit node list.  The cause appears to be related to rate limiting due to more requests than anticipated, so this ensures the exit node list is only requested once per pipeline.  See T12455

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [X] Lint and unit tests pass locally with my changes (if applicable)
- [X] I have added tests that prove my fix is effective or that my feature works
