### PR TITLE
Redirect `/legal` to `/nest/legal`

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -613,7 +613,7 @@ async def api_generate(  # noqa: C901  # gen is large
             # raise HTTPException(status_code=400, detail="Email is blocked.")
             return response_error(
                 6,
-                "Blocked email supplied. Please see our Acceptable Use Policy at https://canarytokens.org/legal",
+                "Blocked email supplied. Please see our Acceptable Use Policy at https://canarytokens.org/nest/legal",
             )
 
     if token_request_details.token_type == TokenTypes.CREDIT_CARD_V2:

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -290,6 +290,7 @@ vue_index = Jinja2Templates(directory="../dist/")
 
 
 @app.get("/")
+@app.get("/legal")
 @app.get("/nest/legal")
 @app.get("/manage")
 @app.get("/nest/manage/{rest_of_path:path}")


### PR DESCRIPTION
## Proposed changes

Our `/legal` page now lives at `/nest/legal`. This PR redirects the old URL to the new one and corrects one place it is outdated in the codebase.

## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
