### PR TITLE
Fix credit card token triggers where transaction_amount is int or float

### DIFF
--- a/canarytokens/credit_card_v2.py
+++ b/canarytokens/credit_card_v2.py
@@ -13,7 +13,7 @@ if sys.version_info >= (3, 11):
     from enum import StrEnum  # Python 3.11+
 else:
     from backports.strenum import StrEnum  # Python < 3.11
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 frontend_settings = FrontendSettings()
@@ -66,6 +66,8 @@ class Customer:
 
 
 class CreditCardTrigger3DSNotification(BaseModel):
+    model_config = ConfigDict(coerce_numbers_to_str=True)
+
     trigger_type: Literal[TriggerWebhookEvent.ThreeDSecureNotification] = (
         TriggerWebhookEvent.ThreeDSecureNotification
     )
@@ -79,6 +81,8 @@ class CreditCardTrigger3DSNotification(BaseModel):
 
 
 class CreditCardTriggerTransaction(BaseModel):
+    model_config = ConfigDict(coerce_numbers_to_str=True)
+
     trigger_type: Literal[TriggerWebhookEvent.TransactionFailed] = (
         TriggerWebhookEvent.TransactionFailed
     )

--- a/tests/units/test_http_channel.py
+++ b/tests/units/test_http_channel.py
@@ -512,7 +512,7 @@ def test_GET_aws_token_back(
 
 
 @pytest.mark.parametrize(
-    "trigger_type,webhook_data_extra",
+    "trigger_type,webhook_data_extra,amount",
     [
         (
             "issuing.transaction.failed",
@@ -521,10 +521,40 @@ def test_GET_aws_token_back(
                 "transaction_type": "PURCHASE",
                 "status": "DECLINED",
             },
+            "6.39",
+        ),
+        (
+            "issuing.transaction.failed",
+            {
+                "transaction_date": "2025-02-03T00:42:00Z",
+                "transaction_type": "PURCHASE",
+                "status": "DECLINED",
+            },
+            -444.57,
+        ),
+        (
+            "issuing.transaction.failed",
+            {
+                "transaction_date": "2025-02-03T00:42:00Z",
+                "transaction_type": "PURCHASE",
+                "status": "DECLINED",
+            },
+            0,
         ),
         (
             "issuing.3ds_notification.stepup_otp",
             {},
+            "6.39",
+        ),
+        (
+            "issuing.3ds_notification.stepup_otp",
+            {},
+            -444.57,
+        ),
+        (
+            "issuing.3ds_notification.stepup_otp",
+            {},
+            0,
         ),
     ],
 )
@@ -534,6 +564,7 @@ def test_POST_cc_token_v2_back(
     setup_db: None,
     trigger_type: str,
     webhook_data_extra: dict,
+    amount: str | float | int,
     http_channel: ChannelHTTP,
 ):
     """
@@ -566,7 +597,6 @@ def test_POST_cc_token_v2_back(
     merchant_city = "New York"
     merchant_country = "US"
     masked_card = "**** **** **** 1234"
-    amount = "6.39"
     currency = "USD"
 
     webhook_data = {
@@ -605,7 +635,7 @@ def test_POST_cc_token_v2_back(
     assert hit_info.merchant_identifier == merchant_identifier
     assert hit_info.acquirer_identifier == acquirer_identifier
     assert hit_info.masked_card_number == masked_card
-    assert hit_info.transaction_amount == amount
+    assert hit_info.transaction_amount == str(amount)
     assert hit_info.transaction_currency == currency
     assert hit_info.merchant == f"{merchant_name}, {merchant_city}, {merchant_country}"
 


### PR DESCRIPTION
## Proposed changes

Fix a bug after the pydantic v2 migration where credit card triggers with non-string numbers break. This was missed in the tests as the "test credit card" button already wrapped the transaction_amount param as a string.

Pydantic v1 automatically converted numbers such as -34.4 and 0 to strings. Pydantic v2 doesn't, hence this bug.

We add a test to catch this too.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update

## Checklist

- [x] Lint and unit tests pass locally with my changes (if applicable)
- [x] I have run pre-commit (`pre-commit` in the repo)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Linked to the relevant github issue or github discussion

## Further comments

Test via:
```
curl -i -X POST "https://canarytokens.org/<TOKEN>" \
  -H "Content-Type: application/json" \
  --data '{
    "trigger_type": "issuing.transaction.failed",
    "canarytoken": "<TOKEN>",
    "transaction_amount": -444.57
  }'
HTTP/1.1 200 OK
Date: Wed, 02 Sep 2026 13:31:54 GMT
Content-Type: text/html
Content-Length: 7
Connection: keep-alive
Server: TwistedWeb/26.4.0

success
```