### PR TITLE
Globally Enable Jinja auto-escaping

### DIFF
--- a/canarytokens/channel_http.py
+++ b/canarytokens/channel_http.py
@@ -100,7 +100,6 @@ class CanarytokenPage(InputChannel, resource.Resource):
 
         if canarydrop.type == TokenTypes.PWA:
             template_env = get_template_env()
-            template_env.autoescape = True
             if request.path.endswith(b"/manifest.json"):
                 request.setHeader("Content-Type", "application/manifest+json")
                 template = template_env.get_template("pwa_manifest.json")

--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -426,7 +426,9 @@ class EmailOutputChannel(OutputChannel):
         """
 
         BasicDetails = EmailOutputChannel.extract_basic_details(details)
-        email_template = get_autoescaped_template(template_path.open().read())
+        email_template = get_autoescaped_template(
+            template_path.open().read(), trim_blocks=True
+        )
         rendered_text = email_template.render(
             Title=EmailOutputChannel.DESCRIPTION,
             Intro=EmailOutputChannel.format_report_intro(details),

--- a/canarytokens/channel_output_email.py
+++ b/canarytokens/channel_output_email.py
@@ -20,7 +20,6 @@ import sendgrid
 import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
-from jinja2 import Template
 from pydantic import EmailStr, HttpUrl, SecretStr
 from python_http_client.exceptions import HTTPError
 from sendgrid.helpers.mail import Content, From, Mail, MailSettings, SandBoxMode, To
@@ -43,6 +42,7 @@ from canarytokens.models import (
 )
 from canarytokens.settings import FrontendSettings, SwitchboardSettings
 from canarytokens.switchboard import Switchboard
+from canarytokens.utils import get_autoescaped_template
 
 log = Logger()
 
@@ -353,7 +353,8 @@ class EmailOutputChannel(OutputChannel):
         BasicDetails["time_ymd"] = details.time_ymd
         BasicDetails["time_hm"] = details.time_hm
 
-        rendered_html = Template(template_path.read_text()).render(
+        html_template = get_autoescaped_template(template_path.read_text())
+        rendered_html = html_template.render(
             BasicDetails=BasicDetails,
             ManageLink=details.manage_url,
             HistoryLink=details.history_url,
@@ -425,7 +426,8 @@ class EmailOutputChannel(OutputChannel):
         """
 
         BasicDetails = EmailOutputChannel.extract_basic_details(details)
