### PR TITLE
Skip running tests for PRs from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ on:
         required: false
 jobs:
   tests:
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
     env:
       AWS_REGION: 'eu-west-1'


### PR DESCRIPTION
## Proposed changes

The tests can't work for outside contributor forks because they require certain secrets that are not exposed to outside contributors. The workflow just errors because of GitHub's security model. So this change skips running tests where the pull request origin is a fork.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update