### PR TITLE
Fix "How does it work" icon size on mobile

### DIFF
--- a/frontend_vue/src/components/ui/HowDoesItWorkSteps.vue
+++ b/frontend_vue/src/components/ui/HowDoesItWorkSteps.vue
@@ -10,7 +10,7 @@
         <img
           :src="getImageUrl(item.imgSrc)"
           :alt="item.altText"
-          class="h-auto sm:w-[8rem]"
+          class="h-auto max-h-[150px]"
         />
         <div class="mt-16">
           <h3 class="px-16 text-sm font-semibold sm:text-center text-grey-700">


### PR DESCRIPTION
## Proposed changes

Adds a max height to the size of the icons for "How does it work" so they don't behave weirdly on mobile

Main:
<img width="374" height="748" alt="Screenshot 2026-07-21 at 14 57 00" src="https://github.com/user-attachments/assets/7223589c-76c0-4a4c-9de0-e8ed4af71c9e" />

Diff:
<img width="405" height="745" alt="Screenshot 2026-07-21 at 15 37 05" src="https://github.com/user-attachments/assets/8c44f3a9-6621-4a82-8f8b-24d130001160" />

## Test
Pull the branch
Verify the icon shows correctly on mobile and other views