-        rendered_text = Template(template_path.open().read(), trim_blocks=True).render(
+        email_template = get_autoescaped_template(template_path.open().read())
+        rendered_text = email_template.render(
             Title=EmailOutputChannel.DESCRIPTION,
             Intro=EmailOutputChannel.format_report_intro(details),
             BasicDetails=BasicDetails,

--- a/canarytokens/constants.py
+++ b/canarytokens/constants.py
@@ -37,3 +37,7 @@ WEBHOOK_BASE_URL_DISCORD = "https://discord.com/api/webhooks"
 WEBHOOK_BASE_URL_REGEX_MS_TEAMS = (
     r"^https:\/\/\S+\.ac\.environment\.api\.powerplatform\.com"
 )
+
+# Auto escaping
+
+AUTO_ESCAPED_FILE_EXTENSIONS = ( "html", "htm", "xhtml", "xml", "svg", "mjml" )

--- a/canarytokens/tokens.py
+++ b/canarytokens/tokens.py
@@ -10,7 +10,6 @@ from typing import Any, AnyStr, Match, Optional, Union
 import logging
 import secrets
 
-from jinja2 import Environment, FileSystemLoader
 from pydantic import parse_obj_as
 from twisted.web.http import Request
 from twisted.web.util import redirectTo
@@ -43,6 +42,7 @@ from canarytokens.models import (
     AWSInfraAssetType,
 )
 from canarytokens.credit_card_v2 import AnyCreditCardTrigger
+from canarytokens.utils import get_autoescaped_env
 
 # TODO: put these in a nicer place. Ensure re.compile is called only once at startup
 # add a naming convention for easy reading when seen in other files.
@@ -102,7 +102,7 @@ def get_template_env():
     global g_template_dir
     if g_template_dir is None:
         raise ValueError("g_template_dir must be set via tokens.set_template_env(...)")
-    return Environment(loader=FileSystemLoader(g_template_dir))
+    return get_autoescaped_env(g_template_dir)
 
 
 class Canarytoken(object):

--- a/canarytokens/utils.py
+++ b/canarytokens/utils.py
@@ -5,6 +5,40 @@ from typing import Any, Literal, Union
 
 import pycountry_convert
 from pydantic import BaseModel
+from jinja2 import Template, Environment, FileSystemLoader, select_autoescape
+from canarytokens.constants import AUTO_ESCAPED_FILE_EXTENSIONS
+
+autoescape_config = select_autoescape(
+    enabled_extensions=AUTO_ESCAPED_FILE_EXTENSIONS,
+    disabled_extensions=(),
+    default_for_string=True,
+    default=True
+)
+
+def get_autoescaped_env(template_dir: str) -> Environment:
+    """ Returns a jinja2.Environment with auto escaping enabled on it.
+        This environment uses the provided template_dir as its search path
+
+    Args:
+        template_dir (str): Path to use as a search path to the jinja2.Environment.
+
+    Returns:
+        Environment: A jinja2.Environment with auto escaping enabled on it.
+    """
+    return Environment(autoescape=autoescape_config ,loader=FileSystemLoader(template_dir))
+
+
+def get_autoescaped_template(template_source: str) -> Template:
+    """ Returns a jinja2.Template with auto escaping enabled on it.
+        This template uses the provided template_source as the source of its contents.
+
+    Args:
+        template_source (str): The contents of the jinja2.Template.
+
+    Returns:
+        Template: A jinja2.Template with auto escaping enabled on it.
+    """
+    return Template(template_source, autoescape=autoescape_config)
 
 
 def json_safe_dict(m: BaseModel, exclude: tuple = ()) -> dict[str, str]:

--- a/canarytokens/utils.py
+++ b/canarytokens/utils.py
@@ -25,20 +25,22 @@ def get_autoescaped_env(template_dir: str) -> Environment:
     Returns:
         Environment: A jinja2.Environment with auto escaping enabled on it.
     """
-    return Environment(autoescape=autoescape_config ,loader=FileSystemLoader(template_dir))
+    return Environment(autoescape=autoescape_config, loader=FileSystemLoader(template_dir))
 
 
-def get_autoescaped_template(template_source: str) -> Template:
+def get_autoescaped_template(template_source: str, trim_blocks: bool = False) -> Template:
     """ Returns a jinja2.Template with auto escaping enabled on it.
         This template uses the provided template_source as the source of its contents.
 
     Args:
-        template_source (str): The contents of the jinja2.Template.
+        template_source (str)   : The contents of the jinja2.Template.
+        trim_blocks     (bool)  : If this is set to True the first newline after a Jinja
+                                  block is removed (block, not variable tag!)
 
     Returns:
         Template: A jinja2.Template with auto escaping enabled on it.
     """
-    return Template(template_source, autoescape=autoescape_config)
+    return Template(template_source, trim_blocks=trim_blocks, autoescape=autoescape_config)
 
 
 def json_safe_dict(m: BaseModel, exclude: tuple = ()) -> dict[str, str]:

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -249,6 +249,7 @@ from canarytokens.tokens import Canarytoken, get_template_env, set_template_env
 from canarytokens.utils import get_deployed_commit_sha
 from canarytokens.windows_fake_fs import windows_fake_fs
 from canarytokens.ziplib import make_canary_zip
+from canarytokens.utils import get_autoescaped_env
 
 log = logging.getLogger("uvicorn")
 
@@ -291,7 +292,7 @@ app = FastAPI(
     version=canarytokens.__version__,
 )
 
-vue_index = Jinja2Templates(directory="../dist/")
+vue_index = Jinja2Templates(env=get_autoescaped_env("../dist/"))
 
 
 @app.get("/")
@@ -362,7 +363,7 @@ try:
 except RuntimeError:
     log.warning("Error: No Vue dist found. Please build the frontend.")
 
-templates = Jinja2Templates(directory=frontend_settings.TEMPLATES_PATH)
+templates = Jinja2Templates(env=get_autoescaped_env(frontend_settings.TEMPLATES_PATH))
 
 if (
     frontend_settings.SENTRY_DSN

--- a/templates/fortune.html
+++ b/templates/fortune.html
@@ -5,9 +5,11 @@
 {% if redirect_url %}    <noscript><meta http-equiv="refresh" content="0; {{redirect_url|e}}"></noscript>{% endif %}
 {% if include_pale_blue_dot %}{% include 'pale_blue_dot/head.html' %}{% endif %}
   </head>
-{% autoescape false %}
-  {{'<body class="stars"></body>' if include_pale_blue_dot else '<body>'}}
-{% endautoescape %}
+{% if include_pale_blue_dot %}
+  <body class="stars">
+{% else %}
+  <body>
+{% endif %}
 {% if include_pale_blue_dot %}{% include 'pale_blue_dot/body.html' %}{% endif %}
 {% if include_browser_scanner %}{% include 'scanner/body.html' %}{% endif %}
 {% if include_pale_blue_dot %}{% include 'pale_blue_dot/script.html' %}{% endif %}

--- a/templates/fortune.html
+++ b/templates/fortune.html
@@ -5,7 +5,9 @@
 {% if redirect_url %}    <noscript><meta http-equiv="refresh" content="0; {{redirect_url|e}}"></noscript>{% endif %}
 {% if include_pale_blue_dot %}{% include 'pale_blue_dot/head.html' %}{% endif %}
   </head>
-  {{'<body class="stars"></body>'if include_pale_blue_dot else '<body>'}}
+{% autoescape false %}
+  {{'<body class="stars"></body>' if include_pale_blue_dot else '<body>'}}
+{% endautoescape %}
 {% if include_pale_blue_dot %}{% include 'pale_blue_dot/body.html' %}{% endif %}
 {% if include_browser_scanner %}{% include 'scanner/body.html' %}{% endif %}
 {% if include_pale_blue_dot %}{% include 'pale_blue_dot/script.html' %}{% endif %}


### PR DESCRIPTION
## Proposed changes

Currently, we sometimes get `XSS` vulnerability reports on `canarytokens.org`. 
And have been addressing these reports on a case-by-case basis.

These changes globally enable auto-escaping on our `jinja` rendering. 
This will help address  `XSS` vulnerabilities on `canarytokens.org` that we haven't gotten a report on yet. 

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

## Manual Tests:
- Created a web bug token with the memo `<script>window.alert(window.location.search)</script>`
- Triggered that token with `https://canarytokens.com/feedback/<token>/submit.aspx?args=%3Cscript%3Ewindow.alert(window.location.search)%3C/script%3E`
  - Checked that the rendered gif of Earth is correct
 
- Ensured the email I got is correct 
  - Ensured no `jinja` rendering is broken
  - Ensured the memo is `<script>window.alert(window.location.search)</script>`
  - Ensured no browser alert pops up

- Clicked `show original` in the mail i got (i used gmail)
  - In the middle of the large text i saw:
```
Your Canarytoken was triggered!
-------------------------------

A Web bug Canarytoken has been triggered by the Source IP 1.2.3.4

Reminder:
  &lt;script&gt;window.alert(window.location.search)&lt;/script&gt;

...

Request arguments:
  {&#39;args&#39;: &#39;&lt;script&gt;window.alert(window.location.search)&lt;/script&gt;&#39;}

```    
- Checked the `Alert history` link from my email.
  - Ensured no `jinja` rendering is broken
  - Ensured the requested args in the `Basic info` of the `Incident info` is `<script>window.alert(window.location.search)</script>`
  - Ensured no browser alert pops up

- Checked the `Manage Alert` link from my email 
  - Ensured no `jinja` rendering is broken
  - Ensured the memo is `<script>window.alert(window.location.search)</script>`
  - Ensured no browser alert pops up


- Created a `fake app` canarytoken with the name `<script>alert(1)</script>`
  - Ensured the App name shows up as `<script>alert(1)</script>` on the `canarytokens.com` site.
<img width="921" height="443" alt="Screenshot 2026-07-29 at 19 17 16" src="https://github.com/user-attachments/assets/0b16a3c4-5f43-4dc3-b4b4-acaf485c18f1" />

  - Ensured the App name shows up as `&lt;script&gt;alert(1)&lt;:script&gt;` when trying to install the app from chrome and when I have installed the app.

<img width="507" height="230" alt="Screenshot 2026-07-29 at 19 15 01" src="https://github.com/user-attachments/assets/cc7464f2-37b7-433f-8816-4d715a133dbb" />

<img width="495" height="381" alt="Screenshot 2026-07-29 at 19 21 48" src="https://github.com/user-attachments/assets/e3b8859e-1891-4f68-a9a1-8609ab0873c5" />

## Unit Tests:
Ensured the unit tests below pass, with these changes:
```
$ uv run pytest units
============================== test session starts ================================
platform darwin -- Python 3.13.12, pytest-9.1.1, pluggy-1.5.0
rootdir: /Users/my-random-name/work/canarytokens
configfile: pyproject.toml
plugins: cov-6.0.0, asyncio-0.18.3, repeat-0.9.4, twisted-1.14.3, mock-3.14.0, 
hypothesis-6.119.4, Faker-17.6.0, anyio-4.6.2.post1
asyncio: mode=Mode.AUTO
collected 677 items                                                                                                                

units/test_aws_infra.py .......ssssssssss..........................           [  6%]
units/test_awskeys.py .......                                                 [  7%]
units/test_canarydrops.py ............................................
.............................                                                 [ 18%]
units/test_channel_output_email.py ...............s..sss                      [ 21%]
units/test_channel_output_webhook.py ..........                               [ 22%]
units/test_dns_channel.py ...............                                     [ 24%]
units/test_extendtoken.py s                                                   [ 25%]
units/test_frontend.py .......................................................
....................................................                          [ 58%]
..............................................................................
....................................................
.......                                                                       [ 61%]
units/test_http_channel.py ........................                           [ 64%]
units/test_kubeconfig.py .....                                                [ 65%]
units/test_models.py .........................................................
...................                                                           [ 76%]
units/test_msreg.py ..                                                        [ 76%]
units/test_mysql_input_channel.py sss..                                       [ 77%]
units/test_pdfgen.py .                                                        [ 77%]
units/test_queries.py .............................                           [ 82%]
units/test_saml.py .                                                          [ 82%]
units/test_smtp_input_channel.py ..                                           [ 82%]
units/test_ssrf_advocate_baseline.py ..............                           [ 84%]
units/test_switchboard.py .....                                               [ 85%]
units/test_tokens.py ..................................................       [ 92%]
units/test_utils.py ............                                              [ 94%]
units/test_v2_v3_data_model_compatibility.py sss                              [ 94%]
units/test_version.py .                                                       [ 95%]
units/test_webhook_formatting.py ...............                              [ 97%]
units/test_wireguard.py .............                                         [ 99%]
units/test_wireguard_input_channel.py .                                       [ 99%]
units/test_ziplib.py ....                                                     [100%]

========== 656 passed, 21 skipped, 1181 warnings in 123.08s (0:02:03) =============
```
