### PR TITLE
Make canarytoken deletion safer

### DIFF
--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -214,8 +214,8 @@ def add_email_token_idx(email: str, canarytoken: str) -> int:
 def remove_email_token_idx(
     email: str, canarytoken: str, pipe: Optional[Pipeline] = None
 ) -> None:
-    target = pipe or DB.get_db()
-    target.srem(KEY_EMAIL_IDX + email.lower(), canarytoken)
+    db = pipe or DB.get_db()
+    db.srem(KEY_EMAIL_IDX + email.lower(), canarytoken)
 
 
 def add_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> int:
@@ -225,8 +225,8 @@ def add_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> int:
 def remove_webhook_token_idx(
     webhook: HttpUrl, canarytoken: str, pipe: Optional[Pipeline] = None
 ) -> None:
-    target = pipe or DB.get_db()
-    target.srem(KEY_WEBHOOK_IDX + webhook, canarytoken)
+    db = pipe or DB.get_db()
+    db.srem(KEY_WEBHOOK_IDX + webhook, canarytoken)
 
 
 def add_auth_token_idx(auth: str, token: str) -> int:
@@ -236,8 +236,8 @@ def add_auth_token_idx(auth: str, token: str) -> int:
 def remove_auth_token_idx(
     auth: str, token: str, pipe: Optional[Pipeline] = None
 ) -> None:
-    target = pipe or DB.get_db()
-    target.srem(KEY_AUTH_IDX + auth, token)
+    db = pipe or DB.get_db()
+    db.srem(KEY_AUTH_IDX + auth, token)
 
 
 def delete_email_tokens(email_address):
@@ -299,6 +299,7 @@ def save_canarydrop(canarydrop: cand.Canarydrop):
 
 def delete_canarydrop(canarydrop: cand.Canarydrop) -> None:
     token = canarydrop.canarytoken.value()
+    log.info(f"Deleting canarydrop for token: {token}")
 
     db = DB.get_db()
     with db.pipeline() as pipe:

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -215,29 +215,29 @@ def remove_email_token_idx(
     email: str, canarytoken: str, pipe: Optional[Pipeline] = None
 ) -> None:
     db = pipe or DB.get_db()
-    db.srem(KEY_EMAIL_IDX + email.lower(), canarytoken)
+    db.srem(f"{KEY_EMAIL_IDX}{email.lower()}", canarytoken)
 
 
 def add_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> int:
-    return DB.get_db().sadd(KEY_WEBHOOK_IDX + webhook, canarytoken)
+    return DB.get_db().sadd(f"{KEY_WEBHOOK_IDX}{webhook}", canarytoken)
 
 
 def remove_webhook_token_idx(
     webhook: HttpUrl, canarytoken: str, pipe: Optional[Pipeline] = None
 ) -> None:
     db = pipe or DB.get_db()
-    db.srem(KEY_WEBHOOK_IDX + webhook, canarytoken)
+    db.srem(f"{KEY_WEBHOOK_IDX}{webhook}", canarytoken)
 
 
 def add_auth_token_idx(auth: str, token: str) -> int:
-    return DB.get_db().sadd(KEY_AUTH_IDX + auth, token)
+    return DB.get_db().sadd(f"{KEY_AUTH_IDX}{auth}", token)
 
 
 def remove_auth_token_idx(
     auth: str, token: str, pipe: Optional[Pipeline] = None
 ) -> None:
     db = pipe or DB.get_db()
-    db.srem(KEY_AUTH_IDX + auth, token)
+    db.srem(f"{KEY_AUTH_IDX}{auth}", token)
 
 
 def delete_email_tokens(email_address):
@@ -299,7 +299,7 @@ def save_canarydrop(canarydrop: cand.Canarydrop):
 
 def delete_canarydrop(canarydrop: cand.Canarydrop) -> None:
     token = canarydrop.canarytoken.value()
-    log.info(f"Deleting canarydrop for token: {token}")
+    log.info("Deleting canarydrop for token: %s", token)
 
     db = DB.get_db()
     with db.pipeline() as pipe:

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -299,7 +299,7 @@ def save_canarydrop(canarydrop: cand.Canarydrop):
 
 def delete_canarydrop(canarydrop: cand.Canarydrop) -> None:
     token = canarydrop.canarytoken.value()
-    log.info("Deleting canarydrop for token: %s", token)
+    log.info("Deleting canarydrop for token: {token}", token=token)
 
     db = DB.get_db()
     with db.pipeline() as pipe:

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -301,7 +301,7 @@ def delete_canarydrop(canarydrop: cand.Canarydrop) -> None:
     token = canarydrop.canarytoken.value()
 
     db = DB.get_db()
