### PR TITLE
Potential fix for code scanning alert no. 20: Bad HTML filtering regexp

### DIFF
--- a/frontend_vue/src/components/tokens/clonedsite/obfuscateToken.ts
+++ b/frontend_vue/src/components/tokens/clonedsite/obfuscateToken.ts
@@ -1,8 +1,8 @@
 import JavascriptObfuscator from 'javascript-obfuscator';
 export default function obfuscateToken(jsCode: string) {
   const modifyScriptJs = (scriptJs: any, cb: any) => {
-    let innerJs = scriptJs.replace(/^<script>/, '');
-    innerJs = innerJs.replace(/<\/script>$/, '');
+    const scriptWrapperMatch = scriptJs.match(/^\s*<script\b[^>]*>([\s\S]*?)<\/script\s*>\s*$/i);
+    const innerJs = scriptWrapperMatch ? scriptWrapperMatch[1] : scriptJs;
     const newInnerJs = cb(innerJs);
     // Break up script tag strings otherwise Vue build breaks
     /* eslint-disable-next-line prefer-template,no-useless-concat */


### PR DESCRIPTION
Potential fix for [https://github.com/thinkst/canarytokens/security/code-scanning/20](https://github.com/thinkst/canarytokens/security/code-scanning/20)

General fix approach: avoid hand-rolled HTML tag stripping regexes for script tags. Use a proper HTML parser/sanitizer where possible. Since this function appears to only need to unwrap a single `<script>...</script>` wrapper, a safe minimal fix is to use a robust regex that handles case-insensitive tags, optional attributes, and surrounding whitespace, and only unwrap when the full input matches that wrapper.

Best fix in this file without changing behavior materially:
- In `frontend_vue/src/components/tokens/clonedsite/obfuscateToken.ts`, replace the two separate `replace` calls on lines 4–5 with a single anchored, case-insensitive extraction:
  - Match full string: `^\s*<script\b[^>]*>([\s\S]*?)<\/script\s*>\s*$` with `i` flag.
  - If matched, use capture group 1 as inner JS.
  - If not matched, keep original string unchanged.
- This preserves current flow, avoids partial brittle stripping, and handles uppercase/mixed-case tags plus attributes.

No new imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
