### PR TITLE
Temporarily disable CrowdStrike Canarytoken while resolving integration issues

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1962,6 +1962,13 @@ def _create_crowdstrike_cc_token_response(
     canarydrop: Canarydrop,
     settings: Optional[FrontendSettings] = None,
 ) -> CrowdStrikeCCTokenResponse:
+    return JSONResponse(
+        {
+            "msg": "CrowdStrike API Key creation paused while CrowdStrike integration issues are being resolved."
+        },
+        status_code=SERVICE_UNAVAILABLE,
+    )
+
     if settings is None:
         settings = frontend_settings
 

--- a/frontend_vue/src/utils/tokenServices.ts
+++ b/frontend_vue/src/utils/tokenServices.ts
@@ -517,23 +517,23 @@ export const tokenServices: TokenServicesType = {
     category: [TOKEN_CATEGORY.CLOUD, TOKEN_CATEGORY.PHISHING],
     keywords: [],
   },
-  [TOKENS_TYPE.CROWDSTRIKE_CC]: {
-    label: 'CrowdStrike API key',
-    description:
-      'Get an alert when an attacker uses your CrowdStrike API credentials.',
-    documentationLink: 'https://docs.canarytokens.org/guide/crowdstrike-cc-token.html',
-    icon: `${TOKENS_TYPE.CROWDSTRIKE_CC}.png`,
-    createRouteTokenAlias: 'crowdstrike',
-    instruction:
-      'Copy this credential pair to your clipboard to use as desired:',
-    howItWorksInstructions: [
-      'We give you a real CrowdStrike API client ID with an invalid secret.',
-      'You place it somewhere an attacker might find it.',
-      'We send you an alert if someone tries to authenticate with those credentials.',
-    ],
-    category: TOKEN_CATEGORY.CLOUD,
-    keywords: ['cloud', 'api', 'edr', 'security'],
-  },
+  // [TOKENS_TYPE.CROWDSTRIKE_CC]: {
+  //   label: 'CrowdStrike API key',
+  //   description:
+  //     'Get an alert when an attacker uses your CrowdStrike API credentials.',
+  //   documentationLink: 'https://docs.canarytokens.org/guide/crowdstrike-cc-token.html',
+  //   icon: `${TOKENS_TYPE.CROWDSTRIKE_CC}.png`,
+  //   createRouteTokenAlias: 'crowdstrike',
+  //   instruction:
+  //     'Copy this credential pair to your clipboard to use as desired:',
+  //   howItWorksInstructions: [
+  //     'We give you a real CrowdStrike API client ID with an invalid secret.',
+  //     'You place it somewhere an attacker might find it.',
+  //     'We send you an alert if someone tries to authenticate with those credentials.',
+  //   ],
+  //   category: TOKEN_CATEGORY.CLOUD,
+  //   keywords: ['cloud', 'api', 'edr', 'security'],
+  // },
   [TOKENS_TYPE.SVG]: {
     label: 'SVG Image',
     description:


### PR DESCRIPTION
Due to an integration issue new CrowdStrike API Key Canarytokens have had alerting paused. This disables creation while we work on a resolution.