-    with db.pipeline(transaction=True) as pipe:
+    with db.pipeline() as pipe:
         if canarydrop.alert_email_recipient:
             remove_email_token_idx(
                 canarydrop.alert_email_recipient,

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -15,6 +15,7 @@ from canarytokens import advocate
 from canarytokens.channel_output_webhook import WEBHOOK_ADDR_VALIDATOR
 import httpx
 import requests
+from redis.client import Pipeline
 from pydantic import EmailStr, HttpUrl, ValidationError, parse_obj_as
 from twisted.logger import Logger
 from twisted.internet.defer import inlineCallbacks
@@ -210,24 +211,33 @@ def add_email_token_idx(email: str, canarytoken: str) -> int:
     return DB.get_db().sadd(KEY_EMAIL_IDX + email.lower(), canarytoken)
 
 
-def remove_email_token_idx(email: str, canarytoken: str) -> None:
-    DB.get_db().srem(KEY_EMAIL_IDX + email.lower(), canarytoken)
+def remove_email_token_idx(
+    email: str, canarytoken: str, pipe: Optional[Pipeline] = None
+) -> None:
+    target = pipe or DB.get_db()
+    target.srem(KEY_EMAIL_IDX + email.lower(), canarytoken)
 
 
 def add_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> int:
     return DB.get_db().sadd(KEY_WEBHOOK_IDX + webhook, canarytoken)
 
 
-def remove_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> None:
-    DB.get_db().srem(KEY_WEBHOOK_IDX + webhook, canarytoken)
+def remove_webhook_token_idx(
+    webhook: HttpUrl, canarytoken: str, pipe: Optional[Pipeline] = None
+) -> None:
+    target = pipe or DB.get_db()
+    target.srem(KEY_WEBHOOK_IDX + webhook, canarytoken)
 
 
 def add_auth_token_idx(auth: str, token: str) -> int:
     return DB.get_db().sadd(KEY_AUTH_IDX + auth, token)
 
 
-def remove_auth_token_idx(auth: str, token: str) -> None:
-    DB.get_db().srem(KEY_AUTH_IDX + auth, token)
+def remove_auth_token_idx(
+    auth: str, token: str, pipe: Optional[Pipeline] = None
+) -> None:
+    target = pipe or DB.get_db()
+    target.srem(KEY_AUTH_IDX + auth, token)
 
 
 def delete_email_tokens(email_address):
@@ -289,18 +299,27 @@ def save_canarydrop(canarydrop: cand.Canarydrop):
 
 def delete_canarydrop(canarydrop: cand.Canarydrop) -> None:
     token = canarydrop.canarytoken.value()
-    DB.get_db().delete(KEY_CANARYDROP + token)
-    log.info(f"Deleted canarydrop for token: {token}")
 
-    DB.get_db().zrem(KEY_CANARYDROPS_TIMELINE, token)
+    db = DB.get_db()
+    with db.pipeline(transaction=True) as pipe:
+        if canarydrop.alert_email_recipient:
+            remove_email_token_idx(
+                canarydrop.alert_email_recipient,
+                token,
+                pipe=pipe,
+            )
 
-    if canarydrop.alert_email_recipient:
-        remove_email_token_idx(canarydrop.alert_email_recipient, token)
+        if canarydrop.alert_webhook_url:
+            remove_webhook_token_idx(
+                canarydrop.alert_webhook_url,
+                token,
+                pipe=pipe,
+            )
 
-    if canarydrop.alert_webhook_url:
-        remove_webhook_token_idx(canarydrop.alert_webhook_url, token)
-
-    remove_auth_token_idx(canarydrop.auth, token)
+        remove_auth_token_idx(canarydrop.auth, token, pipe=pipe)
+        pipe.zrem(KEY_CANARYDROPS_TIMELINE, token)
+        pipe.delete(KEY_CANARYDROP + token)
+        pipe.execute()
 
     if canarydrop.type == models.TokenTypes.WIREGUARD:
         wireguard.deleteCanarytokenPrivateKey(canarydrop.wg_key)

--- a/canarytokens/queries.py
+++ b/canarytokens/queries.py
@@ -219,7 +219,7 @@ def remove_email_token_idx(
 
 
 def add_webhook_token_idx(webhook: HttpUrl, canarytoken: str) -> int:
-    return DB.get_db().sadd(f"{KEY_WEBHOOK_IDX}{webhook}", canarytoken)
+    return DB.get_db().sadd(KEY_WEBHOOK_IDX + webhook, canarytoken)
 
 
 def remove_webhook_token_idx(
@@ -230,7 +230,7 @@ def remove_webhook_token_idx(
 
 
 def add_auth_token_idx(auth: str, token: str) -> int:
-    return DB.get_db().sadd(f"{KEY_AUTH_IDX}{auth}", token)
+    return DB.get_db().sadd(KEY_AUTH_IDX + auth, token)
 
 
 def remove_auth_token_idx(

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -869,9 +869,16 @@ async def api_mail_token_list(request: FetchLinksRequest) -> JSONResponse:
 
     token_set = queries.list_email_tokens(request.email)
     if token_set:
+
+        def _safe_get_canarydrop(token: str):
+            try:
+                return queries.get_canarydrop(Canarytoken(token))
+            except NoCanarydropFound:
+                return None
+
         drops = filter(
             None,
-            map(lambda token: queries.get_canarydrop(Canarytoken(token)), token_set),
+            map(_safe_get_canarydrop, token_set),
         )
         token_list = sorted(
             drops, key=lambda canarydrop: canarydrop.created_at, reverse=True

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -867,19 +867,17 @@ async def api_mail_token_list(request: FetchLinksRequest) -> JSONResponse:
             status_code=BAD_REQUEST,
         )
 
+    def _safe_get_canarydrop(token: str):
+        try:
+            return queries.get_canarydrop(Canarytoken(token))
+        except NoCanarydropFound:
+            return None
+
     token_set = queries.list_email_tokens(request.email)
-    if token_set:
-
-        def _safe_get_canarydrop(token: str):
-            try:
-                return queries.get_canarydrop(Canarytoken(token))
-            except NoCanarydropFound:
-                return None
-
-        drops = filter(
-            None,
-            map(_safe_get_canarydrop, token_set),
-        )
+    drops = [
+        drop for token in token_set if (drop := _safe_get_canarydrop(token)) is not None
+    ]
+    if drops:
         token_list = sorted(
             drops, key=lambda canarydrop: canarydrop.created_at, reverse=True
         )


### PR DESCRIPTION
## Proposed changes

Make Canarytoken deletion safer by running all Redis delete operations atomically in one pipeline.

Currently when deleting the a canarytoken the different delete operations are called one after the other and if the process were to terminate/crash in between these operation we can end up with a faulty state.

## Types of changes

What types of changes does your code introduce to this repository?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

